### PR TITLE
Fix dialyzer check and cache PLTs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ bin/configlet
 bin/configlet*
 deps
 _build
+/priv/plts/*.plt
+/priv/plts/*.plt.hash

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ elixir:
   - 1.9.0
 
 otp_release:
-  - 20.3
+  - 21.3
   - 22.0
 
 matrix:
@@ -34,3 +34,5 @@ cache:
   directories:
     - _build
     - deps
+    - ~/.mix/
+    - priv/plts

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,10 @@ defmodule ExercismTestRunner.Mixfile do
       deps: deps(),
       test_paths: ["exercises"],
       consolidate_protocols: false,
-      dialyzer: [paths: ["tmp/build"]]
+      dialyzer: [
+        paths: ["_build"],
+        plt_file: {:no_warn, "priv/plts/eventstore.plt"}
+      ]
     ]
   end
 
@@ -18,6 +21,6 @@ defmodule ExercismTestRunner.Mixfile do
   end
 
   defp deps do
-    [{:dialyxir, "~> 0.5"}]
+    [{:dialyxir, "~> 1.0.0-rc.7"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,4 @@
 %{
-  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], []},
+  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.7", "6287f8f2cb45df8584317a4be1075b8c9b8a69de8eeb82b4d9e6c761cf2664cd", [:mix], [{:erlex, ">= 0.2.5", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
+  "erlex": {:hex, :erlex, "0.2.5", "e51132f2f472e13d606d808f0574508eeea2030d487fc002b46ad97e738b0510", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
This will cache the Erlang & Elixir PLTs for each combination, and also
fixes the dialyzer run for us to make sure we're not referencing any
invalid types or anything else like that.