### PR TITLE
Fix invalid uuid

### DIFF
--- a/config.json
+++ b/config.json
@@ -803,7 +803,7 @@
         "transforming"
       ],
       "unlocked_by": null,
-      "uuid": "b0216103-000b-8480-556d-816ddca02c40810d1e9"
+      "uuid": "cf28d2b2-763e-404b-90b0-637263d3bba6"
     }
   ],
   "foregone": [


### PR DESCRIPTION
Configlet previously could generate invalid uuids. Here, `spiral-matrix` seems to have an invalid uuid.