### PR TITLE
Fix link for Etudes for Elixir on Learning page

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -7,7 +7,7 @@ started:
 * [Programming Elixir](https://pragprog.com/book/elixir13/programming-elixir-1-3), by Dave Thomas
 * [StackOverflow](http://stackoverflow.com/questions/tagged/elixir)
 * [Introducing Elixir](http://shop.oreilly.com/product/0636920030584.do), by Simon St. Laurent, J. David Eisenberg
-* [Etudes for Elixir](http://chimera.labs.oreilly.com/books/1234000001642), by J. David Eisenberg (exercise companion for Intro to Elixir)
+* [Etudes for Elixir](https://github.com/oreillymedia/etudes-for-elixir), by J. David Eisenberg (exercise companion for Introducing Elixir)
 * [Elixir School](https://elixirschool.com)
 * [Elixir Examples](https://elixir-examples.github.io/)
 * [Exercism's BEAM Gitter channel](https://gitter.im/exercism/xerlang)


### PR DESCRIPTION
This fixes the link for the "Etudes for Elixir" ebook on the Learning page. The old link just redirects to oreilly.com (see similar complaints at https://github.com/oreillymedia/etudes-for-elixir/issues/51). The book is open source and on github, so I changed the link to point to the repo.

I also corrected the description since the book is a companion for "Introducing Elixir", not "Intro to Elixir".