### PR TITLE
Fix the incorrect slashes denoting a default value in sum-of-multiples

### DIFF
--- a/sum-of-multiples/sum_of_multiples.exs
+++ b/sum-of-multiples/sum_of_multiples.exs
@@ -1,13 +1,11 @@
 defmodule SumOfMultiples do
-
   @doc """
   Adds up all numbers from 1 to a given end number that are multiples of the factors provided.
-  
+
   The default factors are 3 and 5.
   """
   @spec to(non_neg_integer, [non_neg_integer]) :: non_neg_integer
   def to(limit, factors \\ [3, 5]) do
-  
+    
   end
-
 end


### PR DESCRIPTION
This PR changes the incorrect forward slashes into backslashes which denote the default values for a function. I also cleaned up the whitespace for consistency.
