### PR TITLE
String.strip is deprecated in elixir 1.5

### DIFF
--- a/exercises/bob/example.exs
+++ b/exercises/bob/example.exs
@@ -26,7 +26,7 @@ defmodule Bob do
     end
   end
 
-  defp silent?(input),   do: "" == String.strip(input)
+  defp silent?(input),   do: "" == String.trim(input)
   defp shouting?(input), do: input == String.upcase(input) && letters?(input)
   defp question?(input), do: String.ends_with?(input, "?")
   defp letters?(input),  do: Regex.match?(~r/\p{L}+/, input)


### PR DESCRIPTION
reference: https://github.com/elixir-lang/elixir/releases/tag/v1.5.0