### PR TITLE
Add pending tests to match phone_number doc strings

### DIFF
--- a/exercises/phone-number/phone_number_test.exs
+++ b/exercises/phone-number/phone_number_test.exs
@@ -78,12 +78,32 @@ defmodule PhoneTest do
   end
 
   @tag :pending
+  test "invalid area code" do
+    assert Phone.area_code("(100) 555-1234") == "000"
+  end
+
+  @tag :pending
+  test "no area code" do
+    assert Phone.area_code("867.5309") == "000"
+  end
+
+  @tag :pending
   test "pretty print" do
     assert Phone.pretty("2125550100") == "(212) 555-0100"
   end
 
   @tag :pending
   test "pretty print with full US phone number" do
-    assert Phone.pretty("12125550100") == "(212) 555-0100"
+    assert Phone.pretty("+1 (303) 555-1212") == "(303) 555-1212"
+  end
+
+  @tag :pending
+  test "pretty print invalid US phone number" do
+    assert Phone.pretty("212-155-0100") == "(000) 000-0000"
+  end
+
+  @tag :pending
+  test "pretty print invalid, short US phone number" do
+    assert Phone.pretty("867.5309") == "(000) 000-0000"
   end
 end


### PR DESCRIPTION
#### Context

While completing http://exercism.io/tracks/elixir/exercises/phone-number , I was
surprised to see all the tests pass when I'd not written code to satisfy the doc
strings at
https://github.com/exercism/elixir/blob/500bf38d7113c33d0051a73d1732b51bc829865d/exercises/phone-number/phone_number.exs#L43-L47

#### Change

 - Add pending tests to match phone_number doc strings

#### Confirmation

```
% mix test    
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /Users/paj/src/elixir/deps/poison/mix.exs:11

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /Users/paj/src/elixir/deps/poison/mix.exs:12

==> poison
Compiling 4 files (.ex)
Generated poison app
==> tests
Generated tests app
Including tags: [:pending]

.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 15.5 seconds
1085 tests, 0 failures

Randomized with seed 210366
```