### PR TITLE
Reformat 'about' documentation for nextercism

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,31 +1,18 @@
-[Elixir](http://elixir-lang.org/), initially released in 2012, extends upon the
-already robust features of Erlang while also being easier for beginners to
-access, read, test, and write.
+[Elixir](http://elixir-lang.org/), initially released in 2012, extends upon the already robust features of Erlang while also being easier for beginners to access, read, test, and write.
 
-José Valim, the creator of Elixir, explains [here](https://vimeo.com/53221562)
-how he built the language for applications to be:
+José Valim, the creator of Elixir, explains [here](https://vimeo.com/53221562) how he built the language for applications to be:
 
   1. Distributed
   2. Fault-Tolerant
   3. Soft-Real-Time
   4. Hot-Code-Swapped (can introduce new code without stopping the server)
 
-Elixir actually compiles down to [bytecode](https://en.wikipedia.org/wiki/Bytecode)
-and then runs on the [BEAM Erlang Virtual Machine](http://erlangcentral.org/videos/euc-2014-robert-virding-hitchhikers-tour-of-the-beam/).
+Elixir actually compiles down to [bytecode](https://en.wikipedia.org/wiki/Bytecode) and then runs on the [BEAM Erlang Virtual Machine](http://erlangcentral.org/videos/euc-2014-robert-virding-hitchhikers-tour-of-the-beam/).
 
-There is no "conversion cost" for calling Erlang, meaning you can run Erlang
-code right next to Elixir code.
+There is no "conversion cost" for calling Erlang, meaning you can run Erlang code right next to Elixir code.
 
-Being a functional language, everything in Elixir is an expression. Elixir has
-"First Class Documentation" meaning comments  can be attached to a function,
-making it easier to retrieve. Regular expressions are also given first class
-treatment, removing awkward escaping within strings.
+Being a functional language, everything in Elixir is an expression. Elixir has "First Class Documentation" meaning comments  can be attached to a function, making it easier to retrieve. Regular expressions are also given first class treatment, removing awkward escaping within strings.
 
-Elixir's asynchronous communication implementation allows the code to be
-lightweight, yet incorporate high-volume concurrency. Programmers use Elixir to
-handle thousands of requests and responses *concurrently* on a single server
-node. It has been used successfully for microservices that need to consume and
-serve a multitude of APIs rapidly.
+Elixir's asynchronous communication implementation allows the code to be lightweight, yet incorporate high-volume concurrency. Programmers use Elixir to handle thousands of requests and responses *concurrently* on a single server node. It has been used successfully for microservices that need to consume and serve a multitude of APIs rapidly.
 
-The [Phoenix framework](http://www.phoenixframework.org/) helps structure Elixir
-applications for the web.
+The [Phoenix framework](http://www.phoenixframework.org/) helps structure Elixir applications for the web.


### PR DESCRIPTION
Hello. I'm trying to get all of the ABOUT.md files reformatted to fit with the new look and feel of nextercism. This means removing things like line-breaks and markdown that we're not supporting.

As an example from the C++ Track, we've gone from:
<img width="1167" alt="screen shot 2017-08-06 at 15 16 34" src="https://user-images.githubusercontent.com/286476/29004482-b990fad8-7abf-11e7-98c5-cc3f2f1ee3e8.png">
to:
<img width="1161" alt="screen shot 2017-08-06 at 15 15 43" src="https://user-images.githubusercontent.com/286476/29004485-c26acf6c-7abf-11e7-90f1-575b2edd5316.png">

As a general note, after these formatting changes get merged, we're hoping that track
maintainers will take some time to review the contents of the ABOUT.md file and edit
it to make it a bit shorter and more casual. We're looking for less wikipedia and more
of an enthusiastic and friendly pitch that you might make to a friend over a drink for
why they should try the language.

For some examples of tracks where I think they've done this well take a look at the
Go and R tracks:
- https://github.com/exercism/go/blob/master/docs/ABOUT.md
- https://github.com/exercism/r/blob/3f05539d19d7e20d2a9d5cd2cecd3dc56f4f23e8/docs/ABOUT.md

See https://github.com/exercism/meta/issues/84 for more details.

Thank you!