### PR TITLE
Adds test for very long input

### DIFF
--- a/exercises/rna-transcription/rna_transcription_test.exs
+++ b/exercises/rna-transcription/rna_transcription_test.exs
@@ -32,7 +32,7 @@ defmodule RNATranscriptionTest do
   test "transcribes all dna nucleotides to rna equivalents" do
     assert RNATranscription.to_rna('ACGTGGTCTTAA') == 'UGCACCAGAAUU'
   end
-  
+
   @tag :pending
   test "transcribes very long dna" do
     dna_list = Enum.reduce(1..500000, [],
@@ -41,7 +41,6 @@ defmodule RNATranscriptionTest do
     rna_list = Enum.reduce(1..500000, [],
                          fn x, acc -> if x <= 250000, do: [?U | acc], else: [?G | acc]
                          end)
-    
     assert RNATranscription.to_rna(dna_list) == rna_list
   end
 end

--- a/exercises/rna-transcription/rna_transcription_test.exs
+++ b/exercises/rna-transcription/rna_transcription_test.exs
@@ -29,7 +29,19 @@ defmodule RNATranscriptionTest do
   end
 
   @tag :pending
-  test "it transcribes all dna nucleotides to rna equivalents" do
+  test "transcribes all dna nucleotides to rna equivalents" do
     assert RNATranscription.to_rna('ACGTGGTCTTAA') == 'UGCACCAGAAUU'
+  end
+  
+  @tag :pending
+  test "transcribes very long dna" do
+    dna_list = Enum.reduce(1..500000, [], 
+                         fn x, acc -> if x <= 250000, do: [?A | acc], else: [?C | acc]
+                         end)
+    rna_list = Enum.reduce(1..500000, [],
+                         fn x, acc -> if x <= 250000, do: [?U | acc], else: [?G | acc]
+                         end)
+    
+    assert RNATranscription.to_rna(dna_list) == rna_list
   end
 end

--- a/exercises/rna-transcription/rna_transcription_test.exs
+++ b/exercises/rna-transcription/rna_transcription_test.exs
@@ -35,7 +35,7 @@ defmodule RNATranscriptionTest do
   
   @tag :pending
   test "transcribes very long dna" do
-    dna_list = Enum.reduce(1..500000, [], 
+    dna_list = Enum.reduce(1..500000, [],
                          fn x, acc -> if x <= 250000, do: [?A | acc], else: [?C | acc]
                          end)
     rna_list = Enum.reduce(1..500000, [],


### PR DESCRIPTION
This test builds a charlist of 500,000 codepoints to be tested.  This should not take much time to process, unless the student's algorithm reduces the list via appending/concatenation, in which case it will probably not finish.  Hopefully this test will showcase the poor performance of appending vs prepending.

resolves #481 