### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# xElixir
+# Exercism Elixir Track
 
-![build status](https://travis-ci.org/exercism/xelixir.svg?branch=master)
+![build status](https://travis-ci.org/exercism/elixir.svg?branch=master)
 
 Exercism Exercises in Elixir
 
@@ -72,7 +72,7 @@ test "shouting" do
 end
 ```
 
-All the tests for xElixir exercises can be run from the top level of the repo
+All the tests for Exercism Elixir Track exercises can be run from the top level of the repo
 with `$ mix test`. Please run this command before submitting your PR. Watch out
 for and correct any compiler warnings you may have introduced.
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "elixir",
   "language": "Elixir",
-  "repository": "https://github.com/exercism/xelixir",
+  "repository": "https://github.com/exercism/elixir",
   "active": true,
   "exercises": [
     {


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1