### PR TITLE
Pig Latin: Added tests and improved test descriptions

### DIFF
--- a/exercises/pig-latin/example.exs
+++ b/exercises/pig-latin/example.exs
@@ -32,7 +32,7 @@ defmodule PigLatin do
   end
 
   defp consonant_prefix_and_rest(word) do
-    if Regex.match?(~r/^yt|xr/, word) do
+    if Regex.match?(~r/^[yx][bcdfghjklmnpqrstvwxy]+/, word) do
       ["", word]
     else
       ~r/^(s?qu|(?:[^aeiou]*))?([aeiou].*)$/
@@ -40,4 +40,3 @@ defmodule PigLatin do
     end
   end
 end
-

--- a/exercises/pig-latin/pig_latin_test.exs
+++ b/exercises/pig-latin/pig_latin_test.exs
@@ -63,7 +63,7 @@ defmodule PigLatinTest do
 
     @tag :pending
     test "word beginning with q without a following u" do
-      assert PigLatin.translate("qatar") == "atarqay"
+      assert PigLatin.translate("qat") == "atqay"
     end
 
     @tag :pending

--- a/exercises/pig-latin/pig_latin_test.exs
+++ b/exercises/pig-latin/pig_latin_test.exs
@@ -63,7 +63,7 @@ defmodule PigLatinTest do
 
     @tag :pending
     test "word beginning with q without a following u" do
-      assert PigLatin.translate("qat") == "atqay"
+      assert PigLatin.translate("qatar") == "atarqay"
     end
 
     @tag :pending
@@ -82,7 +82,7 @@ defmodule PigLatinTest do
     end
   end
 
-  describe "some letter clusters are treated like a single consonant" do
+  describe "consecutive consonants are treated like a single consonant" do
     @tag :pending
     test "word beginning with ch" do
       assert PigLatin.translate("chair") == "airchay"
@@ -114,15 +114,25 @@ defmodule PigLatinTest do
     end
   end
 
-  describe "some letter clusters are treated like a single vowel" do
+  describe "'x' and 'y', when followed by a consonant, are treated like a vowel" do
     @tag :pending
-    test "word beginning with yt" do
+    test "word beginning with y, followed by a consonant" do
       assert PigLatin.translate("yttria") == "yttriaay"
+    end
+
+    @tag :pending
+    test "word beginning with y, followed by another consonant" do
+      assert PigLatin.translate("yddria") == "yddriaay"
     end
 
     @tag :pending
     test "word beginning with xr" do
       assert PigLatin.translate("xray") == "xrayay"
+    end
+
+    @tag :pending
+    test "word beginning with xb" do
+      assert PigLatin.translate("xbot") == "xbotay"
     end
   end
 
@@ -133,4 +143,3 @@ defmodule PigLatinTest do
     end
   end
 end
-


### PR DESCRIPTION
Some test descriptions weren't doing a good job of communicating the rules of Pig Latin, leading to implementations that gamed the tests. For example, implementations were looking specifically for a leading 'xr' word as a vowel word (such as "xray"), but not any other combination of 'x' and a consonant (like "xbox").

Some descriptions are updated to communicate better what the implementation should provide.

A couple tests are added to break these overly-specific implementations.

The following implementation passes the new version of the tests:

http://exercism.io/submissions/2ec927894ece47baa8fe482f9f210a63