### PR TITLE
change doctest to match readme and spec

### DIFF
--- a/phone-number/phone_number.exs
+++ b/phone-number/phone_number.exs
@@ -11,7 +11,7 @@ defmodule Phone do
   "1234567890"
 
   iex> Phone.number("+1 (303) 555-1212")
-  "13035551212"
+  "3035551212"
 
   iex> Phone.number("867.5309")
   "0000000000"


### PR DESCRIPTION
As I read it, the original doctest asserts that a string representing an 11 digit number will be returned when the first character of the string is "1". The README and one of the specs directly contradict this.

From the README:
- If the phone number is 11 digits and the first number is 1, trim the 1 and use the first 10 digits

From the spec, line 22:
assert Phone.number("11234567890") == "1234567890"
