### PR TITLE
Fix student name order

### DIFF
--- a/exercises/kindergarten-garden/test/garden_test.exs
+++ b/exercises/kindergarten-garden/test/garden_test.exs
@@ -43,7 +43,7 @@ defmodule GardenTest do
 
   @tag :pending
   test "accepts custom child names" do
-    garden_info = Garden.info("VC\nRC", [:nate, :maggie])
+    garden_info = Garden.info("VC\nRC", [:maggie, :nate])
     assert garden_info.maggie == {:violets, :clover, :radishes, :clover}
     assert garden_info.nate == {}
   end

--- a/exercises/kindergarten-garden/test/garden_test.exs
+++ b/exercises/kindergarten-garden/test/garden_test.exs
@@ -53,7 +53,6 @@ defmodule GardenTest do
     names = [
       :maggie,
       :nate,
-      :xander,
       :ophelia,
       :pete,
       :reggie,
@@ -62,6 +61,7 @@ defmodule GardenTest do
       :ursula,
       :victor,
       :winnie,
+      :xander,
       :ynold
     ]
 


### PR DESCRIPTION
The order of student names in one of the Kindergarten Garden tests is reversed, which results in a spurious test failure.