### PR TITLE
Fix Clock docs

### DIFF
--- a/exercises/clock/clock.exs
+++ b/exercises/clock/clock.exs
@@ -2,7 +2,7 @@ defmodule Clock do
   defstruct hour: 0, minute: 0
 
   @doc """
-  Returns a string representation of a clock:
+  Returns a clock that can be represented as a string:
 
       iex> Clock.new(8, 9) |> to_string
       "08:09"
@@ -14,7 +14,7 @@ defmodule Clock do
   @doc """
   Adds two clock times:
 
-      iex> Clock.add(10, 0) |> Clock.add(3) |> to_string
+      iex> Clock.new(10, 0) |> Clock.add(3) |> to_string
       "10:03"
   """
   @spec add(Clock, integer) :: Clock


### PR DESCRIPTION
The description of `Clock.new` was confusing because it suggested that `Clock.new` itself is supposed to return a string.

The doctest for `Clock.add` was just incorrect because it claimed `Clock.add` takes an integer as the first argument.