### PR TITLE
Split out Kindergarten Garden's order requirement

### DIFF
--- a/exercises/kindergarten-garden/test/garden_test.exs
+++ b/exercises/kindergarten-garden/test/garden_test.exs
@@ -25,6 +25,13 @@ defmodule GardenTest do
   end
 
   @tag :pending
+  test "plants are assigned in alphabetical order" do
+    garden_info = Garden.info("VVCC\nGGRR", [:bob, :alice])
+    assert garden_info.alice == {:violets, :violets, :grass, :grass}
+    assert garden_info.bob == {:clover, :clover, :radishes, :radishes}
+  end
+
+  @tag :pending
   test "gets the garden for all students" do
     garden_info = Garden.info("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV")
     assert garden_info.alice == {:violets, :radishes, :violets, :radishes}


### PR DESCRIPTION
This commit adds a test to the Kindergarten Garden exercise that
explicitly calls out that arguments should be processed in alphabetical
order instead of in the order they're given.

Before this commit, this requirement was checked in the first test where
a non-default value for the argument in question was provided. For
learners who haven't read the specification carefully, it's easy to get
the wrong idea about why that test is failing. An explicit reference to
that requirement in the test suite gives those folks a second chance to
understand it properly.

This commit is a follow-up to #522