### PR TITLE
Remove invalid spec from queen-attack

### DIFF
--- a/exercises/queen-attack/queen_attack.exs
+++ b/exercises/queen-attack/queen_attack.exs
@@ -5,13 +5,12 @@ defmodule Queens do
   @doc """
   Creates a new set of Queens
   """
-  @spec new() :: Queens.t()
   @spec new({integer, integer}, {integer, integer}) :: Queens.t()
   def new(white, black) do
   end
 
   @doc """
-  Gives a string reprentation of the board with
+  Gives a string representation of the board with
   white and black queen locations shown
   """
   @spec to_string(Queens.t()) :: String.t()

--- a/exercises/queen-attack/queen_attack.exs
+++ b/exercises/queen-attack/queen_attack.exs
@@ -5,8 +5,9 @@ defmodule Queens do
   @doc """
   Creates a new set of Queens
   """
+  @spec new() :: Queens.t()
   @spec new({integer, integer}, {integer, integer}) :: Queens.t()
-  def new(white, black) do
+  def new(white \\ nil, black \\ nil) do
   end
 
   @doc """


### PR DESCRIPTION
When I wanted to solve this exercise, I noticed that the provided empty solution file doesn't even compile:
```
** (CompileError) queen_attack.exs:8: spec for undefined function new/0
```

This PR fixes that problem, and additionally removes one typo.