### PR TITLE
Remove malware links

### DIFF
--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -55,9 +55,5 @@ Or, you can enable all the tests by commenting out the
 For more detailed information about the Elixir track, please
 see the [help page](http://exercism.io/languages/elixir).
 
-## Source
-
-Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists. [http://www.brpreiss.com/books/opus8/html/page96.html#SECTION004300000000000000000](http://www.brpreiss.com/books/opus8/html/page96.html#SECTION004300000000000000000)
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
Unfortunately, brpreiss dot com has been taken over by a malware pushing site. Removing the links here.