### PR TITLE
fix bowling typespecs

### DIFF
--- a/exercises/bowling/bowling.exs
+++ b/exercises/bowling/bowling.exs
@@ -1,29 +1,30 @@
 defmodule Bowling do
+  @type t :: any()
+
   @doc """
     Creates a new game of bowling that can be used to store the results of
     the game
   """
-
-  @spec start() :: any
+  @spec start() :: t()
   def start do
   end
 
   @doc """
     Records the number of pins knocked down on a single roll. Returns `any`
     unless there is something wrong with the given number of pins, in which
-    case it returns a helpful message.
+    case it returns a helpful error tuple.
   """
 
-  @spec roll(any, integer) :: any | String.t()
+  @spec roll(t(), integer()) :: t() | {:error, String.t()}
   def roll(game, roll) do
   end
 
   @doc """
     Returns the score of a given game of bowling if the game is complete.
-    If the game isn't complete, it returns a helpful message.
+    If the game isn't complete, it returns a helpful error tuple.
   """
 
-  @spec score(any) :: integer | String.t()
+  @spec score(t()) :: integer() | {:error, String.t()}
   def score(game) do
   end
 end


### PR DESCRIPTION
I'm thinking we should have the non-error returns in an ok tuple as well. It's nicer to pattern match `{:ok, game}`  and `{:ok, score}` than `game when is_game(game)` or `score when is_integer(score)`. But that could be done later, if desirable.