### PR TITLE
Implement dominoes exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -614,6 +614,17 @@
       "topics": [
         "Recursion"
       ]
+    },
+    {
+      "slug": "dominoes",
+      "difficulty": 4,
+      "topics": [
+        "Recursion",
+        "Enumerations",
+        "Trees",
+        "Algorithms",
+        "Sorting"
+      ]
     }
   ],
   "deprecated": [

--- a/exercises/dominoes/dominoes.exs
+++ b/exercises/dominoes/dominoes.exs
@@ -3,10 +3,8 @@ defmodule Dominoes do
   @type domino :: {1..6, 1..6}
 
   @doc """
-  chain?/1 takes a list of integer and returns boolean indicating if chain is possible
-  number to 1 when following the rules:
-    - if number is odd, multiply with 3 and add 1
-    - if number is even, divide by 2
+  chain?/1 takes a list of domino stones and returns boolean indicating if it's
+  possible to make a full chain
   """
   @spec chain?(dominoes :: [domino] | []) :: boolean
   def chain?(dominoes) do

--- a/exercises/dominoes/dominoes.exs
+++ b/exercises/dominoes/dominoes.exs
@@ -1,12 +1,14 @@
 defmodule Dominoes do
 
+  @type domino :: {1..6, 1..6}
+
   @doc """
   chain?/1 takes a list of integer and returns boolean indicating if chain is possible
   number to 1 when following the rules:
     - if number is odd, multiply with 3 and add 1
     - if number is even, divide by 2
   """
-  @spec chain?(dominoes :: list) :: boolean
-  def chain?(input) do
+  @spec chain?(dominoes :: [domino] | []) :: boolean
+  def chain?(dominoes) do
   end
 end

--- a/exercises/dominoes/dominoes.exs
+++ b/exercises/dominoes/dominoes.exs
@@ -1,0 +1,12 @@
+defmodule Dominoes do
+
+  @doc """
+  chain?/1 takes a list of integer and returns boolean indicating if chain is possible
+  number to 1 when following the rules:
+    - if number is odd, multiply with 3 and add 1
+    - if number is even, divide by 2
+  """
+  @spec chain?(dominoes :: list) :: boolean
+  def chain?(input) do
+  end
+end

--- a/exercises/dominoes/dominoes_test.exs
+++ b/exercises/dominoes/dominoes_test.exs
@@ -14,67 +14,67 @@ defmodule DominoesTest do
 
   @tag :pending
   test "singleton input = singleton output" do
-    assert Dominoes.chain?([[1, 1]]) == true
+    assert Dominoes.chain?([{1, 1}]) == true
   end
 
   @tag :pending
   test "singleton that can't be chained" do
-    assert Dominoes.chain?([[1, 2]]) == false
+    assert Dominoes.chain?([{1, 2}]) == false
   end
 
   @tag :pending
   test "three elements" do
-    assert Dominoes.chain?([[1, 2], [3, 1], [2, 3]]) == true
+    assert Dominoes.chain?([{1, 2}, {3, 1}, {2, 3}]) == true
   end
 
   @tag :pending
   test "can reverse dominoes" do
-    assert Dominoes.chain?([[1, 2], [1, 3], [2, 3]]) == true
+    assert Dominoes.chain?([{1, 2}, {1, 3}, {2, 3}]) == true
   end
 
   @tag :pending
   test "can't be chained" do
-    assert Dominoes.chain?([[1, 2], [4, 1], [2, 3]]) == false
+    assert Dominoes.chain?([{1, 2}, {4, 1}, {2, 3}]) == false
   end
 
   @tag :pending
   test "disconnected - double loop" do
-    assert Dominoes.chain?([[1, 2], [2, 1], [3, 4], [4, 3]]) == false
+    assert Dominoes.chain?([{1, 2}, {2, 1}, {3, 4}, {4, 3}]) == false
   end
 
   @tag :pending
   test "disconnected - single isolated" do
-    assert Dominoes.chain?([[1, 2], [2, 3], [3, 1], [4, 4]]) == false
+    assert Dominoes.chain?([{1, 2}, {2, 3}, {3, 1}, {4, 4}]) == false
   end
 
   @tag :pending
   test "need backtrack" do
-    assert Dominoes.chain?([[1, 2], [2, 3], [3, 1], [2, 4], [2, 4]]) == true # a variation in which we have to turn but no duplicates
+    assert Dominoes.chain?([{1, 2}, {2, 3}, {3, 1}, {2, 4}, {2, 4}]) == true # a variation in which we have to turn but no duplicates
   end
 
   @tag :pending
   test "separate loops" do
-    assert Dominoes.chain?([[1, 2], [2, 3], [3, 1], [1, 1], [2, 2], [3, 3]]) == true
+    assert Dominoes.chain?([{1, 2}, {2, 3}, {3, 1}, {1, 1}, {2, 2}, {3, 3}]) == true
   end
 
   @tag :pending
   test "nine elements" do
-    assert Dominoes.chain?([[1, 2], [5, 3], [3, 1], [1, 2], [2, 4], [1, 6], [2, 3], [3, 4], [5, 6]]) == true
+    assert Dominoes.chain?([{1, 2}, {5, 3}, {3, 1}, {1, 2}, {2, 4}, {1, 6}, {2, 3}, {3, 4}, {5, 6}]) == true
  end
 
 
   @tag :pending
   test "disconnected - simple" do
-    refute Dominoes.chain?([[1, 1], [2, 2]])
+    refute Dominoes.chain?([{1, 1}, {2, 2}])
   end
 
   @tag :pending
   test "first and last not matching" do
-    assert Dominoes.chain?([[1, 2], [2, 3], [3, 4]]) == false
+    assert Dominoes.chain?([{1, 2}, {2, 3}, {3, 4}]) == false
   end
 
   @tag :pending
   test "wrong starting order" do
-    assert Dominoes.chain?([[2, 1], [2, 3], [3, 1]]) == true
+    assert Dominoes.chain?([{2, 1}, {2, 3}, {3, 1}]) == true
   end
 end

--- a/exercises/dominoes/dominoes_test.exs
+++ b/exercises/dominoes/dominoes_test.exs
@@ -1,0 +1,80 @@
+if !System.get_env("EXERCISM_TEST_EXAMPLES") do
+  Code.load_file("dominoes.exs", __DIR__)
+end
+
+ExUnit.start
+ExUnit.configure exclude: :pending, trace: true
+
+defmodule DominoesTest do
+  use ExUnit.Case
+
+  test "empty input = empty output" do
+    assert Dominoes.chain?([]) == true
+  end
+
+  @tag :pending
+  test "singleton input = singleton output" do
+    assert Dominoes.chain?([[1, 1]]) == true
+  end
+
+  @tag :pending
+  test "singleton that can't be chained" do
+    assert Dominoes.chain?([[1, 2]]) == false
+  end
+
+  @tag :pending
+  test "three elements" do
+    assert Dominoes.chain?([[1, 2], [3, 1], [2, 3]]) == true
+  end
+
+  @tag :pending
+  test "can reverse dominoes" do
+    assert Dominoes.chain?([[1, 2], [1, 3], [2, 3]]) == true
+  end
+
+  @tag :pending
+  test "can't be chained" do
+    assert Dominoes.chain?([[1, 2], [4, 1], [2, 3]]) == false
+  end
+
+  @tag :pending
+  test "disconnected - double loop" do
+    assert Dominoes.chain?([[1, 2], [2, 1], [3, 4], [4, 3]]) == false
+  end
+
+  @tag :pending
+  test "disconnected - single isolated" do
+    assert Dominoes.chain?([[1, 2], [2, 3], [3, 1], [4, 4]]) == false
+  end
+
+  @tag :pending
+  test "need backtrack" do
+    assert Dominoes.chain?([[1, 2], [2, 3], [3, 1], [2, 4], [2, 4]]) == true # a variation in which we have to turn but no duplicates
+  end
+
+  @tag :pending
+  test "separate loops" do
+    assert Dominoes.chain?([[1, 2], [2, 3], [3, 1], [1, 1], [2, 2], [3, 3]]) == true
+  end
+
+  @tag :pending
+  test "nine elements" do
+    assert Dominoes.chain?([[1, 2], [5, 3], [3, 1], [1, 2], [2, 4], [1, 6], [2, 3], [3, 4], [5, 6]]) == true
+ end
+
+
+  @tag :pending
+  test "disconnected - simple" do
+    refute Dominoes.chain?([[1, 1], [2, 2]])
+  end
+
+  @tag :pending
+  test "first and last not matching" do
+    assert Dominoes.chain?([[1, 2], [2, 3], [3, 4]]) == false
+  end
+
+  @tag :pending
+  test "wrong starting order" do
+    assert Dominoes.chain?([[2, 1], [2, 3], [3, 1]]) == true
+  end
+end

--- a/exercises/dominoes/example.exs
+++ b/exercises/dominoes/example.exs
@@ -1,34 +1,36 @@
 defmodule Dominoes do
 
+  @type domino :: {1..6, 1..6}
+
   @doc """
   chain?/1 takes a list of integer and returns boolean indicating if chain is possible
   number to 1 when following the rules:
     - if number is odd, multiply with 3 and add 1
     - if number is even, divide by 2
   """
-  @spec chain?(dominoes :: list) :: boolean
+  @spec chain?(dominoes :: [domino] | []) :: boolean
   def chain?([]), do: true
-  def chain?([[a, a]]), do: true
-  def chain?([[_a, _b]]), do: false
+  def chain?([{a, a}]), do: true
+  def chain?([{_a, _b}]), do: false
   def chain?(dominoes), do: [] !== chains(dominoes)
 
   def chains([first | rest]) do
     for combi <- permutations(rest), {:ok, result} <- chain(combi, [], first), do: result
   end
 
-  defp chain([], [a | _] = acc, [_, a] = last), do: [{:ok, acc ++ last}]
+  defp chain([], [{a, _} | _] = acc, {_, a} = last), do: [{:ok, acc ++ [last]}]
   defp chain([], _acc, _last), do: [{:error, :ends_not_same}]
 
-  defp chain([[b, c] = this | rest], acc, [_, b] = next) when b != c do
-    chain(rest, acc ++ next, this)
+  defp chain([{b, c} = this | rest], acc, {_, b} = next) when b != c do
+    chain(rest, acc ++ [next], this)
   end
 
-  defp chain([[c, b] | rest], acc, [_, b] = next) when b != c  do
-    chain(rest, acc ++ next, [b, c])
+  defp chain([{c, b} | rest], acc, {_, b} = next) when b != c  do
+    chain(rest, acc ++ [next], {b, c})
   end
 
-  defp chain([[b, b] = this | rest], acc, [_, b] = next)  do
-    chain(rest, acc ++ next, this)
+  defp chain([{b, b} = this | rest], acc, {_, b} = next)  do
+    chain(rest, acc ++ [next], this)
   end
 
   defp chain(_a, _b, _c), do: [{:error, :no_followup}]

--- a/exercises/dominoes/example.exs
+++ b/exercises/dominoes/example.exs
@@ -1,0 +1,40 @@
+defmodule Dominoes do
+
+  @doc """
+  chain?/1 takes a list of integer and returns boolean indicating if chain is possible
+  number to 1 when following the rules:
+    - if number is odd, multiply with 3 and add 1
+    - if number is even, divide by 2
+  """
+  @spec chain?(dominoes :: list) :: boolean
+  def chain?([]), do: true
+  def chain?([[a, a]]), do: true
+  def chain?([[_a, _b]]), do: false
+  def chain?(dominoes), do: [] !== chains(dominoes)
+
+  def chains([first | rest]) do
+    for combi <- permutations(rest), {:ok, result} <- chain(combi, [], first), do: result
+  end
+
+  defp chain([], [a | _] = acc, [_, a] = last), do: [{:ok, acc ++ last}]
+  defp chain([], _acc, _last), do: [{:error, :ends_not_same}]
+
+  defp chain([[b, c] = this | rest], acc, [_, b] = next) when b != c do
+    chain(rest, acc ++ next, this)
+  end
+
+  defp chain([[c, b] | rest], acc, [_, b] = next) when b != c  do
+    chain(rest, acc ++ next, [b, c])
+  end
+
+  defp chain([[b, b] = this | rest], acc, [_, b] = next)  do
+    chain(rest, acc ++ next, this)
+  end
+
+  defp chain(_a, _b, _c), do: [{:error, :no_followup}]
+
+  defp permutations([]), do: [[]]
+  defp permutations(list) do
+    for h <- list, t <- permutations(list -- [h]), do: [h | t]
+  end
+end

--- a/exercises/dominoes/example.exs
+++ b/exercises/dominoes/example.exs
@@ -3,10 +3,8 @@ defmodule Dominoes do
   @type domino :: {1..6, 1..6}
 
   @doc """
-  chain?/1 takes a list of integer and returns boolean indicating if chain is possible
-  number to 1 when following the rules:
-    - if number is odd, multiply with 3 and add 1
-    - if number is even, divide by 2
+  chain?/1 takes a list of domino stones and returns boolean indicating if it's
+  possible to make a full chain
   """
   @spec chain?(dominoes :: [domino] | []) :: boolean
   def chain?([]), do: true


### PR DESCRIPTION
# Implements the [dominoes exercise](https://github.com/exercism/problem-specifications/tree/master/exercises/dominoes):

> Make a chain of dominoes.
> 
> Compute a way to order a given set of dominoes in such a way that they form a correct domino chain (the dots on one half of a stone match the dots on the neighbouring half of an adjacent stone) and that dots on the halfs of the stones which don't have a neighbour (the first and last stone) match each other.
> 
> For example given the stones 21, 23 and 13 you should compute something like 12 23 31 or 32 21 13 or 13 32 21 etc, where the first and last numbers are the same.
> 
> For stones 12, 41 and 23 the resulting chain is not valid: 41 12 23's first and last numbers are not the same. 4 != 3

## Solution/example

Creates all permutations of the given dominoes and then tries to find sets that match the specifications by simply checking if next stone can be added to last one. This example falls in the 'brute-force' category, there are definitely better solutions.

## Tests

Basically copies of the ones in problem description with some extra (that were missing imo):

- test if first and last number also match
- in all other tests the first stone can stay 'first' to make a match, added an exception ("scrambled" order)

## Topics & difficulty 

I've given it difficulty 4, since it's harder than most "starter" assignments. My example involved recursion, enumerations and sorting but someone clever might use trees and an actual algorithm to solve it.

Let me know what your thoughts are :)