### PR TITLE
introduce collatz conjecture exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -607,6 +607,13 @@
         "Strings",
         "Enumerations"
       ]
+    },
+    {
+      "slug": "collatz-conjecture",
+      "difficulty": 2,
+      "topics": [
+        "Recursion"
+      ]
     }
   ],
   "deprecated": [

--- a/exercises/collatz-conjecture/collatz_conjecture.exs
+++ b/exercises/collatz-conjecture/collatz_conjecture.exs
@@ -1,0 +1,13 @@
+defmodule CollatzConjecture do
+
+  @doc """
+  calc/1 takes an integer and returns the number of steps required to get the
+  number to 1 when following the rules:
+    - if number is odd, multiply with 3 and add 1
+    - if number is even, divide by 2
+  """
+  @spec calc(number :: integer) :: pos_integer
+  def calc(input) do
+    raise "ain't got no time for that"
+  end
+end

--- a/exercises/collatz-conjecture/collatz_conjecture.exs
+++ b/exercises/collatz-conjecture/collatz_conjecture.exs
@@ -6,8 +6,7 @@ defmodule CollatzConjecture do
     - if number is odd, multiply with 3 and add 1
     - if number is even, divide by 2
   """
-  @spec calc(number :: integer) :: pos_integer
+  @spec calc(number :: pos_integer) :: pos_integer
   def calc(input) do
-    raise "ain't got no time for that"
   end
 end

--- a/exercises/collatz-conjecture/collatz_conjecture_test.exs
+++ b/exercises/collatz-conjecture/collatz_conjecture_test.exs
@@ -13,7 +13,7 @@ defmodule CollatzConjectureTest do
   end
 
   test "zero is an error" do
-    assert_raise ArgumentError, "Only positive numbers are allowed", fn -> CollatzConjecture.calc(0) end
+    assert_raise FunctionClauseError, fn -> CollatzConjecture.calc(0) end
   end
 
   @tag :pending
@@ -43,6 +43,11 @@ defmodule CollatzConjectureTest do
 
   @tag :pending
   test "negative value is an error " do
-    assert_raise ArgumentError, "Only positive numbers are allowed", fn -> CollatzConjecture.calc(-15) end
+    assert_raise FunctionClauseError, fn -> CollatzConjecture.calc(-15) end
+  end
+
+  @tag :pending
+  test "string as input value is an error " do
+    assert_raise FunctionClauseError, fn -> CollatzConjecture.calc("fubar") end
   end
 end

--- a/exercises/collatz-conjecture/collatz_conjecture_test.exs
+++ b/exercises/collatz-conjecture/collatz_conjecture_test.exs
@@ -12,6 +12,7 @@ defmodule CollatzConjectureTest do
     assert CollatzConjecture.calc(1) == 0
   end
 
+  @tag :pending
   test "zero is an error" do
     assert_raise FunctionClauseError, fn -> CollatzConjecture.calc(0) end
   end

--- a/exercises/collatz-conjecture/collatz_conjecture_test.exs
+++ b/exercises/collatz-conjecture/collatz_conjecture_test.exs
@@ -1,0 +1,48 @@
+if !System.get_env("EXERCISM_TEST_EXAMPLES") do
+  Code.load_file("collatz_conjecture.exs", __DIR__)
+end
+
+ExUnit.start
+ExUnit.configure exclude: :pending, trace: true
+
+defmodule CollatzConjectureTest do
+  use ExUnit.Case
+
+  test "zero steps for one" do
+    assert CollatzConjecture.calc(1) == 0
+  end
+
+  test "zero is an error" do
+    assert_raise ArgumentError, "Only positive numbers are allowed", fn -> CollatzConjecture.calc(0) end
+  end
+
+  @tag :pending
+  test "divide if even" do
+    assert CollatzConjecture.calc(16) == 4
+  end
+
+  @tag :pending
+  test "even and odd steps" do
+    assert CollatzConjecture.calc(12) == 9
+  end
+
+  @tag :pending
+  test "Large number of even and odd steps" do
+    assert CollatzConjecture.calc(1000000) == 152
+  end
+
+  @tag :pending
+  test "start with odd step" do
+    assert CollatzConjecture.calc(21) == 7
+  end
+
+  @tag :pending
+  test "more steps than starting number" do
+    assert CollatzConjecture.calc(7) == 16
+  end
+
+  @tag :pending
+  test "negative value is an error " do
+    assert_raise ArgumentError, "Only positive numbers are allowed", fn -> CollatzConjecture.calc(-15) end
+  end
+end

--- a/exercises/collatz-conjecture/example.exs
+++ b/exercises/collatz-conjecture/example.exs
@@ -1,0 +1,25 @@
+defmodule CollatzConjecture do
+
+  @doc """
+  calc/1 takes number (> 1), and returns the number of steps required to get to 1 when
+  following the rules: if n is odd, multiply with 3 and add 1. if n is even, divide by 2
+  """
+  @spec calc(number :: integer) :: pos_integer
+  def calc(number) when number < 1 do
+    raise ArgumentError, "Only positive numbers are allowed"
+  end
+
+  def calc(number) do
+    calc(number, 0)
+  end
+
+  defp calc(1, steps), do: steps
+  defp calc(number, steps) when rem(number, 2) == 0 do
+    calc(div(number, 2), steps + 1)
+  end
+
+  defp calc(number, steps) do
+    calc(number * 3 + 1, steps + 1)
+  end
+end
+

--- a/exercises/collatz-conjecture/example.exs
+++ b/exercises/collatz-conjecture/example.exs
@@ -4,12 +4,8 @@ defmodule CollatzConjecture do
   calc/1 takes number (> 1), and returns the number of steps required to get to 1 when
   following the rules: if n is odd, multiply with 3 and add 1. if n is even, divide by 2
   """
-  @spec calc(number :: integer) :: pos_integer
-  def calc(number) when number < 1 do
-    raise ArgumentError, "Only positive numbers are allowed"
-  end
-
-  def calc(number) do
+  @spec calc(number :: pos_integer) :: pos_integer
+  def calc(number) when number > 0 and is_integer(number) do
     calc(number, 0)
   end
 
@@ -22,4 +18,3 @@ defmodule CollatzConjecture do
     calc(number * 3 + 1, steps + 1)
   end
 end
-


### PR DESCRIPTION
Adds Collatz Conjecture exercise as [described in x-common repo](https://github.com/exercism/x-common/blob/master/exercises/collatz-conjecture/description.md)

It wasn't clear how to use the [provided JSON as test data](https://github.com/exercism/x-common/blob/master/exercises/collatz-conjecture/canonical-data.json), so I ported them to ExUnit manually. Since this is my first (exercism) PR, let me know if I missed anything :)