### PR TITLE
Create Docker image for users to use via Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM elixir:1.6.4-alpine
+
+# Download and install Exercism CLI
+RUN set -ex; \
+    oldwd=$(pwd); \
+    mkdir -p /tmp/exercism-install; \
+    cd /tmp/exercism-install; \
+    wget https://github.com/exercism/cli/releases/download/v2.4.1/exercism-linux-64bit.tgz; \
+    tar -xzvf exercism-linux-64bit.tgz; \
+    mv exercism /usr/local/bin/exercism; \
+    cd $oldwd; \
+    rm -rfv /tmp/exercism-install; \
+    exercism fetch elixir; \
+    export PATH=/usr/local/bin:$PATH; \
+    echo 'export PATH=/usr/local/bin:$PATH' >> ~/.bashrc
+
+# Create working directory
+WORKDIR /root/exercism/elixir
+VOLUME /root/exercism/elixir
+
+CMD ["sh"]


### PR DESCRIPTION
We want to improve the user experience for all Exercism users. We want to make it as easy as possible to get up and running solving exercises without the frustration. Windows users usually run into some sort of installation problems too.

One way we can achieve this is by setting up environments ourselves for them to use via Docker! So in the Elixir track, we can provide participants a Docker image to use. Sometimes users also don't want to install too many packages in their machine to avoid cluttering.

Users would just need to type in something like:

```bash
$ docker run -it -v $(pwd):/root/exercism/elixir exercism-elixir
```

And get started asap!

This is in response to #397.

With the help of @NobbZ, the Dockerfile can be defined as such in an official registry on DockerHub for Exercism:

