### PR TITLE
fix the sorting of map keys

### DIFF
--- a/exercises/etl/lib/etl.ex
+++ b/exercises/etl/lib/etl.ex
@@ -5,7 +5,7 @@ defmodule ETL do
   ## Examples
 
   iex> ETL.transform(%{"a" => ["ABILITY", "AARDVARK"], "b" => ["BALLAST", "BEAUTY"]})
-  %{"ability" => "a", "aardvark" => "a", "ballast" => "b", "beauty" =>"b"}
+  %{"aardvark" => "a", "ability" => "a", "ballast" => "b", "beauty" => "b"}
   """
   @spec transform(map) :: map
   def transform(input) do


### PR DESCRIPTION
the map always be alphabetically sorted.

ex:
```
iex> %{"ability" => "a", "aardvark" => "a", "ballast" => "b", "beauty" =>"b" }
%{"aardvark" => "a", "ability" => "a", "ballast" => "b", "beauty" => "b"}
```