### PR TITLE
fix spec for convert function

### DIFF
--- a/exercises/ocr-numbers/lib/ocr_numbers.ex
+++ b/exercises/ocr-numbers/lib/ocr_numbers.ex
@@ -3,7 +3,7 @@ defmodule OcrNumbers do
   Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or
   whether it is garbled.
   """
-  @spec convert([String.t()]) :: String.t()
+  @spec convert([String.t()]) :: {:ok, String.t()} | {:error, charlist()}
   def convert(input) do
   end
 end


### PR DESCRIPTION
Hello guys, It seems that the convert function does not return strings, but instead tuples with either an ok atom with the answer as a string or a tuple with an error atom with a charlist as a message.