### PR TITLE
Add missing nil return value

### DIFF
--- a/exercises/all-your-base/lib/all_your_base.ex
+++ b/exercises/all-your-base/lib/all_your_base.ex
@@ -4,7 +4,7 @@ defmodule AllYourBase do
   or returns nil if either of the bases are less than 2
   """
 
-  @spec convert(list, integer, integer) :: list
+  @spec convert(list, integer, integer) :: list | nil
   def convert(digits, base_a, base_b) do
   end
 end


### PR DESCRIPTION
Hey everyone, do you think adding that `nil` on the `@spec` as a return value is accurate? After all, the exercise description clearly states that returns a sequence of numbers (list) or a `nil`.