### PR TITLE
remove leading newlines in test files and update READMEs

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -9,7 +9,7 @@
 Execute the tests with:
 
 ```bash
-$ elixir {{ .Spec.SnakeCaseName }}_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -30,7 +30,7 @@ Solve this one yourself using other basic tools instead.
 Execute the tests with:
 
 ```bash
-$ elixir accumulate_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -12,7 +12,7 @@ like Portable Network Graphics to its acronym (PNG).
 Execute the tests with:
 
 ```bash
-$ elixir acronym_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -36,7 +36,7 @@ I think you got the idea!
 Execute the tests with:
 
 ```bash
-$ elixir all_your_base_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/all-your-base/test/all_your_base_test.exs
+++ b/exercises/all-your-base/test/all_your_base_test.exs
@@ -1,4 +1,3 @@
-
 defmodule AllYourBaseTest do
   use ExUnit.Case
 

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -34,7 +34,7 @@ score is 257, your program should only report the eggs (1) allergy.
 Execute the tests with:
 
 ```bash
-$ elixir allergies_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/allergies/test/allergies_test.exs
+++ b/exercises/allergies/test/allergies_test.exs
@@ -1,4 +1,3 @@
-
 defmodule AllergiesTest do
   use ExUnit.Case
 

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -36,7 +36,7 @@ Write a function to solve alphametics puzzles.
 Execute the tests with:
 
 ```bash
-$ elixir alphametics_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/alphametics/test/alphametics_test.exs
+++ b/exercises/alphametics/test/alphametics_test.exs
@@ -1,4 +1,3 @@
-
 defmodule AlphameticsTest do
   use ExUnit.Case
 

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -11,7 +11,7 @@ Given `"listen"` and a list of candidates like `"enlists" "google"
 Execute the tests with:
 
 ```bash
-$ elixir anagram_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/anagram/test/anagram_test.exs
+++ b/exercises/anagram/test/anagram_test.exs
@@ -1,4 +1,3 @@
-
 defmodule AnagramTest do
   use ExUnit.Case
 

--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -16,7 +16,7 @@ Write some code to determine whether a number is an Armstrong number.
 Execute the tests with:
 
 ```bash
-$ elixir armstrong_number_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/armstrong-numbers/test/armstrong_number_test.exs
+++ b/exercises/armstrong-numbers/test/armstrong_number_test.exs
@@ -1,4 +1,3 @@
-
 defmodule ArmstrongNumberTest do
   use ExUnit.Case
 

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -33,7 +33,7 @@ things based on word boundaries.
 Execute the tests with:
 
 ```bash
-$ elixir atbash_cipher_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/atbash-cipher/test/atbash_test.exs
+++ b/exercises/atbash-cipher/test/atbash_test.exs
@@ -1,4 +1,3 @@
-
 defmodule AtbashTest do
   use ExUnit.Case
 

--- a/exercises/bank-account/README.md
+++ b/exercises/bank-account/README.md
@@ -31,7 +31,7 @@ Have fun!
 Execute the tests with:
 
 ```bash
-$ elixir bank_account_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/bank-account/test/bank_account_test.exs
+++ b/exercises/bank-account/test/bank_account_test.exs
@@ -1,4 +1,3 @@
-
 defmodule BankAccountTest do
   use ExUnit.Case
 

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -325,7 +325,7 @@ experiment make the code better? Worse? Did you learn anything from it?
 Execute the tests with:
 
 ```bash
-$ elixir beer_song_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/beer-song/test/beer_song_test.exs
+++ b/exercises/beer-song/test/beer_song_test.exs
@@ -1,4 +1,3 @@
-
 defmodule BeerSongTest do
   use ExUnit.Case
 

--- a/exercises/binary-search-tree/README.md
+++ b/exercises/binary-search-tree/README.md
@@ -58,7 +58,7 @@ And if we then added 1, 5, and 7, it would look like this
 Execute the tests with:
 
 ```bash
-$ elixir binary_search_tree_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/binary-search-tree/test/binary_search_tree_test.exs
+++ b/exercises/binary-search-tree/test/binary_search_tree_test.exs
@@ -1,4 +1,3 @@
-
 defmodule BinarySearchTreeTest do
   use ExUnit.Case
 

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -39,7 +39,7 @@ A binary search is a dichotomic divide and conquer search algorithm.
 Execute the tests with:
 
 ```bash
-$ elixir binary_search_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/binary-search/test/binary_search_test.exs
+++ b/exercises/binary-search/test/binary_search_test.exs
@@ -1,4 +1,3 @@
-
 defmodule BinarySearchTest do
   use ExUnit.Case
 

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -35,7 +35,7 @@ So: `101 => 1*2^2 + 0*2^1 + 1*2^0 => 1*4 + 0*2 + 1*1 => 4 + 1 => 5 base 10`.
 Execute the tests with:
 
 ```bash
-$ elixir binary_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/binary/test/binary_test.exs
+++ b/exercises/binary/test/binary_test.exs
@@ -1,4 +1,3 @@
-
 defmodule BinaryTest do
   use ExUnit.Case
 

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -20,7 +20,7 @@ Bob's conversational partner is a purist when it comes to written communication 
 Execute the tests with:
 
 ```bash
-$ elixir bob_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/bob/test/bob_test.exs
+++ b/exercises/bob/test/bob_test.exs
@@ -1,4 +1,3 @@
-
 defmodule BobTest do
   use ExUnit.Case
 

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -65,7 +65,7 @@ support two operations:
 Execute the tests with:
 
 ```bash
-$ elixir bowling_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/bowling/test/bowling_test.exs
+++ b/exercises/bowling/test/bowling_test.exs
@@ -1,4 +1,3 @@
-
 defmodule BowlingTest do
   use ExUnit.Case
 

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -9,7 +9,7 @@ and nested correctly.
 Execute the tests with:
 
 ```bash
-$ elixir bracket_push_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/bracket-push/test/bracket_push_test.exs
+++ b/exercises/bracket-push/test/bracket_push_test.exs
@@ -1,4 +1,3 @@
-
 defmodule BracketPushTest do
   use ExUnit.Case
 

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -21,7 +21,7 @@ that the sum of the coins' value would equal the correct amount of change.
 Execute the tests with:
 
 ```bash
-$ elixir change_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/change/test/change_test.exs
+++ b/exercises/change/test/change_test.exs
@@ -1,4 +1,3 @@
-
 defmodule ChangeTest do
   use ExUnit.Case
 

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -11,7 +11,7 @@ Two clocks that represent the same time should be equal to each other.
 Execute the tests with:
 
 ```bash
-$ elixir clock_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/clock/test/clock_test.exs
+++ b/exercises/clock/test/clock_test.exs
@@ -1,4 +1,3 @@
-
 defmodule ClockTest do
   use ExUnit.Case
 

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -31,7 +31,7 @@ Resulting in 9 steps. So for input n = 12, the return value would be 9.
 Execute the tests with:
 
 ```bash
-$ elixir collatz_conjecture_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/collatz-conjecture/test/collatz_conjecture_test.exs
+++ b/exercises/collatz-conjecture/test/collatz_conjecture_test.exs
@@ -1,4 +1,3 @@
-
 defmodule CollatzConjectureTest do
   use ExUnit.Case
 

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -35,7 +35,7 @@ won since `O` didn't connect top and bottom.
 Execute the tests with:
 
 ```bash
-$ elixir connect_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/connect/test/connect_test.exs
+++ b/exercises/connect/test/connect_test.exs
@@ -1,4 +1,3 @@
-
 defmodule ConnectTest do
   use ExUnit.Case
 

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -77,7 +77,7 @@ cyphertext back in to the original message:
 Execute the tests with:
 
 ```bash
-$ elixir crypto_square_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/crypto-square/test/crypto_square_test.exs
+++ b/exercises/crypto-square/test/crypto_square_test.exs
@@ -1,4 +1,3 @@
-
 defmodule CryptoSquareTest do
   use ExUnit.Case
 

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -12,7 +12,7 @@ unique elements.
 Execute the tests with:
 
 ```bash
-$ elixir custom_set_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/custom-set/test/custom_set_test.exs
+++ b/exercises/custom-set/test/custom_set_test.exs
@@ -1,4 +1,3 @@
-
 defmodule CustomSetTest do
   use ExUnit.Case
 

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -57,7 +57,7 @@ E·······E
 Execute the tests with:
 
 ```bash
-$ elixir diamond_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/diamond/test/diamond_test.exs
+++ b/exercises/diamond/test/diamond_test.exs
@@ -1,4 +1,3 @@
-
 defmodule DiamondTest do
   use ExUnit.Case
 

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -17,7 +17,7 @@ natural numbers is 3025 - 385 = 2640.
 Execute the tests with:
 
 ```bash
-$ elixir difference_of_squares_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/difference-of-squares/test/difference_of_squares_test.exs
+++ b/exercises/difference-of-squares/test/difference_of_squares_test.exs
@@ -1,4 +1,3 @@
-
 defmodule DifferenceOfSquaresTest do
   use ExUnit.Case
 

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -54,7 +54,7 @@ particularly for enormous integers, but you might need :binary to decode it.
 Execute the tests with:
 
 ```bash
-$ elixir diffie_hellman_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/diffie-hellman/test/diffie_hellman_test.exs
+++ b/exercises/diffie-hellman/test/diffie_hellman_test.exs
@@ -1,4 +1,3 @@
-
 defmodule DiffieHellmanTest do
   use ExUnit.Case
 

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -19,7 +19,7 @@ Some test cases may use duplicate stones in a chain solution, assume that multip
 Execute the tests with:
 
 ```bash
-$ elixir dominoes_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/dominoes/test/dominoes_test.exs
+++ b/exercises/dominoes/test/dominoes_test.exs
@@ -1,4 +1,3 @@
-
 defmodule DominoesTest do
   use ExUnit.Case
 

--- a/exercises/dot-dsl/README.md
+++ b/exercises/dot-dsl/README.md
@@ -28,7 +28,7 @@ Create a DSL similar to the dot language.
 Execute the tests with:
 
 ```bash
-$ elixir dot_dsl_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/dot-dsl/test/dot_test.exs
+++ b/exercises/dot-dsl/test/dot_test.exs
@@ -1,4 +1,3 @@
-
 defmodule DotTest do
   use ExUnit.Case
   require Dot

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -51,7 +51,7 @@ game while being scored at 4 in the Hawaiian-language version.
 Execute the tests with:
 
 ```bash
-$ elixir etl_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/etl/test/etl_test.exs
+++ b/exercises/etl/test/etl_test.exs
@@ -1,4 +1,3 @@
-
 defmodule TransformTest do
   use ExUnit.Case
 

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -15,7 +15,7 @@ output: [1,2,3,4,5]
 Execute the tests with:
 
 ```bash
-$ elixir flatten_array_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/flatten-array/test/flatten_array_test.exs
+++ b/exercises/flatten-array/test/flatten_array_test.exs
@@ -1,4 +1,3 @@
-
 defmodule FlattenArrayTest do
   use ExUnit.Case
 

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -30,7 +30,7 @@ Words are case-insensitive.
 Execute the tests with:
 
 ```bash
-$ elixir forth_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/forth/test/forth_test.exs
+++ b/exercises/forth/test/forth_test.exs
@@ -1,4 +1,3 @@
-
 defmodule ForthTest do
   use ExUnit.Case
 

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -9,7 +9,7 @@ A gigasecond is 10^9 (1,000,000,000) seconds.
 Execute the tests with:
 
 ```bash
-$ elixir gigasecond_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/gigasecond/test/gigasecond_test.exs
+++ b/exercises/gigasecond/test/gigasecond_test.exs
@@ -1,4 +1,3 @@
-
 defmodule GigasecondTest do
   use ExUnit.Case
 

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -39,7 +39,7 @@ experiment make the code better? Worse? Did you learn anything from it?
 Execute the tests with:
 
 ```bash
-$ elixir grade_school_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/grade-school/test/school_test.exs
+++ b/exercises/grade-school/test/school_test.exs
@@ -1,4 +1,3 @@
-
 defmodule SchoolTest do
   use ExUnit.Case
 

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -31,7 +31,7 @@ experiment make the code better? Worse? Did you learn anything from it?
 Execute the tests with:
 
 ```bash
-$ elixir grains_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/grains/test/grains_test.exs
+++ b/exercises/grains/test/grains_test.exs
@@ -1,4 +1,3 @@
-
 defmodule GrainsTest do
   use ExUnit.Case
 

--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -69,7 +69,7 @@ print the names of files that do not contain the string "hello".
 Execute the tests with:
 
 ```bash
-$ elixir grep_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/grep/test/grep_test.exs
+++ b/exercises/grep/test/grep_test.exs
@@ -1,4 +1,3 @@
-
 defmodule GrepTest do
   use ExUnit.Case
 

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -41,7 +41,7 @@ exception vs returning a special value) may differ between languages.
 Execute the tests with:
 
 ```bash
-$ elixir hamming_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/hamming/test/hamming_test.exs
+++ b/exercises/hamming/test/hamming_test.exs
@@ -1,4 +1,3 @@
-
 defmodule HammingTest do
   use ExUnit.Case
 

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -19,7 +19,7 @@ If everything goes well, you will be ready to fetch your first real exercise.
 Execute the tests with:
 
 ```bash
-$ elixir hello_world_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/hello-world/test/hello_world_test.exs
+++ b/exercises/hello-world/test/hello_world_test.exs
@@ -1,4 +1,3 @@
-
 defmodule HelloWorldTest do
   use ExUnit.Case
 

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -12,7 +12,7 @@ The program should handle invalid hexadecimal strings.
 Execute the tests with:
 
 ```bash
-$ elixir hexadecimal_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/hexadecimal/test/hexadecimal_test.exs
+++ b/exercises/hexadecimal/test/hexadecimal_test.exs
@@ -1,4 +1,3 @@
-
 defmodule HexadecimalTest do
   use ExUnit.Case
 

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -45,7 +45,7 @@ Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (represen
 Execute the tests with:
 
 ```bash
-$ elixir isbn_verifier_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/isbn-verifier/test/isbn_verifier_test.exs
+++ b/exercises/isbn-verifier/test/isbn_verifier_test.exs
@@ -1,4 +1,3 @@
-
 defmodule IsbnVerifierTest do
   use ExUnit.Case
 

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -18,7 +18,7 @@ The word *isograms*, however, is not an isogram, because the s repeats.
 Execute the tests with:
 
 ```bash
-$ elixir isogram_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/isogram/test/isogram_test.exs
+++ b/exercises/isogram/test/isogram_test.exs
@@ -1,4 +1,3 @@
-
 defmodule IsogramTest do
   use ExUnit.Case
 

--- a/exercises/kindergarten-garden/README.md
+++ b/exercises/kindergarten-garden/README.md
@@ -64,7 +64,7 @@ While asking for Bob's plants would yield:
 Execute the tests with:
 
 ```bash
-$ elixir kindergarten_garden_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/kindergarten-garden/test/garden_test.exs
+++ b/exercises/kindergarten-garden/test/garden_test.exs
@@ -1,4 +1,3 @@
-
 defmodule GardenTest do
   use ExUnit.Case
 

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -18,7 +18,7 @@ the largest product for a series of 6 digits is 23520.
 Execute the tests with:
 
 ```bash
-$ elixir largest_series_product_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/largest-series-product/test/largest_series_product_test.exs
+++ b/exercises/largest-series-product/test/largest_series_product_test.exs
@@ -1,4 +1,3 @@
-
 defmodule LargestSeriesProductTest do
   use ExUnit.Case
 

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -31,7 +31,7 @@ phenomenon, go watch [this youtube video][video].
 Execute the tests with:
 
 ```bash
-$ elixir leap_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/leap/test/leap_test.exs
+++ b/exercises/leap/test/leap_test.exs
@@ -1,4 +1,3 @@
-
 defmodule LeapTest do
   use ExUnit.Case
 

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -11,7 +11,7 @@ without using existing functions.
 Execute the tests with:
 
 ```bash
-$ elixir list_ops_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/list-ops/test/list_ops_test.exs
+++ b/exercises/list-ops/test/list_ops_test.exs
@@ -1,4 +1,3 @@
-
 defmodule ListOpsTest do
   alias ListOps, as: L
 

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -69,7 +69,7 @@ Sum the digits
 Execute the tests with:
 
 ```bash
-$ elixir luhn_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/luhn/test/luhn_test.exs
+++ b/exercises/luhn/test/luhn_test.exs
@@ -1,4 +1,3 @@
-
 defmodule LuhnTest do
   use ExUnit.Case
 

--- a/exercises/markdown/README.md
+++ b/exercises/markdown/README.md
@@ -19,7 +19,7 @@ important thing is to make the code better!
 Execute the tests with:
 
 ```bash
-$ elixir markdown_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/markdown/test/markdown_test.exs
+++ b/exercises/markdown/test/markdown_test.exs
@@ -1,4 +1,3 @@
-
 defmodule MarkdownTest do
   use ExUnit.Case
 

--- a/exercises/matrix/README.md
+++ b/exercises/matrix/README.md
@@ -45,7 +45,7 @@ And its columns:
 Execute the tests with:
 
 ```bash
-$ elixir matrix_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/matrix/test/matrix_test.exs
+++ b/exercises/matrix/test/matrix_test.exs
@@ -1,4 +1,3 @@
-
 defmodule MatrixTest do
   use ExUnit.Case
 

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -31,7 +31,7 @@ descriptor calculate the date of the actual meetup.  For example, if given
 Execute the tests with:
 
 ```bash
-$ elixir meetup_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/meetup/test/meetup_test.exs
+++ b/exercises/meetup/test/meetup_test.exs
@@ -1,4 +1,3 @@
-
 defmodule MeetupTest do
   use ExUnit.Case
 

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -31,7 +31,7 @@ into this:
 Execute the tests with:
 
 ```bash
-$ elixir minesweeper_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/minesweeper/test/minesweeper_test.exs
+++ b/exercises/minesweeper/test/minesweeper_test.exs
@@ -1,4 +1,3 @@
-
 defmodule MinesweeperTest do
   use ExUnit.Case
 

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -13,7 +13,7 @@ numbers, pretend they don't exist and implement them yourself.
 Execute the tests with:
 
 ```bash
-$ elixir nth_prime_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/nth-prime/test/nth_prime_test.exs
+++ b/exercises/nth-prime/test/nth_prime_test.exs
@@ -1,4 +1,3 @@
-
 defmodule NthPrimeTest do
   use ExUnit.Case
 

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -17,7 +17,7 @@ Here is an analogy:
 Execute the tests with:
 
 ```bash
-$ elixir nucleotide_count_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/nucleotide-count/test/nucleotide_count_test.exs
+++ b/exercises/nucleotide-count/test/nucleotide_count_test.exs
@@ -1,4 +1,3 @@
-
 defmodule NucleotideCountTest do
   use ExUnit.Case
 

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -83,7 +83,7 @@ Is converted to "123,456,789"
 Execute the tests with:
 
 ```bash
-$ elixir ocr_numbers_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/ocr-numbers/test/ocr_numbers_test.exs
+++ b/exercises/ocr-numbers/test/ocr_numbers_test.exs
@@ -1,4 +1,3 @@
-
 defmodule OcrNumbersTest do
   use ExUnit.Case
 

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -37,7 +37,7 @@ The largest palindrome product is `9009`. Its factors are `(91, 99)`.
 Execute the tests with:
 
 ```bash
-$ elixir palindrome_products_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/palindrome-products/test/palindrome_products_test.exs
+++ b/exercises/palindrome-products/test/palindrome_products_test.exs
@@ -1,4 +1,3 @@
-
 defmodule PalindromeProductsTest do
   use ExUnit.Case
 

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -13,7 +13,7 @@ insensitive. Input will not contain non-ASCII symbols.
 Execute the tests with:
 
 ```bash
-$ elixir pangram_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/pangram/test/pangram_test.exs
+++ b/exercises/pangram/test/pangram_test.exs
@@ -1,4 +1,3 @@
-
 defmodule PangramTest do
   use ExUnit.Case
 

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -12,7 +12,7 @@ list of texts and that employs parallelism.
 Execute the tests with:
 
 ```bash
-$ elixir parallel_letter_frequency_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/parallel-letter-frequency/test/frequency_test.exs
+++ b/exercises/parallel-letter-frequency/test/frequency_test.exs
@@ -1,4 +1,3 @@
-
 defmodule FrequencyTest do
   use ExUnit.Case
 

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -19,7 +19,7 @@ the right and left of the current position in the previous row.
 Execute the tests with:
 
 ```bash
-$ elixir pascals_triangle_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/pascals-triangle/test/pascals_triangle_test.exs
+++ b/exercises/pascals-triangle/test/pascals_triangle_test.exs
@@ -1,4 +1,3 @@
-
 defmodule PascalsTriangleTest do
   use ExUnit.Case
 

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -22,7 +22,7 @@ Implement a way to determine whether a given number is **perfect**. Depending on
 Execute the tests with:
 
 ```bash
-$ elixir perfect_numbers_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/perfect-numbers/test/perfect_numbers_test.exs
+++ b/exercises/perfect-numbers/test/perfect_numbers_test.exs
@@ -1,4 +1,3 @@
-
 defmodule PerfectNumbersTest do
   use ExUnit.Case
 

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -33,7 +33,7 @@ should all produce the output
 Execute the tests with:
 
 ```bash
-$ elixir phone_number_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/phone-number/test/phone_number_test.exs
+++ b/exercises/phone-number/test/phone_number_test.exs
@@ -1,4 +1,3 @@
-
 defmodule PhoneTest do
   use ExUnit.Case
 

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -22,7 +22,7 @@ See <http://en.wikipedia.org/wiki/Pig_latin> for more details.
 Execute the tests with:
 
 ```bash
-$ elixir pig_latin_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/pig-latin/test/pig_latin_test.exs
+++ b/exercises/pig-latin/test/pig_latin_test.exs
@@ -1,4 +1,3 @@
-
 defmodule PigLatinTest do
   use ExUnit.Case
 

--- a/exercises/poker/README.md
+++ b/exercises/poker/README.md
@@ -10,7 +10,7 @@ overview of poker hands.
 Execute the tests with:
 
 ```bash
-$ elixir poker_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/poker/test/poker_test.exs
+++ b/exercises/poker/test/poker_test.exs
@@ -1,4 +1,3 @@
-
 defmodule PokerTest do
   use ExUnit.Case
 

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -34,7 +34,7 @@ You can check this yourself:
 Execute the tests with:
 
 ```bash
-$ elixir prime_factors_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/prime-factors/test/prime_factors_test.exs
+++ b/exercises/prime-factors/test/prime_factors_test.exs
@@ -1,4 +1,3 @@
-
 defmodule PrimeFactorsTest do
   use ExUnit.Case
 

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -46,7 +46,7 @@ Learn more about [protein translation on Wikipedia](http://en.wikipedia.org/wiki
 Execute the tests with:
 
 ```bash
-$ elixir protein_translation_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/protein-translation/test/protein_translation_test.exs
+++ b/exercises/protein-translation/test/protein_translation_test.exs
@@ -1,4 +1,3 @@
-
 defmodule ProteinTranslationTest do
   use ExUnit.Case
 

--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -22,7 +22,7 @@ Find the product a * b * c.
 Execute the tests with:
 
 ```bash
-$ elixir pythagorean_triplet_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/pythagorean-triplet/test/pythagorean_triplet_test.exs
+++ b/exercises/pythagorean-triplet/test/pythagorean_triplet_test.exs
@@ -1,4 +1,3 @@
-
 defmodule PythagoreanTripletTest do
   use ExUnit.Case
 

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -31,7 +31,7 @@ share a diagonal.
 Execute the tests with:
 
 ```bash
-$ elixir queen_attack_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/queen-attack/test/queen_attack_test.exs
+++ b/exercises/queen-attack/test/queen_attack_test.exs
@@ -1,4 +1,3 @@
-
 defmodule QueenAttackTest do
   use ExUnit.Case
 

--- a/exercises/rail-fence-cipher/README.md
+++ b/exercises/rail-fence-cipher/README.md
@@ -63,7 +63,7 @@ If you now read along the zig-zag shape you can read the original message.
 Execute the tests with:
 
 ```bash
-$ elixir rail_fence_cipher_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/rail-fence-cipher/test/rail_fence_cipher_test.exs
+++ b/exercises/rail-fence-cipher/test/rail_fence_cipher_test.exs
@@ -1,4 +1,3 @@
-
 defmodule RailFenceCipherTest do
   use ExUnit.Case
 

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -22,7 +22,7 @@ Convert a number to a string, the contents of which depend on the number's facto
 Execute the tests with:
 
 ```bash
-$ elixir raindrops_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/raindrops/test/raindrops_test.exs
+++ b/exercises/raindrops/test/raindrops_test.exs
@@ -1,4 +1,3 @@
-
 defmodule RaindropsTest do
   use ExUnit.Case
 

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -23,7 +23,7 @@ each nucleotide with its complement:
 Execute the tests with:
 
 ```bash
-$ elixir rna_transcription_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/rna-transcription/test/rna_transcription_test.exs
+++ b/exercises/rna-transcription/test/rna_transcription_test.exs
@@ -1,4 +1,3 @@
-
 defmodule RnaTranscriptionTest do
   use ExUnit.Case
 

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -32,7 +32,7 @@ direction it is pointing.
 Execute the tests with:
 
 ```bash
-$ elixir robot_simulator_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/robot-simulator/test/robot_simulator_test.exs
+++ b/exercises/robot-simulator/test/robot_simulator_test.exs
@@ -1,4 +1,3 @@
-
 defmodule RobotSimulatorTest do
   use ExUnit.Case
 

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -47,7 +47,7 @@ See also: http://www.novaroma.org/via_romana/numbers.html
 Execute the tests with:
 
 ```bash
-$ elixir roman_numerals_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/roman-numerals/test/roman_test.exs
+++ b/exercises/roman-numerals/test/roman_test.exs
@@ -1,4 +1,3 @@
-
 defmodule RomanTest do
   use ExUnit.Case
 

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -35,7 +35,7 @@ Ciphertext is written out in the same formatting as the input including spaces a
 Execute the tests with:
 
 ```bash
-$ elixir rotational_cipher_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/rotational-cipher/test/rotational_cipher_test.exs
+++ b/exercises/rotational-cipher/test/rotational_cipher_test.exs
@@ -1,4 +1,3 @@
-
 defmodule RotationalCipherTest do
   use ExUnit.Case
 

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -28,7 +28,7 @@ be decoded always represent the count for the following character.
 Execute the tests with:
 
 ```bash
-$ elixir run_length_encoding_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/run-length-encoding/test/run_length_encoder_test.exs
+++ b/exercises/run-length-encoding/test/run_length_encoder_test.exs
@@ -1,4 +1,3 @@
-
 defmodule RunLengthEncoderTest do
   use ExUnit.Case
 

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -33,7 +33,7 @@ but the tests for this exercise follow the above unambiguous definition.
 Execute the tests with:
 
 ```bash
-$ elixir saddle_points_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/saddle-points/test/saddle_points_test.exs
+++ b/exercises/saddle-points/test/saddle_points_test.exs
@@ -1,4 +1,3 @@
-
 defmodule SaddlePointsTest do
   use ExUnit.Case
 

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -67,7 +67,7 @@ Use _and_ (correctly) when spelling out the number in English:
 Execute the tests with:
 
 ```bash
-$ elixir say_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/say/test/say_test.exs
+++ b/exercises/say/test/say_test.exs
@@ -1,4 +1,3 @@
-
 defmodule SayTest do
   use ExUnit.Case
 

--- a/exercises/scale-generator/README.md
+++ b/exercises/scale-generator/README.md
@@ -53,7 +53,7 @@ figure into this exercise.
 Execute the tests with:
 
 ```bash
-$ elixir scale_generator_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/scale-generator/test/scale_generator_test.exs
+++ b/exercises/scale-generator/test/scale_generator_test.exs
@@ -1,4 +1,3 @@
-
 defmodule ScaleGeneratorTest do
   use ExUnit.Case
 

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -44,7 +44,7 @@ And to total:
 Execute the tests with:
 
 ```bash
-$ elixir scrabble_score_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/scrabble-score/test/scrabble_test.exs
+++ b/exercises/scrabble-score/test/scrabble_test.exs
@@ -1,4 +1,3 @@
-
 defmodule ScrabbleTest do
   use ExUnit.Case
 

--- a/exercises/secret-handshake/README.md
+++ b/exercises/secret-handshake/README.md
@@ -55,7 +55,7 @@ Flags &&& Check: 0b10010 (Third bit not set)
 Execute the tests with:
 
 ```bash
-$ elixir secret_handshake_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/secret-handshake/test/secret_handshake_test.exs
+++ b/exercises/secret-handshake/test/secret_handshake_test.exs
@@ -1,4 +1,3 @@
-
 defmodule SecretHandshakeTest do
   use ExUnit.Case
 

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -25,7 +25,7 @@ in the input; the digits need not be *numerically consecutive*.
 Execute the tests with:
 
 ```bash
-$ elixir series_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/series/test/series_test.exs
+++ b/exercises/series/test/series_test.exs
@@ -1,4 +1,3 @@
-
 defmodule StringSeriesTest do
   use ExUnit.Case
 

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -34,7 +34,7 @@ language).
 Execute the tests with:
 
 ```bash
-$ elixir sieve_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/sieve/test/sieve_test.exs
+++ b/exercises/sieve/test/sieve_test.exs
@@ -1,4 +1,3 @@
-
 defmodule SieveTest do
   use ExUnit.Case
 

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -86,7 +86,7 @@ on Wikipedia][dh] for one of the first implementations of this scheme.
 Execute the tests with:
 
 ```bash
-$ elixir simple_cipher_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/simple-cipher/test/simple_cipher_test.exs
+++ b/exercises/simple-cipher/test/simple_cipher_test.exs
@@ -1,4 +1,3 @@
-
 defmodule SimpleCipherTest do
   use ExUnit.Case
 

--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -26,7 +26,7 @@ implement your own abstract data type.
 Execute the tests with:
 
 ```bash
-$ elixir linked_list_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/simple-linked-list/test/linked_list_test.exs
+++ b/exercises/simple-linked-list/test/linked_list_test.exs
@@ -1,4 +1,3 @@
-
 defmodule LinkedListTest do
   use ExUnit.Case
 

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -22,7 +22,7 @@ youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
 Execute the tests with:
 
 ```bash
-$ elixir space_age_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/space-age/test/space_age_test.exs
+++ b/exercises/space-age/test/space_age_test.exs
@@ -1,4 +1,3 @@
-
 defmodule SpageAgeTest do
   use ExUnit.Case
 

--- a/exercises/spiral-matrix/README.md
+++ b/exercises/spiral-matrix/README.md
@@ -28,7 +28,7 @@ like these examples:
 Execute the tests with:
 
 ```bash
-$ elixir spiral_matrix_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/spiral-matrix/test/spiral_test.exs
+++ b/exercises/spiral-matrix/test/spiral_test.exs
@@ -1,4 +1,3 @@
-
 defmodule SpiralTest do
   use ExUnit.Case
 

--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -41,7 +41,7 @@ basic tools instead.
 Execute the tests with:
 
 ```bash
-$ elixir strain_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/strain/test/strain_test.exs
+++ b/exercises/strain/test/strain_test.exs
@@ -1,4 +1,3 @@
-
 defmodule StrainTest do
   use ExUnit.Case
 

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -22,7 +22,7 @@ Examples:
 Execute the tests with:
 
 ```bash
-$ elixir sublist_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/sublist/test/sublist_test.exs
+++ b/exercises/sublist/test/sublist_test.exs
@@ -1,4 +1,3 @@
-
 defmodule SublistTest do
   use ExUnit.Case
 

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -13,7 +13,7 @@ The sum of these multiples is 78.
 Execute the tests with:
 
 ```bash
-$ elixir sum_of_multiples_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/sum-of-multiples/test/sum_of_multiples_test.exs
+++ b/exercises/sum-of-multiples/test/sum_of_multiples_test.exs
@@ -1,4 +1,3 @@
-
 defmodule SumOfMultiplesTest do
   use ExUnit.Case
 

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -74,7 +74,7 @@ team name column can be right-padded with spaces to a width of 30.
 Execute the tests with:
 
 ```bash
-$ elixir tournament_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/tournament/test/tournament_test.exs
+++ b/exercises/tournament/test/tournament_test.exs
@@ -1,4 +1,3 @@
-
 defmodule TournamentTest do
   use ExUnit.Case
 

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -63,7 +63,7 @@ the corresponding output row should contain the spaces in its right-most column(
 Execute the tests with:
 
 ```bash
-$ elixir transpose_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/transpose/test/transpose_test.exs
+++ b/exercises/transpose/test/transpose_test.exs
@@ -1,4 +1,3 @@
-
 defmodule TransposeTest do
   use ExUnit.Case
 

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -27,7 +27,7 @@ a single line. Feel free to add your own code/tests to check for degenerate tria
 Execute the tests with:
 
 ```bash
-$ elixir triangle_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/triangle/test/triangle_test.exs
+++ b/exercises/triangle/test/triangle_test.exs
@@ -1,4 +1,3 @@
-
 defmodule TriangleTest do
   use ExUnit.Case
 

--- a/exercises/twelve-days/README.md
+++ b/exercises/twelve-days/README.md
@@ -33,7 +33,7 @@ On the twelfth day of Christmas my true love gave to me: twelve Drummers Drummin
 Execute the tests with:
 
 ```bash
-$ elixir twelve_days_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/twelve-days/test/twelve_days_test.exs
+++ b/exercises/twelve-days/test/twelve_days_test.exs
@@ -1,4 +1,3 @@
-
 defmodule TwelveDaysTest do
   use ExUnit.Case
 

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -17,7 +17,7 @@ If no name is given, the result should be "One for you, one for me."
 Execute the tests with:
 
 ```bash
-$ elixir two_fer_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/two-fer/test/two_fer_test.exs
+++ b/exercises/two-fer/test/two_fer_test.exs
@@ -1,4 +1,3 @@
-
 defmodule TwoFerTest do
   use ExUnit.Case
 

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -19,7 +19,7 @@ The keys are lowercase.
 Execute the tests with:
 
 ```bash
-$ elixir word_count_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/word-count/test/word_count_test.exs
+++ b/exercises/word-count/test/word_count_test.exs
@@ -1,4 +1,3 @@
-
 defmodule WordsTest do
   use ExUnit.Case
 

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -56,7 +56,7 @@ If you'd like, handle exponentials.
 Execute the tests with:
 
 ```bash
-$ elixir wordy_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/wordy/test/wordy_test.exs
+++ b/exercises/wordy/test/wordy_test.exs
@@ -1,4 +1,3 @@
-
 defmodule WordyTest do
   use ExUnit.Case
 

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -32,7 +32,7 @@ list of child nodes) a zipper might support these operations:
 Execute the tests with:
 
 ```bash
-$ elixir zipper_test.exs
+$ mix test
 ```
 
 ### Pending tests

--- a/exercises/zipper/test/zipper_test.exs
+++ b/exercises/zipper/test/zipper_test.exs
@@ -1,4 +1,3 @@
-
 defmodule ZipperTest do
   alias BinTree, as: BT
   import Zipper


### PR DESCRIPTION
`git diff --ignore-blank-lines master` produces no output after commit https://github.com/exercism/elixir/pull/485/commits/51dd9b7d95b064d227416154e3baadc9cc742b62, showing that this only removes blank lines.

I also confirmed that the README fixes only affected the READMEs and README template.