### PR TITLE
clock: Fix instructions for String.Chars protocol

### DIFF
--- a/exercises/clock/clock_test.exs
+++ b/exercises/clock/clock_test.exs
@@ -18,7 +18,7 @@ defmodule ClockTest do
         Can't convert Clock to string.
         Hint: implement the String.Chars protocol for Clock.
         http://elixir-lang.org/getting-started/protocols.html
-        http://elixir-lang.org/docs/stable/elixir/String.Chars.html
+        https://hexdocs.pm/elixir/String.Chars.html
         """)
     end
   end


### PR DESCRIPTION
I know this excercise is probably getting dropped from the main track but the instructions should still be maintained.