### PR TITLE
Use on_exit callback instead of teardown for bank-account tests

### DIFF
--- a/bank-account/bank_account_test.exs
+++ b/bank-account/bank_account_test.exs
@@ -28,12 +28,8 @@ defmodule BankAccountTest do
 
   setup do
     account = BankAccount.open_bank()
+    on_exit fn -> BankAccount.close_bank(account) end
     { :ok, [ account: account ] }
-  end
-
-  teardown context do
-    BankAccount.close_bank(context[:account])
-    :ok
   end
 
   test "initial balance is 0", context do


### PR DESCRIPTION
The teardown functionality was removed from ExUnit and replaced by the [on_exit function](https://github.com/elixir-lang/elixir/issues/2319). This PR fixes the unit tests so they'll actually run.

That said, I'd also like to note that keeping the `BankAccount.close_bank/1` function in the exercise forces you to use `GenServer.start/3` instead of `GenServer.start_link/3` which would automatically clean things up for you when the parent dies...which is a better/safer way to go.
