### PR TITLE
Pig Lating exercise: Add tests for the case of words beginning with multiple consonants

### DIFF
--- a/exercises/pig-latin/example.exs
+++ b/exercises/pig-latin/example.exs
@@ -17,28 +17,27 @@ defmodule PigLatin do
   def translate(phrase) do
     phrase
     |> String.split(" ")
-    |> Enum.map_join(" ", &to_pig_latin/1)
+    |> Enum.map(&translate_word/1)
+    |> Enum.join(" ")
   end
 
-  @consonant_sounds ["ch", "sch", "qu", "squ", "thr", "th"]
-  @vowel_sounds ["xr", "yt"]
-  @consonants "bcdfghjklmnpqrstvwxyz" |> String.graphemes
-  @vowels "aeiou" |> String.graphemes
-
-  for sound <- @consonant_sounds do
-    defp to_pig_latin(unquote(sound) <> rest), do: "#{rest}#{unquote(sound)}ay"
+  defp translate_word(word) do
+    word
+    |> consonant_prefix_and_rest
+    |> case do
+      ["", _] -> word <> "ay"
+      [consonant_prefix, rest] -> rest <> consonant_prefix <> "ay"
+      _ -> word
+    end
   end
 
-  for sound <- @vowel_sounds do
-    defp to_pig_latin(unquote(sound) <> rest), do: "#{unquote(sound)}#{rest}ay"
-  end
-
-  for sound <- @consonants do
-    defp to_pig_latin(unquote(sound) <> rest), do: "#{rest}#{unquote(sound)}ay"
-  end
-
-  for sound <- @vowels do
-    defp to_pig_latin(unquote(sound) <> rest), do: "#{unquote(sound)}#{rest}ay"
+  defp consonant_prefix_and_rest(word) do
+    if Regex.match?(~r/^yt|xr/, word) do
+      ["", word]
+    else
+      ~r/^(s?qu|(?:[^aeiou]*))?([aeiou].*)$/
+      |> Regex.run(word, capture: :all_but_first)
+    end
   end
 end
 

--- a/exercises/pig-latin/pig_latin_test.exs
+++ b/exercises/pig-latin/pig_latin_test.exs
@@ -40,7 +40,7 @@ defmodule PigLatinTest do
     end
   end
 
-  describe "first letter and ay are moved to the end of words that start with consonants" do
+  describe "first consonant letters and ay are moved to the end of words that start with consonants" do
     @tag :pending
     test "word beginning with p" do
       assert PigLatin.translate("pig") == "igpay"
@@ -64,6 +64,21 @@ defmodule PigLatinTest do
     @tag :pending
     test "word beginning with q without a following u" do
       assert PigLatin.translate("qat") == "atqay"
+    end
+
+    @tag :pending
+    test "word beginning with two consonants" do
+      assert PigLatin.translate("pleasure") == "easureplay"
+    end
+
+    @tag :pending
+    test "word beginning with three consonants" do
+      assert PigLatin.translate("stringify") == "ingifystray"
+    end
+
+    @tag :pending
+    test "word beginning with a serie of consonants : aliens speak Pig Latin too" do
+      assert PigLatin.translate("zkrrkrkrkrzzzkewk") == "ewkzkrrkrkrkrzzzkay"
     end
   end
 


### PR DESCRIPTION
To match the rule given in wikipedia: ""For words that begin with consonant sounds, all letters before the initial vowel are placed at the end of the word sequence."

Isssue #359