### PR TITLE
Fix the order of some test assertions

### DIFF
--- a/allergies/allergies_test.exs
+++ b/allergies/allergies_test.exs
@@ -12,35 +12,35 @@ defmodule AllergiesTest do
   doctest Allergies
 
   test "no_allergies_at_all" do
-    assert [] == Allergies.list(0)
+    assert Allergies.list(0) == []
   end
 
   test "allergic_to_just_eggs" do
-    assert ["eggs"] == Allergies.list(1)
+    assert Allergies.list(1) == ["eggs"]
   end
 
   test "allergic_to_just_peanuts" do
-    assert ["peanuts"] == Allergies.list(2)
+    assert Allergies.list(2) == ["peanuts"]
   end
 
   test "allergic_to_just_strawberries" do
-    assert ["strawberries"] == Allergies.list(8)
+    assert Allergies.list(8) == ["strawberries"]
   end
 
   test "allergic_to_eggs_and_peanuts" do
-    assert ["eggs", "peanuts"] == Allergies.list(3)
+    assert Allergies.list(3) == ["eggs", "peanuts"]
   end
 
   test "allergic_to_more_than_eggs_but_not_peanuts" do
-    assert ["eggs", "shellfish"] == Allergies.list(5)
+    assert Allergies.list(5) == ["eggs", "shellfish"]
   end
 
   test "allergic_to_lots_of_stuff" do
-    assert ["strawberries", "tomatoes", "chocolate", "pollen", "cats"] == Allergies.list(248)
+    assert Allergies.list(248) == ["strawberries", "tomatoes", "chocolate", "pollen", "cats"]
   end
 
   test "allergic_to_everything" do
-    assert ["eggs", "peanuts", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats"] == Allergies.list(255)
+    assert Allergies.list(255) == ["eggs", "peanuts", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats"]
   end
 
   test "no_allergies_means_not_allergic" do
@@ -58,6 +58,6 @@ defmodule AllergiesTest do
   end
 
   test "ignore_non_allergen_score_parts" do
-    assert ["eggs", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats"] == Allergies.list(509)
+    assert Allergies.list(509) == ["eggs", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats"]
   end
 end

--- a/atbash-cipher/atbash_cipher_test.exs
+++ b/atbash-cipher/atbash_cipher_test.exs
@@ -11,36 +11,36 @@ defmodule AtbashTest do
   doctest Atbash
 
   test "encode no" do
-    assert "ml" == Atbash.encode("no")
+    assert Atbash.encode("no") == "ml"
   end
 
   test "encode yes" do
-    assert "bvh" == Atbash.encode("yes")
+    assert Atbash.encode("yes") == "bvh"
   end
 
   test "encode OMG" do
-    assert "lnt" == Atbash.encode("OMG")
+    assert Atbash.encode("OMG") == "lnt"
   end
 
   test "encode O M G" do
-    assert "lnt" == Atbash.encode("O M G")
+    assert Atbash.encode("O M G") == "lnt"
   end
 
   test "encode long word" do
-    assert "nrmwy oldrm tob" == Atbash.encode("mindblowingly")
+    assert Atbash.encode("mindblowingly") == "nrmwy oldrm tob"
   end
 
   test "encode numbers" do
-    assert "gvhgr mt123 gvhgr mt" == Atbash.encode("Testing, 1 2 3, testing.")
+    assert Atbash.encode("Testing, 1 2 3, testing.") == "gvhgr mt123 gvhgr mt"
   end
 
   test "encode sentence" do
-    assert "gifgs rhurx grlm" == Atbash.encode("Truth is fiction.")
+    assert Atbash.encode("Truth is fiction.") == "gifgs rhurx grlm"
   end
 
   test "encode all the things" do
     plaintext = "The quick brown fox jumps over the lazy dog."
     cipher = "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
-    assert cipher == Atbash.encode(plaintext)
+    assert Atbash.encode(plaintext) == cipher
   end
 end

--- a/binary/binary_test.exs
+++ b/binary/binary_test.exs
@@ -10,34 +10,34 @@ defmodule BinaryTest do
   use ExUnit.Case, async: true
 
   test "binary 1 is decimal 1" do
-    assert 1 == Binary.to_decimal("1")
+    assert Binary.to_decimal("1") == 1
   end
 
   test "binary 10 is decimal 2" do
-    assert 2 == Binary.to_decimal("10")
+    assert Binary.to_decimal("10") == 2
   end
 
   test "binary 11 is decimal 3" do
-    assert 3 == Binary.to_decimal("11")
+    assert Binary.to_decimal("11") == 3
   end
 
   test "binary 100 is decimal 4" do
-    assert 4 == Binary.to_decimal("100")
+    assert Binary.to_decimal("100") == 4
   end
 
   test "binary 1001 is decimal 9" do
-    assert 9 == Binary.to_decimal("1001")
+    assert Binary.to_decimal("1001") == 9
   end
 
   test "binary 11010 is decimal 26" do
-    assert 26 == Binary.to_decimal("11010")
+    assert Binary.to_decimal("11010") == 26
   end
 
   test "binary 10001101000 is decimal 1128" do
-    assert 1128 == Binary.to_decimal("10001101000")
+    assert Binary.to_decimal("10001101000") == 1128
   end
 
   test "invalid binary is decimal 0" do
-    assert 0 == Binary.to_decimal("carrot")
+    assert Binary.to_decimal("carrot") == 0
   end
 end

--- a/difference-of-squares/difference_of_squares_test.exs
+++ b/difference-of-squares/difference_of_squares_test.exs
@@ -10,39 +10,39 @@ defmodule DifferenceOfSquaresTest do
   use ExUnit.Case, async: true
 
   test "square of sums to 5" do
-    assert 225 == Squares.square_of_sums(5)
+    assert Squares.square_of_sums(5) == 225
   end
 
   test "sum of squares to 5" do
-    assert 55 == Squares.sum_of_squares(5)
+    assert Squares.sum_of_squares(5) == 55
   end
 
   test "difference of sums to 5" do
-    assert 170 == Squares.difference(5)
+    assert Squares.difference(5) == 170
   end
 
   test "square of sums to 10" do
-    assert 3025 == Squares.square_of_sums(10)
+    assert Squares.square_of_sums(10) == 3025
   end
 
   test "sum of squares to 10" do
-    assert 385 == Squares.sum_of_squares(10)
+    assert Squares.sum_of_squares(10) == 385
   end
 
   test "difference of sums to 10" do
-    assert 2640 == Squares.difference(10)
+    assert Squares.difference(10) == 2640
   end
 
   test "square of sums to 100" do
-    assert 25502500 == Squares.square_of_sums(100)
+    assert Squares.square_of_sums(100) == 25502500
   end
 
   test "sum of squares to 100" do
-    assert 338350 == Squares.sum_of_squares(100)
+    assert Squares.sum_of_squares(100) == 338350
   end
 
   test "difference of sums to 100" do
-    assert 25164150 == Squares.difference(100)
+    assert Squares.difference(100) == 25164150
   end
 
 end

--- a/etl/etl_test.exs
+++ b/etl/etl_test.exs
@@ -14,14 +14,14 @@ defmodule TransformTest do
     old = HashDict.new [{1, ["WORLD"]}]
     expected = HashDict.new [{"world", 1}]
 
-    assert expected == ETL.transform(old)
+    assert ETL.transform(old) == expected
   end
 
   test "transform more values" do
     old = HashDict.new [{1, ["WORLD", "GSCHOOLERS"]}]
     expected = HashDict.new [{"world", 1}, {"gschoolers", 1}]
 
-    assert expected == ETL.transform(old)
+    assert ETL.transform(old) == expected
   end
 
   test "more keys" do
@@ -33,7 +33,7 @@ defmodule TransformTest do
       {"ballerina", 2}
     ]
 
-    assert expected == ETL.transform(old)
+    assert ETL.transform(old) == expected
   end
 
   test "full dataset" do
@@ -56,6 +56,6 @@ defmodule TransformTest do
       {"z", 10}
     ]
 
-    assert expected == ETL.transform(old)
+    assert ETL.transform(old) == expected
   end
 end

--- a/gigasecond/gigasecond_test.exs
+++ b/gigasecond/gigasecond_test.exs
@@ -10,21 +10,21 @@ defmodule GigasecondTest do
   use ExUnit.Case
 
   test "from 4/25/2011" do
-    assert {2043, 1, 1} == Gigasecond.from({2011, 4, 25})
+    assert Gigasecond.from({2011, 4, 25}) == {2043, 1, 1}
   end
 
   test "from 6/13/1977" do
-    # assert {2009, 2, 19} == Gigasecond.from({1977, 6, 13})
+    # assert Gigasecond.from({1977, 6, 13}) == {2009, 2, 19}
   end
 
   test "from 7/19/1959" do
-    # assert {1991, 3, 27} == Gigasecond.from({1959, 7, 19})
+    # assert Gigasecond.from({1959, 7, 19}) == {1991, 3, 27}
   end
 
   test "yourself" do
     # customize these values for yourself
     #your_birthday = {year1, month1, day1}
-    #assert {year2, month2, day2} == Gigasecond.from(your_birthday)
+    #assert Gigasecond.from(your_birthday) == {year2, month2, day2}
   end
 end
 

--- a/grade-school/grade_school_test.exs
+++ b/grade-school/grade_school_test.exs
@@ -45,7 +45,7 @@ defmodule SchoolTest do
   end
 
   test "get students in a non existant grade" do
-    # assert [] == School.grade(db, 1)
+    # assert School.grade(db, 1) == []
   end
 
   test "sort school by grade and by student name" do
@@ -62,7 +62,7 @@ defmodule SchoolTest do
     #   {6, ["Kareem"]}
     # ]
     #
-    # assert expected == actual
+    # assert actual == expected
   end
 
 end

--- a/grains/grains_test.exs
+++ b/grains/grains_test.exs
@@ -16,34 +16,34 @@ defmodule GrainsTest do
   use ExUnit.Case
 
   test "square 1" do
-    assert 1 == Grains.square(1)
+    assert Grains.square(1) == 1
   end
 
   test "square 2" do
-    assert 2 == Grains.square(2)
+    assert Grains.square(2) == 2
   end
 
   test "square 3" do
-    assert 4 == Grains.square(3)
+    assert Grains.square(3) == 4
   end
 
   test "square 4" do
-    assert 8 == Grains.square(4)
+    assert Grains.square(4) == 8
   end
 
   test "square 16" do
-    assert 32768 == Grains.square(16)
+    assert Grains.square(16) == 32768
   end
 
   test "square 32" do
-    assert 2147483648 == Grains.square(32)
+    assert Grains.square(32) == 2147483648
   end
 
   test "square 64" do
-    assert 9223372036854775808 == Grains.square(64)
+    assert Grains.square(64) == 9223372036854775808
   end
 
   test "total grains" do
-    assert 18446744073709551615 == Grains.total
+    assert Grains.total == 18446744073709551615
   end
 end

--- a/largest-series-product/largest_series_product_test.exs
+++ b/largest-series-product/largest_series_product_test.exs
@@ -10,78 +10,78 @@ defmodule LargestSeriesProductTest do
   use ExUnit.Case, async: false
 
   test "digits" do
-    assert [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] == Series.digits("0123456789")
+    assert Series.digits("0123456789") == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
   end
 
   test "same digits reversed" do
-    assert [9, 8, 7, 6, 5, 4, 3, 2, 1, 0] == Series.digits("9876543210")
+    assert Series.digits("9876543210") == [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
   end
 
   test "fewer digits" do
-    assert [8, 7, 6, 5, 4] == Series.digits("87654")
+    assert Series.digits("87654") == [8, 7, 6, 5, 4]
   end
 
   test "some other digits" do
-    assert [9, 3, 6, 9, 2, 3, 4, 6, 8] == Series.digits("936923468")
+    assert Series.digits("936923468") == [9, 3, 6, 9, 2, 3, 4, 6, 8]
   end
 
   test "slices of zero" do
-    assert [] == Series.digits("")
+    assert Series.digits("") == []
   end
 
   test "slices of two" do
-    assert [[0, 1], [1, 2], [2, 3], [3, 4]] == Series.slices("01234", 2)
+    assert Series.slices("01234", 2) == [[0, 1], [1, 2], [2, 3], [3, 4]]
   end
 
   test "other slices of two" do
-    assert [[9, 8], [8, 2], [2, 7], [7, 3], [3, 4], [4, 6], [6, 3]] == Series.slices("98273463", 2)
+    assert Series.slices("98273463", 2) == [[9, 8], [8, 2], [2, 7], [7, 3], [3, 4], [4, 6], [6, 3]]
   end
 
   test "slices of three" do
-    assert [[0, 1, 2], [1, 2, 3], [2, 3, 4]] == Series.slices("01234", 3)
+    assert Series.slices("01234", 3) == [[0, 1, 2], [1, 2, 3], [2, 3, 4]]
   end
 
   test "other slices of three" do
-    assert [[9, 8, 2], [8, 2, 3], [2, 3, 4], [3, 4, 7]] == Series.slices("982347", 3)
+    assert Series.slices("982347", 3) == [[9, 8, 2], [8, 2, 3], [2, 3, 4], [3, 4, 7]]
   end
 
   test "largest product of 2" do
-    assert 72 == Series.largest_product("0123456789", 2)
+    assert Series.largest_product("0123456789", 2) == 72
   end
 
   test "largest product of a tiny number" do
-    assert 2 == Series.largest_product("12", 2)
+    assert Series.largest_product("12", 2) == 2
   end
 
   test "another tiny number" do
-    assert 9 == Series.largest_product("19", 2)
+    assert Series.largest_product("19", 2) == 9
   end
 
   test "largest product of 2 shuffled" do
-    assert 48 == Series.largest_product("576802143", 2)
+    assert Series.largest_product("576802143", 2) == 48
   end
 
   test "largest product of 3" do
-    assert 504 == Series.largest_product("0123456789", 3)
+    assert Series.largest_product("0123456789", 3) == 504
   end
 
   test "largest product of 3 shuffled" do
-    assert 270 == Series.largest_product("1027839564", 3)
+    assert Series.largest_product("1027839564", 3) == 270
   end
 
   test "largest product of 5" do
-    assert 15120 == Series.largest_product("0123456789", 5)
+    assert Series.largest_product("0123456789", 5) == 15120
   end
 
   test "some big number" do
-    assert 23520 == Series.largest_product("73167176531330624919225119674426574742355349194934", 6)
+    assert Series.largest_product("73167176531330624919225119674426574742355349194934", 6) == 23520
   end
 
   test "some other big number" do
-    assert 28350 == Series.largest_product("52677741234314237566414902593461595376319419139427", 6)
+    assert Series.largest_product("52677741234314237566414902593461595376319419139427", 6) == 28350
   end
 
   test "identity" do
-    assert 1 == Series.largest_product("", 0)
+    assert Series.largest_product("", 0) == 1
   end
 end

--- a/list-ops/list-ops_test.exs
+++ b/list-ops/list-ops_test.exs
@@ -14,108 +14,108 @@ defmodule ListOpsTest do
   defp odd?(n), do: rem(n, 2) == 1
 
   test "count of empty list" do
-    assert 0 == L.count([])
+    assert L.count([]) == 0
   end
 
   test "count of normal list" do
-    assert 4 == L.count([1,3,5,7])
+    assert L.count([1,3,5,7]) == 4
   end
 
   test "count of huge list" do
-    assert 1_000_000 == L.count(Enum.to_list(1..1_000_000))
+    assert L.count(Enum.to_list(1..1_000_000)) == 1_000_000
   end
 
   test "reverse of empty list" do
-    assert [] == L.reverse([])
+    assert L.reverse([]) == []
   end
 
   test "reverse of normal list" do
-    assert [7,5,3,1] == L.reverse([1,3,5,7])
+    assert L.reverse([1,3,5,7]) == [7,5,3,1]
   end
 
   test "reverse of huge list" do
-    assert Enum.to_list(1_000_000..1) == L.reverse(Enum.to_list(1..1_000_000))
+    assert L.reverse(Enum.to_list(1..1_000_000)) == Enum.to_list(1_000_000..1)
   end
 
   test "map of empty list" do
-    assert [] == L.map([], &(&1+1))
+    assert L.map([], &(&1+1)) == []
   end
 
   test "map of normal list" do
-    assert [2,4,6,8] == L.map([1,3,5,7], &(&1+1))
+    assert L.map([1,3,5,7], &(&1+1)) == [2,4,6,8]
   end
 
   test "map of huge list" do
-    assert Enum.to_list(2..1_000_001) ==
-      L.map(Enum.to_list(1..1_000_000), &(&1+1))
+    assert L.map(Enum.to_list(1..1_000_000), &(&1+1)) ==
+      Enum.to_list(2..1_000_001)
   end
 
   test "filter of empty list" do
-    assert [] == L.filter([], &odd?/1)
+    assert L.filter([], &odd?/1) == []
   end
 
   test "filter of normal list" do
-    assert [1,3] == L.filter([1,2,3,4], &odd?/1)
+    assert L.filter([1,2,3,4], &odd?/1) == [1,3]
   end
 
   test "filter of huge list" do
-    assert Enum.map(1..500_000, &(&1*2-1)) ==
-      L.filter(Enum.to_list(1..1_000_000), &odd?/1)
+    assert L.filter(Enum.to_list(1..1_000_000), &odd?/1) ==
+      Enum.map(1..500_000, &(&1*2-1))
   end
 
   test "reduce of empty list" do
-    assert 0 == L.reduce([], 0, &(&1+&2))
+    assert L.reduce([], 0, &(&1+&2)) == 0
   end
 
   test "reduce of normal list" do
-    assert 7 == L.reduce([1,2,3,4], -3, &(&1+&2))
+    assert L.reduce([1,2,3,4], -3, &(&1+&2)) == 7
   end
 
   test "reduce of huge list" do
-    assert Enum.reduce(1..1_000_000, 0, &(&1+&2)) ==
-      L.reduce(Enum.to_list(1..1_000_000), 0, &(&1+&2))
+    assert L.reduce(Enum.to_list(1..1_000_000), 0, &(&1+&2)) ==
+      Enum.reduce(1..1_000_000, 0, &(&1+&2))
   end
 
   test "reduce with non-commutative function" do
-    assert 0 == L.reduce([1,2,3,4], 10, fn x, acc -> acc - x end)
+    assert L.reduce([1,2,3,4], 10, fn x, acc -> acc - x end) == 0
   end
 
   test "append of empty lists" do
-    assert [] == L.append([], [])
+    assert L.append([], []) == []
   end
 
   test "append of empty and non-empty list" do
-    assert [1,2,3,4] == L.append([], [1,2,3,4])
+    assert L.append([], [1,2,3,4]) == [1,2,3,4]
   end
 
   test "append of non-empty and empty list" do
-    assert [1,2,3,4] == L.append([1,2,3,4], [])
+    assert L.append([1,2,3,4], []) == [1,2,3,4]
   end
 
   test "append of non-empty lists" do
-    assert [1,2,3,4,5] == L.append([1,2,3], [4,5])
+    assert L.append([1,2,3], [4,5]) == [1,2,3,4,5]
   end
 
   test "append of huge lists" do
-    assert Enum.to_list(1..2_000_000) ==
-      L.append(Enum.to_list(1..1_000_000), Enum.to_list(1_000_001..2_000_000))
+    assert L.append(Enum.to_list(1..1_000_000), Enum.to_list(1_000_001..2_000_000)) ==
+      Enum.to_list(1..2_000_000)
   end
 
   test "concat of empty list of lists" do
-    assert [] == L.concat([])
+    assert L.concat([]) == []
   end
 
   test "concat of normal list of lists" do
-    assert [1,2,3,4,5,6] == L.concat([[1,2],[3],[],[4,5,6]])
+    assert L.concat([[1,2],[3],[],[4,5,6]]) == [1,2,3,4,5,6]
   end
 
   test "concat of huge list of small lists" do
-    assert Enum.to_list(1..1_000_000) ==
-      L.concat(Enum.map(1..1_000_000, &[&1]))
+    assert L.concat(Enum.map(1..1_000_000, &[&1])) ==
+      Enum.to_list(1..1_000_000)
   end
 
   test "concat of small list of huge lists" do
-    assert Enum.to_list(1..1_000_000) ==
-      L.concat(Enum.map(0..9, &Enum.to_list((&1*100_000+1)..((&1+1)*100_000))))
+    assert L.concat(Enum.map(0..9, &Enum.to_list((&1*100_000+1)..((&1+1)*100_000)))) ==
+      Enum.to_list(1..1_000_000)
   end
 end

--- a/meetup/meetup_test.exs
+++ b/meetup/meetup_test.exs
@@ -11,367 +11,367 @@ defmodule MeetupTest do
   doctest Meetup
 
   test "monteenth of may 2013" do
-    assert {2013, 5, 13} == Meetup.meetup(2013, 5, :monday, :teenth)
+    assert Meetup.meetup(2013, 5, :monday, :teenth) == {2013, 5, 13}
   end
 
   test "monteenth of august 2013" do
-    assert {2013, 8, 19} == Meetup.meetup(2013, 8, :monday, :teenth)
+    assert Meetup.meetup(2013, 8, :monday, :teenth) == {2013, 8, 19}
   end
 
   test "monteenth of september 2013" do
-    assert {2013, 9, 16} == Meetup.meetup(2013, 9, :monday, :teenth)
+    assert Meetup.meetup(2013, 9, :monday, :teenth) == {2013, 9, 16}
   end
 
   test "tuesteenth of march 2013" do
-    assert {2013, 3, 19} == Meetup.meetup(2013, 3, :tuesday, :teenth)
+    assert Meetup.meetup(2013, 3, :tuesday, :teenth) == {2013, 3, 19}
   end
 
   test "tuesteenth of april 2013" do
-    assert {2013, 4, 16} == Meetup.meetup(2013, 4, :tuesday, :teenth)
+    assert Meetup.meetup(2013, 4, :tuesday, :teenth) == {2013, 4, 16}
   end
 
   test "tuesteenth of august 2013" do
-    assert {2013, 8, 13} == Meetup.meetup(2013, 8, :tuesday, :teenth)
+    assert Meetup.meetup(2013, 8, :tuesday, :teenth) == {2013, 8, 13}
   end
 
   test "wednesteenth of january 2013" do
-    assert {2013, 1, 16} == Meetup.meetup(2013, 1, :wednesday, :teenth)
+    assert Meetup.meetup(2013, 1, :wednesday, :teenth) == {2013, 1, 16}
   end
 
   test "wednesteenth of february 2013" do
-    assert {2013, 2, 13} == Meetup.meetup(2013, 2, :wednesday, :teenth)
+    assert Meetup.meetup(2013, 2, :wednesday, :teenth) == {2013, 2, 13}
   end
 
   test "wednesteenth of june 2013" do
-    assert {2013, 6, 19} == Meetup.meetup(2013, 6, :wednesday, :teenth)
+    assert Meetup.meetup(2013, 6, :wednesday, :teenth) == {2013, 6, 19}
   end
 
   test "thursteenth of may 2013" do
-    assert {2013, 5, 16} == Meetup.meetup(2013, 5, :thursday, :teenth)
+    assert Meetup.meetup(2013, 5, :thursday, :teenth) == {2013, 5, 16}
   end
 
   test "thursteenth of june 2013" do
-    assert {2013, 6, 13} == Meetup.meetup(2013, 6, :thursday, :teenth)
+    assert Meetup.meetup(2013, 6, :thursday, :teenth) == {2013, 6, 13}
   end
 
   test "thursteenth of september 2013" do
-    assert {2013, 9, 19} == Meetup.meetup(2013, 9, :thursday, :teenth)
+    assert Meetup.meetup(2013, 9, :thursday, :teenth) == {2013, 9, 19}
   end
 
   test "friteenth of april 2013" do
-    assert {2013, 4, 19} == Meetup.meetup(2013, 4, :friday, :teenth)
+    assert Meetup.meetup(2013, 4, :friday, :teenth) == {2013, 4, 19}
   end
 
   test "friteenth of august 2013" do
-    assert {2013, 8, 16} == Meetup.meetup(2013, 8, :friday, :teenth)
+    assert Meetup.meetup(2013, 8, :friday, :teenth) == {2013, 8, 16}
   end
 
   test "friteenth of september 2013" do
-    assert {2013, 9, 13} == Meetup.meetup(2013, 9, :friday, :teenth)
+    assert Meetup.meetup(2013, 9, :friday, :teenth) == {2013, 9, 13}
   end
 
   test "saturteenth of february 2013" do
-    assert {2013, 2, 16} == Meetup.meetup(2013, 2, :saturday, :teenth)
+    assert Meetup.meetup(2013, 2, :saturday, :teenth) == {2013, 2, 16}
   end
 
   test "saturteenth of april 2013" do
-    assert {2013, 4, 13} == Meetup.meetup(2013, 4, :saturday, :teenth)
+    assert Meetup.meetup(2013, 4, :saturday, :teenth) == {2013, 4, 13}
   end
 
   test "saturteenth of october 2013" do
-    assert {2013, 10, 19} == Meetup.meetup(2013, 10, :saturday, :teenth)
+    assert Meetup.meetup(2013, 10, :saturday, :teenth) == {2013, 10, 19}
   end
 
   test "sunteenth of map 2013" do
-    assert {2013, 5, 19} == Meetup.meetup(2013, 5, :sunday, :teenth)
+    assert Meetup.meetup(2013, 5, :sunday, :teenth) == {2013, 5, 19}
   end
 
   test "sunteenth of june 2013" do
-    assert {2013, 6, 16} == Meetup.meetup(2013, 6, :sunday, :teenth)
+    assert Meetup.meetup(2013, 6, :sunday, :teenth) == {2013, 6, 16}
   end
 
   test "sunteenth of october 2013" do
-    assert {2013, 10, 13} == Meetup.meetup(2013, 10, :sunday, :teenth)
+    assert Meetup.meetup(2013, 10, :sunday, :teenth) == {2013, 10, 13}
   end
 
   test "first monday of march 2013" do
-    assert {2013, 3, 4} == Meetup.meetup(2013, 3, :monday, :first)
+    assert Meetup.meetup(2013, 3, :monday, :first) == {2013, 3, 4}
   end
 
   test "first monday of april 2013" do
-    assert {2013, 4, 1} == Meetup.meetup(2013, 4, :monday, :first)
+    assert Meetup.meetup(2013, 4, :monday, :first) == {2013, 4, 1}
   end
 
   test "first tuesday of may 2013" do
-    assert {2013, 5, 7} == Meetup.meetup(2013, 5, :tuesday, :first)
+    assert Meetup.meetup(2013, 5, :tuesday, :first) == {2013, 5, 7}
   end
 
   test "first tuesday of june 2013" do
-    assert {2013, 6, 4} == Meetup.meetup(2013, 6, :tuesday, :first)
+    assert Meetup.meetup(2013, 6, :tuesday, :first) == {2013, 6, 4}
   end
 
   test "first wednesday of july 2013" do
-    assert {2013, 7, 3} == Meetup.meetup(2013, 7, :wednesday, :first)
+    assert Meetup.meetup(2013, 7, :wednesday, :first) == {2013, 7, 3}
   end
 
   test "first wednesday of august 2013" do
-    assert {2013, 8, 7} == Meetup.meetup(2013, 8, :wednesday, :first)
+    assert Meetup.meetup(2013, 8, :wednesday, :first) == {2013, 8, 7}
   end
 
   test "first thursday of september 2013" do
-    assert {2013, 9, 5} == Meetup.meetup(2013, 9, :thursday, :first)
+    assert Meetup.meetup(2013, 9, :thursday, :first) == {2013, 9, 5}
   end
 
   test "first thursday of october 2013" do
-    assert {2013, 10, 3} == Meetup.meetup(2013, 10, :thursday, :first)
+    assert Meetup.meetup(2013, 10, :thursday, :first) == {2013, 10, 3}
   end
 
   test "first friday of november 2013" do
-    assert {2013, 11, 1} == Meetup.meetup(2013, 11, :friday, :first)
+    assert Meetup.meetup(2013, 11, :friday, :first) == {2013, 11, 1}
   end
 
   test "first friday of december 2013" do
-    assert {2013, 12, 6} == Meetup.meetup(2013, 12, :friday, :first)
+    assert Meetup.meetup(2013, 12, :friday, :first) == {2013, 12, 6}
   end
 
   test "first saturday of january 2013" do
-    assert {2013, 1, 5} == Meetup.meetup(2013, 1, :saturday, :first)
+    assert Meetup.meetup(2013, 1, :saturday, :first) == {2013, 1, 5}
   end
 
   test "first saturday of february 2013" do
-    assert {2013, 2, 2} == Meetup.meetup(2013, 2, :saturday, :first)
+    assert Meetup.meetup(2013, 2, :saturday, :first) == {2013, 2, 2}
   end
 
   test "first sunday of march 2013" do
-    assert {2013, 3, 3} == Meetup.meetup(2013, 3, :sunday, :first)
+    assert Meetup.meetup(2013, 3, :sunday, :first) == {2013, 3, 3}
   end
 
   test "first sunday of april 2013" do
-    assert {2013, 4, 7} == Meetup.meetup(2013, 4, :sunday, :first)
+    assert Meetup.meetup(2013, 4, :sunday, :first) == {2013, 4, 7}
   end
 
   test "second monday of march 2013" do
-    assert {2013, 3, 11} == Meetup.meetup(2013, 3, :monday, :second)
+    assert Meetup.meetup(2013, 3, :monday, :second) == {2013, 3, 11}
   end
 
   test "second monday of april 2013" do
-    assert {2013, 4, 8} == Meetup.meetup(2013, 4, :monday, :second)
+    assert Meetup.meetup(2013, 4, :monday, :second) == {2013, 4, 8}
   end
 
   test "second tuesday of may 2013" do
-    assert {2013, 5, 14} == Meetup.meetup(2013, 5, :tuesday, :second)
+    assert Meetup.meetup(2013, 5, :tuesday, :second) == {2013, 5, 14}
   end
 
   test "second tuesday of june 2013" do
-    assert {2013, 6, 11} == Meetup.meetup(2013, 6, :tuesday, :second)
+    assert Meetup.meetup(2013, 6, :tuesday, :second) == {2013, 6, 11}
   end
 
   test "second wednesday of july 2013" do
-    assert {2013, 7, 10} == Meetup.meetup(2013, 7, :wednesday, :second)
+    assert Meetup.meetup(2013, 7, :wednesday, :second) == {2013, 7, 10}
   end
 
   test "second wednesday of august 2013" do
-    assert {2013, 8, 14} == Meetup.meetup(2013, 8, :wednesday, :second)
+    assert Meetup.meetup(2013, 8, :wednesday, :second) == {2013, 8, 14}
   end
 
   test "second thursday of september 2013" do
-    assert {2013, 9, 12} == Meetup.meetup(2013, 9, :thursday, :second)
+    assert Meetup.meetup(2013, 9, :thursday, :second) == {2013, 9, 12}
   end
 
   test "second thursday of october 2013" do
-    assert {2013, 10, 10} == Meetup.meetup(2013, 10, :thursday, :second)
+    assert Meetup.meetup(2013, 10, :thursday, :second) == {2013, 10, 10}
   end
 
   test "second friday of november 2013" do
-    assert {2013, 11, 8} == Meetup.meetup(2013, 11, :friday, :second)
+    assert Meetup.meetup(2013, 11, :friday, :second) == {2013, 11, 8}
   end
 
   test "second friday of december 2013" do
-    assert {2013, 12, 13} == Meetup.meetup(2013, 12, :friday, :second)
+    assert Meetup.meetup(2013, 12, :friday, :second) == {2013, 12, 13}
   end
 
   test "second saturday of january 2013" do
-    assert {2013, 1, 12} == Meetup.meetup(2013, 1, :saturday, :second)
+    assert Meetup.meetup(2013, 1, :saturday, :second) == {2013, 1, 12}
   end
 
   test "second saturday of february 2013" do
-    assert {2013, 2, 9} == Meetup.meetup(2013, 2, :saturday, :second)
+    assert Meetup.meetup(2013, 2, :saturday, :second) == {2013, 2, 9}
   end
 
   test "second sunday of march 2013" do
-    assert {2013, 3, 10} == Meetup.meetup(2013, 3, :sunday, :second)
+    assert Meetup.meetup(2013, 3, :sunday, :second) == {2013, 3, 10}
   end
 
   test "second sunday of april 2013" do
-    assert {2013, 4, 14} == Meetup.meetup(2013, 4, :sunday, :second)
+    assert Meetup.meetup(2013, 4, :sunday, :second) == {2013, 4, 14}
   end
 
   test "third monday of march 2013" do
-    assert {2013, 3, 18} == Meetup.meetup(2013, 3, :monday, :third)
+    assert Meetup.meetup(2013, 3, :monday, :third) == {2013, 3, 18}
   end
 
   test "third monday of april 2013" do
-    assert {2013, 4, 15} == Meetup.meetup(2013, 4, :monday, :third)
+    assert Meetup.meetup(2013, 4, :monday, :third) == {2013, 4, 15}
   end
 
   test "third tuesday of may 2013" do
-    assert {2013, 5, 21} == Meetup.meetup(2013, 5, :tuesday, :third)
+    assert Meetup.meetup(2013, 5, :tuesday, :third) == {2013, 5, 21}
   end
 
   test "third tuesday of june 2013" do
-    assert {2013, 6, 18} == Meetup.meetup(2013, 6, :tuesday, :third)
+    assert Meetup.meetup(2013, 6, :tuesday, :third) == {2013, 6, 18}
   end
 
   test "third wednesday of july 2013" do
-    assert {2013, 7, 17} == Meetup.meetup(2013, 7, :wednesday, :third)
+    assert Meetup.meetup(2013, 7, :wednesday, :third) == {2013, 7, 17}
   end
 
   test "third wednesday of august 2013" do
-    assert {2013, 8, 21} == Meetup.meetup(2013, 8, :wednesday, :third)
+    assert Meetup.meetup(2013, 8, :wednesday, :third) == {2013, 8, 21}
   end
 
   test "third thursday of september 2013" do
-    assert {2013, 9, 19} == Meetup.meetup(2013, 9, :thursday, :third)
+    assert Meetup.meetup(2013, 9, :thursday, :third) == {2013, 9, 19}
   end
 
   test "third thursday of october 2013" do
-    assert {2013, 10, 17} == Meetup.meetup(2013, 10, :thursday, :third)
+    assert Meetup.meetup(2013, 10, :thursday, :third) == {2013, 10, 17}
   end
 
   test "third friday of november 2013" do
-    assert {2013, 11, 15} == Meetup.meetup(2013, 11, :friday, :third)
+    assert Meetup.meetup(2013, 11, :friday, :third) == {2013, 11, 15}
   end
 
   test "third friday of december 2013" do
-    assert {2013, 12, 20} == Meetup.meetup(2013, 12, :friday, :third)
+    assert Meetup.meetup(2013, 12, :friday, :third) == {2013, 12, 20}
   end
 
   test "third saturday of january 2013" do
-    assert {2013, 1, 19} == Meetup.meetup(2013, 1, :saturday, :third)
+    assert Meetup.meetup(2013, 1, :saturday, :third) == {2013, 1, 19}
   end
 
   test "third saturday of february 2013" do
-    assert {2013, 2, 16} == Meetup.meetup(2013, 2, :saturday, :third)
+    assert Meetup.meetup(2013, 2, :saturday, :third) == {2013, 2, 16}
   end
 
   test "third sunday of march 2013" do
-    assert {2013, 3, 17} == Meetup.meetup(2013, 3, :sunday, :third)
+    assert Meetup.meetup(2013, 3, :sunday, :third) == {2013, 3, 17}
   end
 
   test "third sunday of april 2013" do
-    assert {2013, 4, 21} == Meetup.meetup(2013, 4, :sunday, :third)
+    assert Meetup.meetup(2013, 4, :sunday, :third) == {2013, 4, 21}
   end
 
   test "fourth monday of march 2013" do
-    assert {2013, 3, 25} == Meetup.meetup(2013, 3, :monday, :fourth)
+    assert Meetup.meetup(2013, 3, :monday, :fourth) == {2013, 3, 25}
   end
 
   test "fourth monday of april 2013" do
-    assert {2013, 4, 22} == Meetup.meetup(2013, 4, :monday, :fourth)
+    assert Meetup.meetup(2013, 4, :monday, :fourth) == {2013, 4, 22}
   end
 
   test "fourth tuesday of may 2013" do
-    assert {2013, 5, 28} == Meetup.meetup(2013, 5, :tuesday, :fourth)
+    assert Meetup.meetup(2013, 5, :tuesday, :fourth) == {2013, 5, 28}
   end
 
   test "fourth tuesday of june 2013" do
-    assert {2013, 6, 25} == Meetup.meetup(2013, 6, :tuesday, :fourth)
+    assert Meetup.meetup(2013, 6, :tuesday, :fourth) == {2013, 6, 25}
   end
 
   test "fourth wednesday of july 2013" do
-    assert {2013, 7, 24} == Meetup.meetup(2013, 7, :wednesday, :fourth)
+    assert Meetup.meetup(2013, 7, :wednesday, :fourth) == {2013, 7, 24}
   end
 
   test "fourth wednesday of august 2013" do
-    assert {2013, 8, 28} == Meetup.meetup(2013, 8, :wednesday, :fourth)
+    assert Meetup.meetup(2013, 8, :wednesday, :fourth) == {2013, 8, 28}
   end
 
   test "fourth thursday of september 2013" do
-    assert {2013, 9, 26} == Meetup.meetup(2013, 9, :thursday, :fourth)
+    assert Meetup.meetup(2013, 9, :thursday, :fourth) == {2013, 9, 26}
   end
 
   test "fourth thursday of october 2013" do
-    assert {2013, 10, 24} == Meetup.meetup(2013, 10, :thursday, :fourth)
+    assert Meetup.meetup(2013, 10, :thursday, :fourth) == {2013, 10, 24}
   end
 
   test "fourth friday of november 2013" do
-    assert {2013, 11, 22} == Meetup.meetup(2013, 11, :friday, :fourth)
+    assert Meetup.meetup(2013, 11, :friday, :fourth) == {2013, 11, 22}
   end
 
   test "fourth friday of december 2013" do
-    assert {2013, 12, 27} == Meetup.meetup(2013, 12, :friday, :fourth)
+    assert Meetup.meetup(2013, 12, :friday, :fourth) == {2013, 12, 27}
   end
 
   test "fourth saturday of january 2013" do
-    assert {2013, 1, 26} == Meetup.meetup(2013, 1, :saturday, :fourth)
+    assert Meetup.meetup(2013, 1, :saturday, :fourth) == {2013, 1, 26}
   end
 
   test "fourth saturday of february 2013" do
-    assert {2013, 2, 23} == Meetup.meetup(2013, 2, :saturday, :fourth)
+    assert Meetup.meetup(2013, 2, :saturday, :fourth) == {2013, 2, 23}
   end
 
   test "fourth sunday of march 2013" do
-    assert {2013, 3, 24} == Meetup.meetup(2013, 3, :sunday, :fourth)
+    assert Meetup.meetup(2013, 3, :sunday, :fourth) == {2013, 3, 24}
   end
 
   test "fourth sunday of april 2013" do
-    assert {2013, 4, 28} == Meetup.meetup(2013, 4, :sunday, :fourth)
+    assert Meetup.meetup(2013, 4, :sunday, :fourth) == {2013, 4, 28}
   end
 
   test "last monday of march 2013" do
-    assert {2013, 3, 25} == Meetup.meetup(2013, 3, :monday, :last)
+    assert Meetup.meetup(2013, 3, :monday, :last) == {2013, 3, 25}
   end
 
   test "last monday of april 2013" do
-    assert {2013, 4, 29} == Meetup.meetup(2013, 4, :monday, :last)
+    assert Meetup.meetup(2013, 4, :monday, :last) == {2013, 4, 29}
   end
 
   test "last tuesday of may 2013" do
-    assert {2013, 5, 28} == Meetup.meetup(2013, 5, :tuesday, :last)
+    assert Meetup.meetup(2013, 5, :tuesday, :last) == {2013, 5, 28}
   end
 
   test "last tuesday of june 2013" do
-    assert {2013, 6, 25} == Meetup.meetup(2013, 6, :tuesday, :last)
+    assert Meetup.meetup(2013, 6, :tuesday, :last) == {2013, 6, 25}
   end
 
   test "last wednesday of july 2013" do
-    assert {2013, 7, 31} == Meetup.meetup(2013, 7, :wednesday, :last)
+    assert Meetup.meetup(2013, 7, :wednesday, :last) == {2013, 7, 31}
   end
 
   test "last wednesday of august 2013" do
-    assert {2013, 8, 28} == Meetup.meetup(2013, 8, :wednesday, :last)
+    assert Meetup.meetup(2013, 8, :wednesday, :last) == {2013, 8, 28}
   end
 
   test "last thursday of september 2013" do
-    assert {2013, 9, 26} == Meetup.meetup(2013, 9, :thursday, :last)
+    assert Meetup.meetup(2013, 9, :thursday, :last) == {2013, 9, 26}
   end
 
   test "last thursday of october 2013" do
-    assert {2013, 10, 31} == Meetup.meetup(2013, 10, :thursday, :last)
+    assert Meetup.meetup(2013, 10, :thursday, :last) == {2013, 10, 31}
   end
 
   test "last friday of november 2013" do
-    assert {2013, 11, 29} == Meetup.meetup(2013, 11, :friday, :last)
+    assert Meetup.meetup(2013, 11, :friday, :last) == {2013, 11, 29}
   end
 
   test "last friday of december 2013" do
-    assert {2013, 12, 27} == Meetup.meetup(2013, 12, :friday, :last)
+    assert Meetup.meetup(2013, 12, :friday, :last) == {2013, 12, 27}
   end
 
   test "last saturday of january 2013" do
-    assert {2013, 1, 26} == Meetup.meetup(2013, 1, :saturday, :last)
+    assert Meetup.meetup(2013, 1, :saturday, :last) == {2013, 1, 26}
   end
 
   test "last saturday of february 2013" do
-    assert {2013, 2, 23} == Meetup.meetup(2013, 2, :saturday, :last)
+    assert Meetup.meetup(2013, 2, :saturday, :last) == {2013, 2, 23}
   end
 
   test "last sunday of march 2013" do
-    assert {2013, 3, 31} == Meetup.meetup(2013, 3, :sunday, :last)
+    assert Meetup.meetup(2013, 3, :sunday, :last) == {2013, 3, 31}
   end
 
   test "last sunday of april 2013" do
-    assert {2013, 4, 28} == Meetup.meetup(2013, 4, :sunday, :last)
+    assert Meetup.meetup(2013, 4, :sunday, :last) == {2013, 4, 28}
   end
 end
 

--- a/minesweeper/minesweeper_test.exs
+++ b/minesweeper/minesweeper_test.exs
@@ -14,33 +14,33 @@ defmodule MinesweeperTest do
 
   test "zero size board" do
     b = []
-    assert b == Minesweeper.annotate(clean(b))
+    assert Minesweeper.annotate(clean(b)) == b
   end
 
   test "empty board" do
     b = ["   ",
          "   ",
          "   "]
-    assert b == Minesweeper.annotate(clean(b))
+    assert Minesweeper.annotate(clean(b)) == b
   end
 
   test "board full of mines" do
     b = ["***",
          "***",
          "***"]
-    assert b == Minesweeper.annotate(clean(b))
+    assert Minesweeper.annotate(clean(b)) == b
   end
 
   test "surrounded" do
     b = ["***",
          "*8*",
          "***"]
-    assert b == Minesweeper.annotate(clean(b))
+    assert Minesweeper.annotate(clean(b)) == b
   end
 
   test "horizontal line" do
     b = ["1*2*1"]
-    assert b == Minesweeper.annotate(clean(b))
+    assert Minesweeper.annotate(clean(b)) == b
   end
 
   test "vertical line" do
@@ -49,7 +49,7 @@ defmodule MinesweeperTest do
          "2",
          "*",
          "1"]
-    assert b == Minesweeper.annotate(clean(b))
+    assert Minesweeper.annotate(clean(b)) == b
   end
 
   test "cross" do
@@ -58,6 +58,6 @@ defmodule MinesweeperTest do
          "*****",
          "25*52",
          " 2*2 "]
-    assert b == Minesweeper.annotate(clean(b))
+    assert Minesweeper.annotate(clean(b)) == b
   end        
 end

--- a/nth-prime/nth_prime_test.exs
+++ b/nth-prime/nth_prime_test.exs
@@ -10,19 +10,19 @@ defmodule NthPrimeTest do
   use ExUnit.Case, async: true
 
   test "first prime" do
-    assert 2 == Prime.nth(1)
+    assert Prime.nth(1) == 2
   end
 
   test "second prime" do
-    assert 3 == Prime.nth(2)
+    assert Prime.nth(2) == 3
   end
 
   test "sixth prime" do
-    assert 13 == Prime.nth(6)
+    assert Prime.nth(6) == 13
   end
 
   test "100th prime" do
-    assert 541 == Prime.nth(100)
+    assert Prime.nth(100) == 541
   end
 
   test "weird case" do

--- a/nucleotide-count/nucleotide_count_test.exs
+++ b/nucleotide-count/nucleotide_count_test.exs
@@ -16,29 +16,29 @@ defmodule DNATest do
 
   test "empty dna string has no nucleotides" do
     expected = HashDict.new [{?A, 0}, {?T, 0}, {?C, 0}, {?G, 0}]
-    assert expected == DNA.nucleotide_counts('')
+    assert DNA.nucleotide_counts('') == expected
   end
 
   test "repetitive cytidine gets counted" do
-    assert 5 == DNA.count('CCCCC', ?C)
+    assert DNA.count('CCCCC', ?C) == 5
   end
 
   test "repetitive sequence has only guanosine" do
     expected = HashDict.new [{?A, 0}, {?T, 0}, {?C, 0}, {?G, 8}]
-    assert expected == DNA.nucleotide_counts('GGGGGGGG')
+    assert DNA.nucleotide_counts('GGGGGGGG') == expected
   end
 
   test "counts only thymidine" do
-    assert 1 == DNA.count('GGGGGTAACCCGG', ?T)
+    assert DNA.count('GGGGGTAACCCGG', ?T) == 1
   end
 
   test "dna has no uracil" do
-    assert 0 == DNA.count('GATTACA', ?U)
+    assert DNA.count('GATTACA', ?U) == 0
   end
 
   test "counts all nucleotides" do
     s = 'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
     expected = HashDict.new [{?A, 20}, {?T, 21}, {?C, 12}, {?G, 17}]
-    assert expected == DNA.nucleotide_counts(s)
+    assert DNA.nucleotide_counts(s) == expected
   end
 end

--- a/palindrome-products/palindrome_products_test.exs
+++ b/palindrome-products/palindrome_products_test.exs
@@ -11,32 +11,32 @@ defmodule PalindromeProductsTest do
 
   test "largest palindrome from single digit factors" do
     palindromes = Palindromes.generate(9)
-    assert 9 == palindromes |> Dict.keys |> Enum.sort |> List.last
-    assert [[1, 9], [3, 3]] == palindromes[9]
+    assert palindromes |> Dict.keys |> Enum.sort |> List.last == 9
+    assert palindromes[9] == [[1, 9], [3, 3]]
   end
 
   test "largest palindrome from double digit factors" do
     palindromes = Palindromes.generate(99, 10)
-    assert 9009 == palindromes |> Dict.keys |> Enum.sort |> List.last
-    assert [[91, 99]] == palindromes[9009]
+    assert palindromes |> Dict.keys |> Enum.sort |> List.last == 9009
+    assert palindromes[9009] == [[91, 99]]
   end
 
   test "smallest palindrome from double digit factors" do
     palindromes = Palindromes.generate(99, 10)
-    assert 121 == palindromes |> Dict.keys |> Enum.sort |> hd
-    assert [[11, 11]] == palindromes[121]
+    assert palindromes |> Dict.keys |> Enum.sort |> hd == 121
+    assert palindromes[121] == [[11, 11]]
   end
 
   test "largest palindrome from triple digit factors" do
     palindromes = Palindromes.generate(999, 100)
-    assert 906609 == palindromes |> Dict.keys |> Enum.sort |> List.last
-    assert [[913, 993]] == palindromes[906609]
+    assert palindromes |> Dict.keys |> Enum.sort |> List.last == 906609
+    assert palindromes[906609] == [[913, 993]]
   end
 
   test "smallest palindromes from triple digit factors" do
     palindromes = Palindromes.generate(999, 100)
-    assert 10201 == palindromes |> Dict.keys |> Enum.sort |> hd
-    assert [[101, 101]] == palindromes[10201]
+    assert palindromes |> Dict.keys |> Enum.sort |> hd == 10201
+    assert palindromes[10201] == [[101, 101]]
 
   end
 

--- a/phone-number/phone_number_test.exs
+++ b/phone-number/phone_number_test.exs
@@ -11,34 +11,34 @@ defmodule PhoneTest do
   doctest Phone
 
   test "cleans number" do
-    assert "1234567890" == Phone.number("(123) 456-7890")
+    assert Phone.number("(123) 456-7890") == "1234567890"
   end
 
   test "cleans number with dots" do
-    # assert "1234567890" == Phone.number("123.456.7890")
+    # assert Phone.number("123.456.7890") == "1234567890"
   end
 
   test "valid when 11 digits and first is 1" do
-    # assert "1234567890" == Phone.number("11234567890")
+    # assert Phone.number("11234567890") == "1234567890"
   end
 
   test "invalid when 11 digits" do
-    # assert "0000000000" == Phone.number("21234567890")
+    # assert Phone.number("21234567890") == "0000000000"
   end
 
   test "invalid when 9 digits" do
-    # assert "0000000000" == Phone.number("123456789")
+    # assert Phone.number("123456789") == "0000000000"
   end
 
   test "area code" do
-    # assert "123" == Phone.area_code("1234567890")
+    # assert Phone.area_code("1234567890") == "123"
   end
 
   test "pretty print" do
-    # assert "(123) 456-7890" == Phone.pretty("1234567890")
+    # assert Phone.pretty("1234567890") == "(123) 456-7890"
   end
 
   test "pretty print with full us phone number" do
-    # assert "(123) 456-7890" == Phone.pretty("11234567890")
+    # assert Phone.pretty("11234567890") == "(123) 456-7890"
   end
 end

--- a/point-mutations/point_mutations_test.exs
+++ b/point-mutations/point_mutations_test.exs
@@ -11,30 +11,30 @@ defmodule DNATest do
   doctest DNA
 
   test "no difference between empty strands" do
-    assert 0 == DNA.hamming_distance('', '')
+    assert DNA.hamming_distance('', '') == 0
   end
 
   test "no difference between identical strands" do
-    # assert 0 == DNA.hamming_distance('GGACTGA', 'GGACTGA')
+    # assert DNA.hamming_distance('GGACTGA', 'GGACTGA') == 0
   end
 
   test "hamming distance in off by one strand" do
-    # assert 19 == DNA.hamming_distance('GGACGGATTCTGACCTGGACTAATTTTGGGG', 'AGGACGGATTCTGACCTGGACTAATTTTGGGG')
+    # assert DNA.hamming_distance('GGACGGATTCTGACCTGGACTAATTTTGGGG', 'AGGACGGATTCTGACCTGGACTAATTTTGGGG') == 19
   end
 
   test "small hamming distance in middle somewhere" do
-    # assert 1 == DNA.hamming_distance('GGACG', 'GGTCG')
+    # assert DNA.hamming_distance('GGACG', 'GGTCG') == 1
   end
 
   test "larger distance" do
-    # assert 2 == DNA.hamming_distance('ACCAGGG', 'ACTATGG')
+    # assert DNA.hamming_distance('ACCAGGG', 'ACTATGG') == 2
   end
 
   test "ignores extra length on other strand when longer" do
-    # assert 3 == DNA.hamming_distance('AAACTAGGGG', 'AGGCTAGCGGTAGGAC')
+    # assert DNA.hamming_distance('AAACTAGGGG', 'AGGCTAGCGGTAGGAC') == 3
   end
 
   test "ignores extra length on original strand when longer" do
-    # assert 5 == DNA.hamming_distance('GACTACGGACAGGGTAGGGAAT', 'GACATCGCACACC')
+    # assert DNA.hamming_distance('GACTACGGACAGGGTAGGGAAT', 'GACATCGCACACC') == 5
   end
 end

--- a/prime-factors/prime_factors_test.exs
+++ b/prime-factors/prime_factors_test.exs
@@ -11,46 +11,46 @@ defmodule PrimeFactorsTest do
   doctest PrimeFactors
 
   test "1" do
-    assert [] == PrimeFactors.factors_for(1)
+    assert PrimeFactors.factors_for(1) == []
   end
 
   test "2" do
-    assert [2] == PrimeFactors.factors_for(2)
+    assert PrimeFactors.factors_for(2) == [2]
   end
 
   test "3" do
-    assert [3] == PrimeFactors.factors_for(3)
+    assert PrimeFactors.factors_for(3) == [3]
   end
 
   test "4" do
-    assert [2, 2] == PrimeFactors.factors_for(4)
+    assert PrimeFactors.factors_for(4) == [2, 2]
   end
 
   test "6" do
-    assert [2, 3] == PrimeFactors.factors_for(6)
+    assert PrimeFactors.factors_for(6) == [2, 3]
   end
 
   test "8" do
-    assert [2, 2, 2] == PrimeFactors.factors_for(8)
+    assert PrimeFactors.factors_for(8) == [2, 2, 2]
   end
 
   test "9" do
-    assert [3, 3] == PrimeFactors.factors_for(9)
+    assert PrimeFactors.factors_for(9) == [3, 3]
   end
 
   test "27" do
-    assert [3, 3, 3] == PrimeFactors.factors_for(27)
+    assert PrimeFactors.factors_for(27) == [3, 3, 3]
   end
 
   test "625" do
-    assert [5, 5, 5, 5] == PrimeFactors.factors_for(625)
+    assert PrimeFactors.factors_for(625) == [5, 5, 5, 5]
   end
 
   test "901255" do
-    assert [5, 17, 23, 461] == PrimeFactors.factors_for(901255)
+    assert PrimeFactors.factors_for(901255) == [5, 17, 23, 461]
   end
 
   test "93819012551" do
-    assert [11, 9539, 894119] == PrimeFactors.factors_for(93819012551)
+    assert PrimeFactors.factors_for(93819012551) == [11, 9539, 894119]
   end
 end

--- a/pythagorean-triplet/pythagorean_triplet_test.exs
+++ b/pythagorean-triplet/pythagorean_triplet_test.exs
@@ -11,12 +11,12 @@ defmodule PythagoreanTripletTest do
 
   test "sum" do
     triplet = [3, 4, 5]
-    assert 12 == Triplet.sum(triplet)
+    assert Triplet.sum(triplet) == 12
   end
 
   test "product" do
     triplet = [3, 4, 5]
-    assert 60 == Triplet.product(triplet)
+    assert Triplet.product(triplet) == 60
   end
 
   test "pythagorean" do
@@ -31,17 +31,17 @@ defmodule PythagoreanTripletTest do
 
   test "triplets up to 10" do
     triplets = Triplet.generate(1, 10)
-    assert [60, 480] == Enum.map(triplets, &Triplet.product/1)
+    assert Enum.map(triplets, &Triplet.product/1) == [60, 480]
   end
 
   test "triplets from 11 up to 20" do
     triplets = Triplet.generate(11, 20)
-    assert [3840] == Enum.map(triplets, &Triplet.product/1)
+    assert Enum.map(triplets, &Triplet.product/1) == [3840]
   end
 
   test "triplets where sum is 180 and max factor is 100" do
     triplets = Triplet.generate(1, 100, 180)
-    assert [118080, 168480, 202500] == Enum.map(triplets, &Triplet.product/1)
+    assert Enum.map(triplets, &Triplet.product/1) == [118080, 168480, 202500]
   end
 
 

--- a/raindrops/raindrops_test.exs
+++ b/raindrops/raindrops_test.exs
@@ -11,66 +11,66 @@ defmodule RaindropsTest do
   doctest Raindrops
 
   test "1" do
-    assert "1" == Raindrops.convert(1)
+    assert Raindrops.convert(1) == "1"
   end
 
   test "3" do
-    assert "Pling" == Raindrops.convert(3)
+    assert Raindrops.convert(3) == "Pling"
   end
 
   test "5" do
-    assert "Plang" == Raindrops.convert(5)
+    assert Raindrops.convert(5) == "Plang"
   end
 
   test "7" do
-    assert "Plong" == Raindrops.convert(7)
+    assert Raindrops.convert(7) == "Plong"
   end
 
   test "6" do
-    assert "Pling" == Raindrops.convert(6)
+    assert Raindrops.convert(6) == "Pling"
   end
 
   test "9" do
-    assert "Pling" == Raindrops.convert(9)
+    assert Raindrops.convert(9) == "Pling"
   end
 
   test "10" do
-    assert "Plang" == Raindrops.convert(10)
+    assert Raindrops.convert(10) == "Plang"
   end
 
   test "14" do
-    assert "Plong" == Raindrops.convert(14)
+    assert Raindrops.convert(14) == "Plong"
   end
 
   test "15" do
-    assert "PlingPlang" == Raindrops.convert(15)
+    assert Raindrops.convert(15) == "PlingPlang"
   end
 
   test "21" do
-    assert "PlingPlong" == Raindrops.convert(21)
+    assert Raindrops.convert(21) == "PlingPlong"
   end
 
   test "25" do
-    assert "Plang" == Raindrops.convert(25)
+    assert Raindrops.convert(25) == "Plang"
   end
 
   test "35" do
-    assert "PlangPlong" == Raindrops.convert(35)
+    assert Raindrops.convert(35) == "PlangPlong"
   end
 
   test "49" do
-    assert "Plong" == Raindrops.convert(49)
+    assert Raindrops.convert(49) == "Plong"
   end
 
   test "52" do
-    assert "52" == Raindrops.convert(52)
+    assert Raindrops.convert(52) == "52"
   end
 
   test "105" do
-    assert "PlingPlangPlong" == Raindrops.convert(105)
+    assert Raindrops.convert(105) == "PlingPlangPlong"
   end
 
   test "12121" do
-    assert "12121" == Raindrops.convert(12121)
+    assert Raindrops.convert(12121) == "12121"
   end
 end

--- a/roman-numerals/roman_numerals_test.exs
+++ b/roman-numerals/roman_numerals_test.exs
@@ -11,74 +11,74 @@ defmodule RomanTest do
   doctest Roman
 
   test "1" do
-    assert "I" == Roman.numerals(1)
+    assert Roman.numerals(1) == "I"
   end
 
   test "2" do
-    assert "II" == Roman.numerals(2)
+    assert Roman.numerals(2) == "II"
   end
 
   test "3" do
-    assert "III" == Roman.numerals(3)
+    assert Roman.numerals(3) == "III"
   end
 
   test "4" do
-    assert "IV" == Roman.numerals(4)
+    assert Roman.numerals(4) == "IV"
   end
 
   test "5" do
-    assert "V" == Roman.numerals(5)
+    assert Roman.numerals(5) == "V"
   end
 
   test "6" do
-    assert "VI" == Roman.numerals(6)
+    assert Roman.numerals(6) == "VI"
   end
 
   test "9" do
-    assert "IX" == Roman.numerals(9)
+    assert Roman.numerals(9) == "IX"
   end
 
   test "27" do
-    assert "XXVII" == Roman.numerals(27)
+    assert Roman.numerals(27) == "XXVII"
   end
 
   test "48" do
-    assert "XLVIII" == Roman.numerals(48)
+    assert Roman.numerals(48) == "XLVIII"
   end
 
   test "59" do
-    assert "LIX" == Roman.numerals(59)
+    assert Roman.numerals(59) == "LIX"
   end
 
   test "93" do
-    assert "XCIII" == Roman.numerals(93)
+    assert Roman.numerals(93) == "XCIII"
   end
 
   test "141" do
-    assert "CXLI" == Roman.numerals(141)
+    assert Roman.numerals(141) == "CXLI"
   end
 
   test "163" do
-    assert "CLXIII" == Roman.numerals(163)
+    assert Roman.numerals(163) == "CLXIII"
   end
 
   test "402" do
-    assert "CDII" == Roman.numerals(402)
+    assert Roman.numerals(402) == "CDII"
   end
 
   test "575" do
-    assert "DLXXV" == Roman.numerals(575)
+    assert Roman.numerals(575) == "DLXXV"
   end
 
   test "911" do
-    assert "CMXI" == Roman.numerals(911)
+    assert Roman.numerals(911) == "CMXI"
   end
 
   test "1024" do
-    assert "MXXIV" == Roman.numerals(1024)
+    assert Roman.numerals(1024) == "MXXIV"
   end
 
   test "3000" do
-    assert "MMM" == Roman.numerals(3000)
+    assert Roman.numerals(3000) == "MMM"
   end
 end

--- a/scrabble-score/scrabble_score_test.exs
+++ b/scrabble-score/scrabble_score_test.exs
@@ -11,34 +11,34 @@ defmodule ScrabbleScoreTest do
   doctest Scrabble
 
   test "empty word scores zero" do
-    assert 0 == Scrabble.score("")
+    assert Scrabble.score("") == 0
   end
 
   test "whitespace scores zero" do
-    assert 0 == Scrabble.score(" \t\n")
+    assert Scrabble.score(" \t\n") == 0
   end
 
   test "scores very short word" do
-    assert 1 == Scrabble.score("a")
+    assert Scrabble.score("a") == 1
   end
 
   test "scores other very short word" do
-    assert 4 == Scrabble.score("f")
+    assert Scrabble.score("f") == 4
   end
 
   test "simple word scores the number of letters" do
-    assert 6 == Scrabble.score("street")
+    assert Scrabble.score("street") == 6
   end
 
   test "complicated word scores more" do
-    assert 22 == Scrabble.score("quirky")
+    assert Scrabble.score("quirky") == 22
   end
 
   test "scores are case insensitive" do
-    assert 20 == Scrabble.score("MULTIBILLIONAIRE")
+    assert Scrabble.score("MULTIBILLIONAIRE") == 20
   end
 
   test "convenient scoring" do
-    assert 13 == Scrabble.score("alacrity")
+    assert Scrabble.score("alacrity") == 13
   end
 end

--- a/sieve/sieve_test.exs
+++ b/sieve/sieve_test.exs
@@ -10,7 +10,7 @@ defmodule SieveTest do
   use ExUnit.Case, async: true
 
   test "a few primes" do
-    assert [2, 3, 5, 7] == Sieve.primes_to(10)
+    assert Sieve.primes_to(10) == [2, 3, 5, 7]
   end
 
   test "primes to 1000" do
@@ -32,7 +32,7 @@ defmodule SieveTest do
     811, 821, 823, 827, 829, 839, 853, 857, 859,
     863, 877, 881, 883, 887, 907, 911, 919, 929,
     937, 941, 947, 953, 967, 971, 977, 983, 991, 997]
-    assert result == Sieve.primes_to(1000)
+    assert Sieve.primes_to(1000) == result
   end
 
 end

--- a/sum-of-multiples/sum_of_multiples_test.exs
+++ b/sum-of-multiples/sum_of_multiples_test.exs
@@ -10,29 +10,29 @@ defmodule SumOfMultiplesTest do
   use ExUnit.Case, async: true
 
   test "sum to 1" do
-    assert 0 == SumOfMultiples.to(1)
+    assert SumOfMultiples.to(1) == 0
   end
 
   test "sum to 3" do
-    assert 3 == SumOfMultiples.to(4)
+    assert SumOfMultiples.to(4) == 3
   end
 
   test "sum to 10" do
-    assert 23 == SumOfMultiples.to(10)
+    assert SumOfMultiples.to(10) == 23
   end
 
   test "sum to 1000" do
-    assert 233168 == SumOfMultiples.to(1000)
+    assert SumOfMultiples.to(1000) == 233168
   end
 
   test "configurable 7, 13, 17 to 20" do
     multiples = [7, 13, 17]
-    assert 51 == SumOfMultiples.to(20, multiples)
+    assert SumOfMultiples.to(20, multiples) == 51
   end
 
   test "configurable 43, 47 to 10000" do
     multiples = [43, 47]
-    assert 2203160 == SumOfMultiples.to(10000, multiples)
+    assert SumOfMultiples.to(10000, multiples) == 2203160
   end
 
 end

--- a/triangle/triangle_test.exs
+++ b/triangle/triangle_test.exs
@@ -10,63 +10,63 @@ defmodule TriangleTest do
   use ExUnit.Case, async: true
 
   test "equilateral triangles have equal sides" do
-    assert { :ok, :equilateral } == Triangle.kind(2, 2, 2)
+    assert Triangle.kind(2, 2, 2) == { :ok, :equilateral }
   end
 
   test "larger equilateral triangles also have equal sides" do
-    assert { :ok, :equilateral } == Triangle.kind(10, 10, 10)
+    assert Triangle.kind(10, 10, 10) == { :ok, :equilateral }
   end
 
   test "isosceles triangles have last two sides equal" do
-    assert { :ok, :isosceles } == Triangle.kind(3, 4, 4)
+    assert Triangle.kind(3, 4, 4) == { :ok, :isosceles }
   end
 
   test "isosceles triangles have first and last sides equal" do
-    assert { :ok, :isosceles } == Triangle.kind(4, 3, 4)
+    assert Triangle.kind(4, 3, 4) == { :ok, :isosceles }
   end
 
   test "isosceles triangles have two first sides equal" do
-    assert { :ok, :isosceles } == Triangle.kind(4, 4, 3)
+    assert Triangle.kind(4, 4, 3) == { :ok, :isosceles }
   end
 
   test "isosceles triangles have in fact exactly two sides equal" do
-    assert { :ok, :isosceles } == Triangle.kind(10, 10, 2)
+    assert Triangle.kind(10, 10, 2) == { :ok, :isosceles }
   end
 
   test "scalene triangles have no equal sides" do
-    assert { :ok, :scalene } == Triangle.kind(3, 4, 5)
+    assert Triangle.kind(3, 4, 5) == { :ok, :scalene }
   end
 
   test "scalene triangles have no equal sides at a larger scale too" do
-    assert { :ok, :scalene } == Triangle.kind(10, 11, 12)
+    assert Triangle.kind(10, 11, 12) == { :ok, :scalene }
   end
 
   test "scalene triangles have no equal sides in descending order either" do
-    assert { :ok, :scalene } == Triangle.kind(5, 4, 2)
+    assert Triangle.kind(5, 4, 2) == { :ok, :scalene }
   end
 
   test "very small triangles are legal" do
-    assert { :ok, :scalene } == Triangle.kind(0.4, 0.6, 0.3)
+    assert Triangle.kind(0.4, 0.6, 0.3) == { :ok, :scalene }
   end
 
   test "triangles with no size are illegal" do
-    assert { :error, "all side lengths must be positive" } == Triangle.kind(0, 0, 0)
+    assert Triangle.kind(0, 0, 0) == { :error, "all side lengths must be positive" }
   end
 
   test "triangles with negative sides are illegal" do
-    assert { :error, "all side lengths must be positive" } == Triangle.kind(3, 4, -5)
+    assert Triangle.kind(3, 4, -5) == { :error, "all side lengths must be positive" }
   end
 
   test "triangles violating triangle inequality are illegal" do
-    assert { :error, "side lengths violate triangle inequality" } == Triangle.kind(1, 1, 3)
+    assert Triangle.kind(1, 1, 3) == { :error, "side lengths violate triangle inequality" }
   end
 
   test "triangles violating triangle inequality are illegal 2" do
-    assert { :error, "side lengths violate triangle inequality" } == Triangle.kind(2, 4, 2)
+    assert Triangle.kind(2, 4, 2) == { :error, "side lengths violate triangle inequality" }
   end
 
   test "triangles violating triangle inequality are illegal 3" do
-    assert { :error, "side lengths violate triangle inequality" } == Triangle.kind(7, 3, 2)
+    assert Triangle.kind(7, 3, 2) == { :error, "side lengths violate triangle inequality" }
   end
 end
 

--- a/zipper/zipper_test.exs
+++ b/zipper/zipper_test.exs
@@ -38,34 +38,34 @@ defmodule ZipperTest do
                      bt(6, leaf(7), leaf(8)))
 
   test "data is retained" do
-    assert t1 == (t1 |> from_tree |> to_tree)
+    assert (t1 |> from_tree |> to_tree) == t1
   end
   
   test "left, right and value" do
-    assert 3 == (t1 |> from_tree |> left |> right |> value)
+    assert (t1 |> from_tree |> left |> right |> value) == 3
   end
   
   test "dead end" do
-    assert nil == (t1 |> from_tree |> left |> left)
+    assert (t1 |> from_tree |> left |> left) == nil
   end
 
   test "tree from deep focus" do
-    assert t1 == (t1 |> from_tree |> left |> right |> to_tree)
+    assert (t1 |> from_tree |> left |> right |> to_tree) == t1
   end
 
   test "set_value" do
-    assert t2 == (t1 |> from_tree |> left |> set_value(5) |> to_tree)
+    assert (t1 |> from_tree |> left |> set_value(5) |> to_tree) == t2
   end
   
   test "set_left with leaf" do
-    assert t3 == (t1 |> from_tree |> left |> set_left(leaf(5)) |> to_tree)
+    assert (t1 |> from_tree |> left |> set_left(leaf(5)) |> to_tree) == t3
   end
   
   test "set_right with nil" do
-    assert t4 == (t1 |> from_tree |> left |> set_right(nil) |> to_tree)
+    assert (t1 |> from_tree |> left |> set_right(nil) |> to_tree) == t4
   end
   
   test "set_right with subtree" do
-    assert t5 == (t1 |> from_tree |> set_right(bt(6, leaf(7), leaf(8))) |> to_tree)
+    assert (t1 |> from_tree |> set_right(bt(6, leaf(7), leaf(8))) |> to_tree) == t5
   end
 end


### PR DESCRIPTION
Several [exercism/xelixir](https://github.com/exercism/xelixir) assertions seem to be flip-flopped, making their failure messages a bit confusing.

The [`assert/1` macro](http://elixir-lang.org/docs/stable/ExUnit.Assertions.html#assert/1) will format failing scenarios in a helpful manner of comparing actual and expected values. Given a script with a failing test:

``` elixir

defmodule Math do
  def add(x, y), do: 0
end

ExUnit.start

defmodule MathTest do
  use ExUnit.Case, async: true

  test "addition works" do
    assert Math.add(1, 1) == 2
  end
end
```

…running `elixir example.exs` produces a helpful failure message:

```
  1) test addition works (MathTest)
     ** (ExUnit.ExpectationError)
                  expected: 0
       to be equal to (==): 2
     at example.exs:11

Finished in 0.02 seconds (0.02s on load, 0.00s on tests)
1 tests, 1 failures
```

The proper form of writing an assertion seems to be:

``` elixir
assert actual_value == expected_value
```

Several [exercism/xelixir](https://github.com/exercism/xelixir) tests have swapped the actual and expected values. For example, if you look at the [the first test of point_mutations_test.exs](https://github.com/exercism/xelixir/blob/8584070f5d8436816c9d7b1480b687947b383bc3/point-mutations/point_mutations_test.exs#L13-L15), the `actual_value` is on the right-hand-side of the `==`, which produces a confusing failure message:

```
  1) test no difference between empty strands (DNATest)
     ** (ExUnit.ExpectationError)
                  expected: 0
       to be equal to (==): nil
     at point_mutations_test.exs:14
```

The message is not describing the correct failure of `DNA.hamming_distance/2`, namely, that it's an empty implementation that's returning `nil` when the caclulation should return 0. Instead, this message leads the implementer to believe that the function is returning 0 when `nil` is what one wants.

Switching up the order of these assertions improves the failure messages and makes it easier to TDD an exercise solution.
## How to test

You could check if the test results for the example solutions match between `master` and the PR. Here's a script that will compare the results:

``` sh
# TODO: Assign the name of your local branch
pr_branch=assertion-order

function md5_of_test_results {
 for i in $(echo */); do pushd>/dev/null $i; EXERCISM_TEST_EXAMPLES=1 elixir *test.exs | tail -1; popd>/dev/null; done | md5
}

echo ""
echo "=== Running tests on master === "
git checkout master
master_md5=$( md5_of_test_results )

echo ""
echo "=== Running tests on $pr_branch ==="
git checkout $pr_branch
branch_md5=$( md5_of_test_results )

echo ""
if [ "$master_md5" = "$branch_md5" ]; then
 echo "✔︎ Same test results"
else
 echo "✘ Different test results"
fi
```

Thanks! I think [exercism.io](http://exercism.io/) is a fantastic project!
