### PR TITLE
Removed OTP from Robot

### DIFF
--- a/config.json
+++ b/config.json
@@ -681,7 +681,6 @@
       "unlocked_by": null,
       "difficulty": 6,
       "topics": [
-        "otp",
         "pattern_matching",
         "structs"
       ]


### PR DESCRIPTION
OTP is not useful for the Robot Simulator.