### PR TITLE
Capitalize 'world' in hello_world implementation @doc

### DIFF
--- a/exercises/hello-world/hello_world.exs
+++ b/exercises/hello-world/hello_world.exs
@@ -1,6 +1,6 @@
 defmodule HelloWorld do
   @doc """
-  Simply returns "Hello, world!"
+  Simply returns "Hello, World!"
   """
   @spec hello :: String.t
   def hello do


### PR DESCRIPTION
This is about a minor as it gets but the capitalization wasn't totally consistent before.