### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,8 +10,8 @@
       "slug": "hello-world",
       "uuid": "cc96d65d-1c79-40d0-8fd2-9a6665a43b01",
       "core": true,
-      "unlocked_by": null,
       "auto_approve": true,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings"
@@ -88,7 +88,6 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "mathematics",
         "pattern_matching"
       ]
     },
@@ -144,7 +143,9 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
-      "topics": ["string_processing"]
+      "topics": [
+        "string_processing"
+      ]
     },
     {
       "slug": "series",
@@ -162,7 +163,9 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
-      "topics": ["mathematics", "conditionals"]
+      "topics": [
+        "conditionals"
+      ]
     },
     {
       "slug": "run-length-encoding",
@@ -170,7 +173,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
-      "topics": ["algorithms", "strings"]
+      "topics": [
+        "algorithms",
+        "strings"
+      ]
     },
     {
       "slug": "sublist",
@@ -178,7 +184,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
-      "topics": ["lists", "enumeration"]
+      "topics": [
+        "enumeration",
+        "lists"
+      ]
     },
     {
       "slug": "scrabble-score",
@@ -186,7 +195,9 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
-      "topics": ["reduce"]
+      "topics": [
+        "reduce"
+      ]
     },
     {
       "slug": "sum-of-multiples",
@@ -194,7 +205,11 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
-      "topics": ["algorithms", "reduce"]
+      "topics": [
+        "algorithms",
+        "math",
+        "reduce"
+      ]
     },
     {
       "slug": "pangram",
@@ -223,7 +238,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
-      "topics": ["filter", "enumeration"]
+      "topics": [
+        "enumeration",
+        "filter"
+      ]
     },
     {
       "slug": "matrix",
@@ -242,7 +260,11 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["algorithms", "reduce", "enumeration"]
+      "topics": [
+        "algorithms",
+        "enumeration",
+        "reduce"
+      ]
     },
     {
       "slug": "rna-transcription",
@@ -250,7 +272,9 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 2,
-      "topics": ["strings"]
+      "topics": [
+        "strings"
+      ]
     },
     {
       "slug": "phone-number",
@@ -258,7 +282,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["string_processing", "pattern_matching"]
+      "topics": [
+        "pattern_matching",
+        "string_processing"
+      ]
     },
     {
       "slug": "nth-prime",
@@ -266,7 +293,11 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
-      "topics": ["algorithms", "mathematics", "recursion"]
+      "topics": [
+        "algorithms",
+        "math",
+        "recursion"
+      ]
     },
     {
       "slug": "roman-numerals",
@@ -274,7 +305,10 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 2,
-      "topics": ["algorithms", "pattern_matching"]
+      "topics": [
+        "algorithms",
+        "pattern_matching"
+      ]
     },
     {
       "slug": "all-your-base",
@@ -282,7 +316,11 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
-      "topics": ["translation", "numbers"]
+      "topics": [
+        "math",
+        "numbers",
+        "translation"
+      ]
     },
     {
       "slug": "hamming",
@@ -290,7 +328,9 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
-      "topics": ["string_processing"]
+      "topics": [
+        "string_processing"
+      ]
     },
     {
       "slug": "triangle",
@@ -298,7 +338,9 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
-      "topics": ["mathematics", "algorithms"]
+      "topics": [
+        "algorithms"
+      ]
     },
     {
       "slug": "beer-song",
@@ -306,7 +348,10 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["recursion", "pattern_matching"]
+      "topics": [
+        "pattern_matching",
+        "recursion"
+      ]
     },
     {
       "slug": "isogram",
@@ -314,7 +359,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["reduce", "algorithms"]
+      "topics": [
+        "algorithms",
+        "reduce"
+      ]
     },
     {
       "slug": "grade-school",
@@ -322,7 +370,9 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["maps"]
+      "topics": [
+        "maps"
+      ]
     },
     {
       "slug": "tournament",
@@ -342,7 +392,11 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 4,
-      "topics": ["lists", "enumeration", "recursion"]
+      "topics": [
+        "enumeration",
+        "lists",
+        "recursion"
+      ]
     },
     {
       "slug": "flatten-array",
@@ -350,7 +404,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["lists", "recursion"]
+      "topics": [
+        "lists",
+        "recursion"
+      ]
     },
     {
       "slug": "leap",
@@ -358,7 +415,9 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["mathematics", "algorithms"]
+      "topics": [
+        "algorithms"
+      ]
     },
     {
       "slug": "kindergarten-garden",
@@ -366,7 +425,9 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["string_processing"]
+      "topics": [
+        "string_processing"
+      ]
     },
     {
       "slug": "etl",
@@ -374,7 +435,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
-      "topics": ["enumeration", "string_processing"]
+      "topics": [
+        "enumeration",
+        "string_processing"
+      ]
     },
     {
       "slug": "meetup",
@@ -382,7 +446,11 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
-      "topics": ["time", "calendar", "pattern_matching"]
+      "topics": [
+        "calendar",
+        "pattern_matching",
+        "time"
+      ]
     },
     {
       "slug": "grains",
@@ -390,7 +458,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["recursion", "reduce"]
+      "topics": [
+        "recursion",
+        "reduce"
+      ]
     },
     {
       "slug": "change",
@@ -398,7 +469,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["enumeration", "reduce"]
+      "topics": [
+        "enumeration",
+        "reduce"
+      ]
     },
     {
       "slug": "parallel-letter-frequency",
@@ -406,7 +480,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
-      "topics": ["concurrency", "otp"]
+      "topics": [
+        "concurrency",
+        "otp"
+      ]
     },
     {
       "slug": "binary",
@@ -414,7 +491,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["binary_operators"]
+      "topics": [
+        "binary_operators",
+        "math"
+      ]
     },
     {
       "slug": "scale-generator",
@@ -433,7 +513,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 5,
-      "topics": ["string_processing", "enumeration"]
+      "topics": [
+        "enumeration",
+        "string_processing"
+      ]
     },
     {
       "slug": "markdown",
@@ -441,7 +524,9 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 5,
-      "topics": ["refactoring"]
+      "topics": [
+        "refactoring"
+      ]
     },
     {
       "slug": "gigasecond",
@@ -449,7 +534,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["calendar", "time"]
+      "topics": [
+        "calendar",
+        "time"
+      ]
     },
     {
       "slug": "queen-attack",
@@ -457,7 +545,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 7,
-      "topics": ["mathematics", "algorithms", "structs"]
+      "topics": [
+        "algorithms",
+        "structs"
+      ]
     },
     {
       "slug": "pascals-triangle",
@@ -465,7 +556,11 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["enumeration", "mathematics", "algorithms"]
+      "topics": [
+        "algorithms",
+        "enumeration",
+        "math"
+      ]
     },
     {
       "slug": "saddle-points",
@@ -473,7 +568,11 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 5,
-      "topics": ["matricies", "string_processing", "enumeration"]
+      "topics": [
+        "enumeration",
+        "matricies",
+        "string_processing"
+      ]
     },
     {
       "slug": "hexadecimal",
@@ -481,7 +580,11 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["numbers", "string_processing"]
+      "topics": [
+        "math",
+        "numbers",
+        "string_processing"
+      ]
     },
     {
       "slug": "diamond",
@@ -489,7 +592,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 5,
-      "topics": ["algorithms", "enumeration"]
+      "topics": [
+        "algorithms",
+        "enumeration"
+      ]
     },
     {
       "slug": "binary-search",
@@ -497,7 +603,10 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["algorithms", "recursion"]
+      "topics": [
+        "algorithms",
+        "recursion"
+      ]
     },
     {
       "slug": "binary-search-tree",
@@ -516,7 +625,11 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["recursion", "mathematics", "pattern_matching"]
+      "topics": [
+        "math",
+        "pattern_matching",
+        "recursion"
+      ]
     },
     {
       "slug": "perfect-numbers",
@@ -524,7 +637,11 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["pattern_matching", "enumeration"]
+      "topics": [
+        "enumeration",
+        "math",
+        "pattern_matching"
+      ]
     },
     {
       "slug": "diffie-hellman",
@@ -533,7 +650,7 @@
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -542,7 +659,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 5,
-      "topics": ["enumeration"]
+      "topics": [
+        "enumeration",
+        "math"
+      ]
     },
     {
       "slug": "wordy",
@@ -550,7 +670,9 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 6,
-      "topics": ["parsers", "mathematics"]
+      "topics": [
+        "parsers"
+      ]
     },
     {
       "slug": "robot-simulator",
@@ -558,7 +680,11 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 6,
-      "topics": ["structs", "pattern_matching", "otp"]
+      "topics": [
+        "otp",
+        "pattern_matching",
+        "structs"
+      ]
     },
     {
       "slug": "atbash-cipher",
@@ -566,7 +692,9 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
-      "topics": ["encryption"]
+      "topics": [
+        "encryption"
+      ]
     },
     {
       "slug": "simple-cipher",
@@ -585,7 +713,9 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 7,
-      "topics": ["otp"]
+      "topics": [
+        "otp"
+      ]
     },
     {
       "slug": "largest-series-product",
@@ -593,7 +723,11 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
-      "topics": ["enumeration", "recursion"]
+      "topics": [
+        "enumeration",
+        "math",
+        "recursion"
+      ]
     },
     {
       "slug": "crypto-square",
@@ -601,7 +735,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
-      "topics": ["encryption", "algorithms"]
+      "topics": [
+        "algorithms",
+        "encryption"
+      ]
     },
     {
       "slug": "pythagorean-triplet",
@@ -609,7 +746,11 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 5,
-      "topics": ["reduce", "algorithms"]
+      "topics": [
+        "algorithms",
+        "math",
+        "reduce"
+      ]
     },
     {
       "slug": "allergies",
@@ -617,7 +758,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
-      "topics": ["binary_operators", "enumeration"]
+      "topics": [
+        "binary_operators",
+        "enumeration"
+      ]
     },
     {
       "slug": "palindrome-products",
@@ -625,7 +769,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 5,
-      "topics": ["reduce", "mathematics"]
+      "topics": [
+        "math",
+        "reduce"
+      ]
     },
     {
       "slug": "rail-fence-cipher",
@@ -633,7 +780,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 6,
-      "topics": ["encryption", "string_processing"]
+      "topics": [
+        "encryption",
+        "string_processing"
+      ]
     },
     {
       "slug": "zipper",
@@ -641,7 +791,12 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 8,
-      "topics": ["structs", "recursion", "trees", "algorithms"]
+      "topics": [
+        "algorithms",
+        "recursion",
+        "structs",
+        "trees"
+      ]
     },
     {
       "slug": "minesweeper",
@@ -649,7 +804,11 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 7,
-      "topics": ["enumeration", "reduce", "algorithms"]
+      "topics": [
+        "algorithms",
+        "enumeration",
+        "reduce"
+      ]
     },
     {
       "slug": "connect",
@@ -657,7 +816,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 7,
-      "topics": ["string_processing", "reduce"]
+      "topics": [
+        "reduce",
+        "string_processing"
+      ]
     },
     {
       "slug": "difference-of-squares",
@@ -665,7 +827,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 4,
-      "topics": ["mathematics", "reduce"]
+      "topics": [
+        "math",
+        "reduce"
+      ]
     },
     {
       "slug": "poker",
@@ -683,7 +848,11 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 8,
-      "topics": ["structs", "algorithms", "pattern_matching"]
+      "topics": [
+        "algorithms",
+        "pattern_matching",
+        "structs"
+      ]
     },
     {
       "slug": "dot-dsl",
@@ -691,7 +860,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 8,
-      "topics": ["structs", "graphs"]
+      "topics": [
+        "graphs",
+        "structs"
+      ]
     },
     {
       "slug": "custom-set",
@@ -699,7 +871,10 @@
       "core": false,
       "unlocked_by": null,
       "difficulty": 5,
-      "topics": ["collections", "enumeration"]
+      "topics": [
+        "collections",
+        "enumeration"
+      ]
     },
     {
       "slug": "forth",
@@ -707,7 +882,9 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 10,
-      "topics": ["parsers"]
+      "topics": [
+        "parsers"
+      ]
     },
     {
       "slug": "clock",
@@ -762,6 +939,7 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
+        "math",
         "recursion"
       ]
     },
@@ -841,7 +1019,7 @@
       "difficulty": 2,
       "topics": [
         "algorithms",
-        "mathematics"
+        "math"
       ]
     }
   ]


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110