### PR TITLE
Check hit count for binary search to assert that search is binary

### DIFF
--- a/exercises/binary-search/binary_search_test.exs
+++ b/exercises/binary-search/binary_search_test.exs
@@ -8,44 +8,81 @@ ExUnit.configure(exclude: :pending, trace: true)
 defmodule BinarySearchTest do
   use ExUnit.Case
 
+  def box_tuple(tuple) do
+    tuple
+    |> Tuple.to_list()
+    |> Enum.reduce({}, fn (elem, acc) ->
+      Tuple.append(acc, fn ->
+        Process.put(:search_hit, Process.get(:search_hit, 0) + 1)
+        elem
+      end)
+    end)
+  end
+
+  def assert_search_is_binary(expected_hit_number) do
+    real_number = Process.get(:search_hit, 0)
+    Process.put(:search_hit, 0)
+
+    case real_number == expected_hit_number do
+      true ->
+        real_number
+
+      false ->
+        raise ExUnit.AssertionError,
+          message:
+            "Your search is not binary: expected #{expected_hit_number} of compares, got #{
+              real_number
+            }"
+    end
+  end
+
   test "returns :not_found on empty tuple" do
-    assert BinarySearch.search({}, 2) == :not_found
+    assert BinarySearch.search(box_tuple({}), 2) == :not_found
+    assert_search_is_binary(0)
   end
 
   @tag :pending
   test "returns :not_found when key is not in the tuple" do
-    assert BinarySearch.search({2, 4, 6}, 3) == :not_found
+    assert BinarySearch.search(box_tuple({2, 4, 6}), 3) == :not_found
+    assert_search_is_binary(2)
   end
 
   @tag :pending
   test "returns :not_found when key is too high" do
-    assert BinarySearch.search({2, 4, 6}, 9) == :not_found
+    assert BinarySearch.search(box_tuple({2, 4, 6}), 9) == :not_found
+    assert_search_is_binary(2)
   end
 
   @tag :pending
   test "finds key in a tuple with a single item" do
-    assert BinarySearch.search({3}, 3) == {:ok, 0}
+    assert BinarySearch.search(box_tuple({3}), 3) == {:ok, 0}
+    assert_search_is_binary(1)
   end
 
   @tag :pending
   test "finds key when it is the first element in tuple" do
-    assert BinarySearch.search({1, 2, 4, 5, 6}, 1) == {:ok, 0}
+    assert BinarySearch.search(box_tuple({1, 2, 4, 5, 6}), 1) == {:ok, 0}
+    assert_search_is_binary(2)
   end
 
   @tag :pending
   test "finds key when it is in the middle of the tuple" do
-    assert BinarySearch.search({1, 2, 4, 5, 6}, 4) == {:ok, 2}
+    assert BinarySearch.search(box_tuple({1, 2, 4, 5, 6}), 4) == {:ok, 2}
+    assert_search_is_binary(1)
   end
 
   @tag :pending
   test "finds key when it is the last element in tuple" do
-    assert BinarySearch.search({1, 2, 4, 5, 6}, 6) == {:ok, 4}
+    assert BinarySearch.search(box_tuple({1, 2, 4, 5, 6}), 6) == {:ok, 4}
+    assert_search_is_binary(3)
   end
 
   @tag :pending
   test "finds key in a tuple with an even number of elements" do
-    tuple = {1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377}
+    tuple = box_tuple({1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377})
     assert BinarySearch.search(tuple, 21) == {:ok, 5}
+    assert_search_is_binary(1)
     assert BinarySearch.search(tuple, 34) == {:ok, 6}
+    assert_search_is_binary(3)
   end
 end

--- a/exercises/binary-search/example.exs
+++ b/exercises/binary-search/example.exs
@@ -28,7 +28,7 @@ defmodule BinarySearch do
 
   defp do_search(numbers, key, low, high) do
     middle = div(low + high, 2)
-    middle_value = elem(numbers, middle)
+    middle_value = elem(numbers, middle).()
 
     cond do
       key < middle_value -> do_search(numbers, key, low, middle - 1)


### PR DESCRIPTION
While mentoring the task, I found out that some student don't understand what's the difference between "search" and "binary search"

So I decided to modify the task and the test, in order to check "algorithmic complexity" of this search.

While this is a first approach - I hope that this can work.

I probably need some suggestions for the Api.

And also need help with task description update, in order to point out, that now it's not the **tuple with ints**, but **a tuple with closures, that returns ints**. 