### PR TITLE
ci update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 language: elixir
-elixir:
-  - 1.6.6
-  - 1.7.2
-  - 1.8.2
-  - 1.9.0
 
-otp_release:
-  - 21.3
-  - 22.0
-
-matrix:
-  exclude:
-  - elixir: 1.6.6
-    otp_release: 22
+# be explicit so travis ci doesn't autopick undesired versions
+jobs:
+  include:
+    - elixir: '1.6.0'
+      otp_release: '19.0'
+    - elixir: '1.7.0'
+      otp_release: '19.0'
+    - elixir: '1.8.0'
+      otp_release: '20.0'
+    - elixir: '1.9.0'
+      otp_release: '20.0'
+    - elixir: '1.10.0'
+      otp_release: '21.0'
 
 script:
   - mix format --check-formatted

--- a/bin/dialyzer_check.sh
+++ b/bin/dialyzer_check.sh
@@ -1,6 +1,11 @@
+# currently dialyzer is timing out after 30 mins only on elixir 1.7 / otp 19
+if elixir --version | grep -q 'Elixir 1.7'; then
+  echo "skipping dialyzer for Elixir 1.7"
+  exit 0
+fi
+
 mkdir -p ./tmp/src
 mkdir ./tmp/build
-
 
 for example_file in exercises/**/example.exs
 do

--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -26,7 +26,7 @@ case $(uname -m) in
         echo 64bit;;
 esac)
 
-VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
+VERSION="$(curl --head --silent $LATEST | awk -v FS=/ 'toupper($0) ~ /LOCATION:/{print $NF}' | tr -d '\r')"
 URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
 
 curl -s --location $URL | tar xz -C bin/

--- a/exercises/isbn-verifier/test/isbn_verifier_test.exs
+++ b/exercises/isbn-verifier/test/isbn_verifier_test.exs
@@ -120,7 +120,7 @@ defmodule IsbnVerifierTest do
   end
 
   @tag :pending
-  test "English-speaking area	Willmann–Bell" do
+  test "English-speaking area Willmann-Bell" do
     assert IsbnVerifier.isbn?("0-943396-04-2")
   end
 

--- a/exercises/two-fer/example.exs
+++ b/exercises/two-fer/example.exs
@@ -3,6 +3,5 @@ defmodule TwoFer do
   Two-fer or 2-fer is short for two for one. One for you and one for me.
   """
   @spec two_fer(String.t()) :: String.t()
-  def two_fer(name \\ "you") when is_bitstring(name),
-    do: "One for #{name}, one for me"
+  def two_fer(name \\ "you") when is_binary(name), do: "One for #{name}, one for me"
 end


### PR DESCRIPTION
ci update to fix some issues 

* fix trying to build nonexistent elixir v1.6.6-otp-22
  * instead of a matrix, specify elixir and otp versions together
    * now running elixir 1.{6..10}.0 with minumum otp versions
      * fix the following so elixir 1.6.0 / otp 19.0 pass in ci:
        * only use ascii chars in test names
        * fix a formatting issue to appease 1.6.0 formatter
      * skip dialyzer for elixir 1.7 as it times out after 30 mins
* update fetch-configlet to be case insensitive on http headers