### PR TITLE
Add pending test case for order of reduction

### DIFF
--- a/exercises/list-ops/list_ops_test.exs
+++ b/exercises/list-ops/list_ops_test.exs
@@ -85,6 +85,11 @@ defmodule ListOpsTest do
   end
 
   @tag :pending
+  test "order of reduction is important" do
+    assert L.reduce(~w(C B A), ". Done!", &(&1 <> &2)) == "ABC. Done!"
+  end
+
+  @tag :pending
   test "reduce of huge list" do
     assert L.reduce(Enum.to_list(1..1_000_000), 0, &(&1+&2)) ==
       Enum.reduce(1..1_000_000, 0, &(&1+&2))


### PR DESCRIPTION
#### Context

@aliaksandr-martsinovich commented on [one of my submissions](http://exercism.io/submissions/49ec774315704a1baf7e2d67151df4e0) that `reduce` is supposed to start with the head of a list.

My implementation started at the tail and all the tests passed.

#### Change

 - Add a test that filed for that submission but passes [when we start with the head](http://exercism.io/submissions/17b3ffeca3874c048618ee4a60f415e8)