### PR TITLE
Crypto square: Keep trailing spaces of the chunks

### DIFF
--- a/exercises/crypto-square/example.exs
+++ b/exercises/crypto-square/example.exs
@@ -15,7 +15,7 @@ defmodule CryptoSquare do
 
     normalized
     |> String.graphemes()
-    |> Enum.chunk_every(section_length, section_length, List.duplicate("", section_length))
+    |> Enum.chunk_every(section_length, section_length, List.duplicate(" ", section_length))
     |> List.zip()
     |> Enum.map(&Tuple.to_list/1)
     |> Enum.join(" ")

--- a/exercises/crypto-square/test/crypto_square_test.exs
+++ b/exercises/crypto-square/test/crypto_square_test.exs
@@ -18,18 +18,18 @@ defmodule CryptoSquareTest do
 
   @tag :pending
   test "small imperfect square" do
-    assert CryptoSquare.encode("This is easy") == "tis hsy ie sa"
+    assert CryptoSquare.encode("This is easy") == "tis hsy ie  sa "
   end
 
   @tag :pending
   test "punctuation and numbers" do
-    assert CryptoSquare.encode("1, 2, 3, Go! Go, for God's sake!") == "1gga 2ook 3fde gos ors"
+    assert CryptoSquare.encode("1, 2, 3, Go! Go, for God's sake!") == "1gga 2ook 3fde gos  ors "
   end
 
   @tag :pending
   test "long string" do
     msg = "If man was meant to stay on the ground, god would have given us roots."
-    cipher = "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau"
+    cipher = "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "
     assert CryptoSquare.encode(msg) == cipher
   end
 end


### PR DESCRIPTION
According to the [specification](https://github.com/exercism/problem-specifications/blob/c76d358b75c32468b8a6541484c50f8144e91beb/exercises/crypto-square/canonical-data.json#L59-L65), the trailing spaces of each chunk must be kept in the output.


I was helping a student in my company and he was having the tests failing because of whitespaces. We realized that the tests were not following the specification of the problem.