### PR TITLE
Remove IO.inspect from dot-dsl tests

### DIFF
--- a/exercises/dot-dsl/dot_dsl_test.exs
+++ b/exercises/dot-dsl/dot_dsl_test.exs
@@ -178,7 +178,6 @@ defmodule DotTest do
           a([color: green][[label: "Alpha!"]])
         end
       )
-      |> IO.inspect()
     end
   end
 


### PR DESCRIPTION
It was added there when the exercise was first added. I believe it's not meant to be there because otherwise it would be there for all the other test cases.