### PR TITLE
fix nucleotide-count solution docs

### DIFF
--- a/exercises/nucleotide-count/nucleotide_count.exs
+++ b/exercises/nucleotide-count/nucleotide_count.exs
@@ -2,7 +2,7 @@ defmodule NucleotideCount do
   @nucleotides [?A, ?C, ?G, ?T]
 
   @doc """
-  Counts individual nucleotides in a NucleotideCount strand.
+  Counts individual nucleotides in a DNA strand.
 
   ## Examples
 


### PR DESCRIPTION
seems to have accidentally been changed in a global search and replace of `DNA` => `NucleotideCount`