### PR TITLE
Fix sigil symbol deprecation warning in v0.12.5+

### DIFF
--- a/anagram/anagram_test.exs
+++ b/anagram/anagram_test.exs
@@ -25,17 +25,17 @@ defmodule AnagramTest do
   end
 
   test "do not detect anagram subsets" do
-    # matches = Anagram.match "good", %w(dog goody)
+    # matches = Anagram.match "good", ~w(dog goody)
     # assert matches == []
   end
 
   test "detect anagram" do
-    # matches = Anagram.match "listen", %w(enlists google inlets banana)
+    # matches = Anagram.match "listen", ~w(enlists google inlets banana)
     # assert matches == ["inlets"]
   end
 
   test "multiple anagrams" do
-    # matches = Anagram.match "allergy", %w(gallery ballerina regally clergy largely leading)
+    # matches = Anagram.match "allergy", ~w(gallery ballerina regally clergy largely leading)
     # assert matches == ["gallery", "regally", "largely"]
   end
 
@@ -45,12 +45,12 @@ defmodule AnagramTest do
   end
 
   test "detect anagrams with case-insensitive subject" do
-    # matches = Anagram.match "Orchestra", %w(cashregister carthorse radishes)
+    # matches = Anagram.match "Orchestra", ~w(cashregister carthorse radishes)
     # assert matches == ["carthorse"]
   end
 
   test "detect anagrams with case-insensitive candidate" do
-    # matches = Anagram.match "orchestra", %w(cashregister Carthorse radishes)
+    # matches = Anagram.match "orchestra", ~w(cashregister Carthorse radishes)
     # assert matches == ["Carthorse"]
   end
 

--- a/atbash-cipher/example.exs
+++ b/atbash-cipher/example.exs
@@ -14,7 +14,7 @@ defmodule Atbash do
   end
 
   defp normalize(input) do
-    Regex.replace(%r{\W}, String.downcase(input), "")
+    Regex.replace(~r{\W}, String.downcase(input), "")
   end
 
   defp cipher(plaintext) do
@@ -29,6 +29,6 @@ defmodule Atbash do
   end
 
   defp chunk(input) do
-    Regex.scan(%r(.{1,5}), input) |> List.flatten
+    Regex.scan(~r(.{1,5}), input) |> List.flatten
   end
 end

--- a/binary/example.exs
+++ b/binary/example.exs
@@ -3,7 +3,7 @@ defmodule Binary do
     string |> bits |> Enum.reverse |> Enum.with_index |> sum
   end
 
-  defp bits(string), do: Enum.map(Regex.scan(%r{[10]}, string), &(&1 == ["1"]))
+  defp bits(string), do: Enum.map(Regex.scan(~r{[10]}, string), &(&1 == ["1"]))
 
   defp sum(bits), do: Enum.reduce(bits, 0, fn(bit, acc) -> acc + power_of_two(bit) end)
 

--- a/bob/example.exs
+++ b/bob/example.exs
@@ -29,7 +29,7 @@ defmodule Teenager do
   defp silent?(input),   do: "" == String.strip(input)
   defp shouting?(input), do: input == String.upcase(input) && letters?(input)
   defp question?(input), do: String.ends_with?(input, "?")
-  defp letters?(input),  do: Regex.match?(%r/\p{L}+/, input)
+  defp letters?(input),  do: Regex.match?(~r/\p{L}+/, input)
 end
 
 # Another approach which abstracts knowing about string categories 
@@ -41,7 +41,7 @@ end
 #   def silent?(input),   do: "" == String.strip(input)
 #   def shouting?(input), do: input == String.upcase(input) && letters?(input)
 #   def question?(input), do: String.ends_with?(input, "?")
-#   defp letters?(input), do: Regex.match?(%r/\p{L}+/, input)
+#   defp letters?(input), do: Regex.match?(~r/\p{L}+/, input)
 # end
 # 
 # defmodule Teenager do

--- a/etl/etl_test.exs
+++ b/etl/etl_test.exs
@@ -38,13 +38,13 @@ defmodule TransformTest do
 
   test "full dataset" do
     old = HashDict.new [
-      {1,  %W(A E I O U L N R S T)},
-      {2,  %W(D G)},
-      {3,  %W(B C M P)},
-      {4,  %W(F H V W Y)},
-      {5,  %W(K)},
-      {8,  %W(J X)},
-      {10, %W(Q Z)}
+      {1,  ~W(A E I O U L N R S T)},
+      {2,  ~W(D G)},
+      {3,  ~W(B C M P)},
+      {4,  ~W(F H V W Y)},
+      {5,  ~W(K)},
+      {8,  ~W(J X)},
+      {10, ~W(Q Z)}
     ]
 
     expected = HashDict.new [

--- a/forth/example.exs
+++ b/forth/example.exs
@@ -114,7 +114,7 @@ defmodule Forth do
   end
 
   defp tokenize(s) do
-    Regex.scan(%r/[\p{L}\p{N}\p{S}\p{P}]+/, s)
+    Regex.scan(~r/[\p{L}\p{N}\p{S}\p{P}]+/, s)
     |> Stream.map(&hd/1)
     |> Enum.map(fn t ->
          case Integer.parse(t) do

--- a/minesweeper/minesweeper_test.exs
+++ b/minesweeper/minesweeper_test.exs
@@ -10,7 +10,7 @@ defmodule MinesweeperTest do
   use ExUnit.Case, async: true
   doctest Minesweeper 
 
-  defp clean(b), do: Enum.map(b, &String.replace(&1, %r/[^*]/, " "))
+  defp clean(b), do: Enum.map(b, &String.replace(&1, ~r/[^*]/, " "))
 
   test "zero size board" do
     b = []

--- a/parallel-letter-frequency/example.exs
+++ b/parallel-letter-frequency/example.exs
@@ -25,7 +25,7 @@ defmodule Frequency do
   defp count_text(string) do
     # At the time of writing Elixir doesn't yet have a way to determine if a
     # character is a letter. So use a workaround with Regex.
-    String.replace(string, %r/\P{L}+/, "") # \P{L} = anything but a letter
+    String.replace(string, ~r/\P{L}+/, "") # \P{L} = anything but a letter
     |> String.downcase()
     |> String.graphemes()
     |> Enum.reduce(HashDict.new(), fn c, acc -> Dict.update(acc, c, 1, &(&1+1)) end)

--- a/word-count/example.exs
+++ b/word-count/example.exs
@@ -6,7 +6,7 @@ defmodule Words do
       |> summarize
   end
 
-  defp to_words(sentence), do: List.flatten Regex.scan(%r/[\p{L}\p{N}-]+/, sentence)
+  defp to_words(sentence), do: List.flatten Regex.scan(~r/[\p{L}\p{N}-]+/, sentence)
 
   defp summarize(words) do
     Enum.reduce words, HashDict.new, &add_count/2


### PR DESCRIPTION
As of v0.12.5, using % for sigils [is deprecated](https://github.com/elixir-lang/elixir/releases/tag/v0.12.5); the ~ character should be used instead. This change fixes up various tests and example files so that they won't throw the deprecation warning.

Thanks for the [great project](http://exercism.io/) and making Elixir a part of it!
