### PR TITLE
Remove OTP from robot-simulator

### DIFF
--- a/config.json
+++ b/config.json
@@ -79,7 +79,6 @@
       "unlocked_by": null,
       "difficulty": 6,
       "topics": [
-        "otp",
         "pattern_matching",
         "structs"
       ]


### PR DESCRIPTION
This does not need OTP and confuses the students.