### PR TITLE
Fixed the "-i" flag in the last test case.

### DIFF
--- a/exercises/grep/grep_test.exs
+++ b/exercises/grep/grep_test.exs
@@ -245,7 +245,7 @@ defmodule GrepTest do
 
     @tag :pending
     test "no matches, various flags" do
-      assert Grep.grep("Frodo", ["-n", "-l", "-x", "i"], [
+      assert Grep.grep("Frodo", ["-n", "-l", "-x", "-i"], [
                "iliad.txt",
                "midsummer-night.txt",
                "paradise-lost.txt"


### PR DESCRIPTION
In the original, it is `"i"`, now changed to `"-i"` for consistency.