### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/concepts/access-behaviour/about.md
+++ b/concepts/access-behaviour/about.md
@@ -1,3 +1,5 @@
+# About
+
 Elixir uses [_Behaviours_][behaviours] to provide common generic interfaces while facilitating specific implementations for each module which implements the behaviour. One of those behaviours is the _Access Behaviour_.
 
 The _Access Behaviour_ provides a common interface for retrieving key-based data from a data structure. It is implemented for maps and keyword lists.

--- a/concepts/access-behaviour/introduction.md
+++ b/concepts/access-behaviour/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Elixir uses code _Behaviours_ to provide common generic interfaces while facilitating specific implementations for each module which implements it. One such common example is the _Access Behaviour_.
 
 The _Access Behaviour_ provides a common interface for retrieving data from a key-based data structure. The _Access Behaviour_ is implemented for maps and keyword lists, but let's look at its use for maps to get a feel for it. _Access Behaviour_ specifies that when you have a map, you may follow it with _square brackets_ and then use the key to retrieve the value associated with that key.

--- a/concepts/agent/about.md
+++ b/concepts/agent/about.md
@@ -1,3 +1,5 @@
+# About
+
 While spawning a process is easy, managing its state and behavior can become very complicated. The [`Agent`][agent-module] module is an abstraction to facilitate managing a shared state in an Elixir process.
 
 When using `Agent` module functions it is customary to encapsulate the agent-related functions in a single module.

--- a/concepts/agent/introduction.md
+++ b/concepts/agent/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 The `Agent` module facilitates an abstraction for spawning processes and the _receive-send_ loop. From here, we will call processes started using the `Agent` module _'agent processes'_. An _agent process_ might be chosen to represent a central shared state.
 
 To start an _agent process_, `Agent` provides the `start/2` function. The supplied function when `start`_-ing_ the _agent process_ returns the initial state of the process:

--- a/concepts/anonymous-functions/about.md
+++ b/concepts/anonymous-functions/about.md
@@ -1,3 +1,5 @@
+# About
+
 [Anonymous functions][anon-fns] are commonly used throughout Elixir on their own, as return values, and as arguments in higher order functions such as `Enum.map/2`:
 
 ```elixir

--- a/concepts/anonymous-functions/introduction.md
+++ b/concepts/anonymous-functions/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Functions are treated as first class citizens in Elixir. This means functions:
 
 - Can be assigned to variables.

--- a/concepts/atoms/about.md
+++ b/concepts/atoms/about.md
@@ -1,3 +1,5 @@
+# About
+
 You can use [atoms][atom] whenever you have a set of constants to express. Atoms provide a type-safe way to compare values. An atom is defined by its name, prefixed by a colon:
 
 ```elixir

--- a/concepts/atoms/introduction.md
+++ b/concepts/atoms/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Elixir's `atom` type represents a fixed constant. An atom's value is simply its own name. This gives us a type-safe way to interact with data. Atoms can be defined as follows:
 
 ```elixir

--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -1,3 +1,5 @@
+# About
+
 - Elixir is dynamically-typed.
   - The type of a variable is only checked at run-time.
 - Using the match [`=`][match] operator, we can bind a value of any type to a variable name:

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Elixir is a dynamically-typed language, meaning that the type of a variable is only checked at runtime. Using the match `=` operator, we can bind a value of any type to a variable name:
 
 ```elixir

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -11,7 +11,7 @@ count = false # You may re-bind any type to a variable
 message = "Success!" # Strings can be created by enclosing characters within double quotes
 ```
 
-### Modules
+## Modules
 
 Elixir is an [functional-programming language][functional-programming] and requires all named functions to be defined in a _module_. The `defmodule` keyword is used to define a module. All modules are available to all other modules at runtime and do not require an _access modifier_ to make them visible to other parts of the program. A _module_ is analogous to a _class_ in other programming languages.
 
@@ -21,7 +21,7 @@ defmodule Calculator do
 end
 ```
 
-### Named functions
+## Named functions
 
 _Named Functions_ must be defined in a module. Each function can have zero or more arguments. All arguments are dynamically-typed, and the return type is not explicitly declared, it is the type of the value returned. An _access modifier_ can be specified for functions, making only desired functions available for use external to the module. In a function, the value of the last expression is _implicitly returned_ to the calling function.
 
@@ -44,7 +44,7 @@ sum = Calculator.short_add(2, 2)
 # => 4
 ```
 
-### Arity of functions
+## Arity of functions
 
 It is common to refer to functions with their _arity_. The _arity_ of a function is the number of arguments it accepts.
 
@@ -55,7 +55,7 @@ def add(x, y, z) do
 end
 ```
 
-### Standard library
+## Standard library
 
 Elixir has a very rich and well-documented standard library. The documentation is available online at [hexdocs.pm/elixir][docs]. Save this link somewhere - you will use it a lot!
 
@@ -63,7 +63,7 @@ Most built-in data types have a corresponding module that offers functions for w
 
 A notable module is the `Kernel` module. It provides the basic capabilities on top of which the rest of the standard library is built, like arithmetic operators, control-flow macros, and much more. Functions for the `Kernel` module are automatically imported, so you can use them without the `Kernel.` prefix.
 
-### Documentation
+## Documentation
 
 Documentation is a priority in high-quality Elixir code bases, and there are 3 ways to write inline documentation:
 

--- a/concepts/binaries/about.md
+++ b/concepts/binaries/about.md
@@ -1,3 +1,5 @@
+# About
+
 - The [binary][binary] type is a specialization of the [bitstring][bitstring] type.
 - Binaries are made up of [bytes][wiki-byte].
   - Bytes are 8 [bits][wiki-bit].

--- a/concepts/binaries/introduction.md
+++ b/concepts/binaries/introduction.md
@@ -14,7 +14,7 @@ Binary literals are defined using the bitstring special form `<<>>`. When defini
 
 A _null-byte_ is another name for `<<0>>`.
 
-### Pattern matching on binary data
+## Pattern matching on binary data
 
 Pattern matching is even extended to binaries, and we can pattern match on a portion of binary data much like we could for a list.
 

--- a/concepts/binaries/introduction.md
+++ b/concepts/binaries/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Elixir provides an elegant syntax for working with binary data as we have seen with the `<<>>` special form provided for working with _bitstrings_.
 
 The binary type is a specialization on the bitstring type. Where bitstrings could be of any length (any number of [bits][wiki-bit]), binaries are where the number of bits can be evenly divided by 8. That is, when working with binaries, we often think of things in terms of [bytes][wiki-byte] (8 bits). A byte can represent integer numbers from `0` to `255`. It is common to work with byte values in [hexadecimal][wiki-hexadecimal], `0x00 - 0xFF`.

--- a/concepts/bit-manipulation/about.md
+++ b/concepts/bit-manipulation/about.md
@@ -1,3 +1,5 @@
+# About
+
 [Bitwise binary functions][bitwise-wiki] can be performed on integers using functions from the [Bitwise module][bitwise-hexdocs].
 
 - [`&&&/2`][bitwise-and]: bitwise AND

--- a/concepts/bit-manipulation/introduction.md
+++ b/concepts/bit-manipulation/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Elixir supports many functions for working with bits found in the _Bitwise module_.
 
 - `&&&/2`: bitwise AND

--- a/concepts/bitstrings/about.md
+++ b/concepts/bitstrings/about.md
@@ -1,3 +1,5 @@
+# About
+
 [Bitstrings][bitstring] allow programmers to work with binary data effectively.
 
 - You can construct bitstrings elegantly using the [`<<>>` special form][bitstring-form].

--- a/concepts/bitstrings/introduction.md
+++ b/concepts/bitstrings/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Working with binary data is an important concept in any language, and Elixir provides an elegant syntax to write, match, and construct binary data.
 
 In Elixir, binary data is referred to as the bitstring type. The binary data *type* (not to be confused with binary data in general) is a specific form of a bitstring, which we will discuss in a later exercise.

--- a/concepts/bitstrings/introduction.md
+++ b/concepts/bitstrings/introduction.md
@@ -29,7 +29,7 @@ By default, bitstrings are displayed in chunks of 8 bits (a byte).
 # => <<251, 3::size(3)>>
 ```
 
-### Constructing
+## Constructing
 
 We can combine bitstrings stored in variables using the special form:
 
@@ -40,7 +40,7 @@ combined = <<first::bitstring, second::bitstring>>
 # => <<49::size(6)>>
 ```
 
-### Pattern matching
+## Pattern matching
 
 Pattern matching can also be done to obtain the value from within the special form:
 

--- a/concepts/booleans/about.md
+++ b/concepts/booleans/about.md
@@ -1,3 +1,5 @@
+# About
+
 Elixir represents true and false values with the boolean type. There are only two values: `true` and `false`. These values can be combined with boolean operators ([`and/2`][strict-and], [`or/2`][strict-or], [`not/1`][strict-not]):
 
 ```elixir

--- a/concepts/booleans/introduction.md
+++ b/concepts/booleans/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Elixir represents true and false values with the boolean type. There are only two values: `true` and `false`.
 
 ```elixir

--- a/concepts/case/about.md
+++ b/concepts/case/about.md
@@ -1,3 +1,5 @@
+# About
+
 [`case`][case] is a control flow structure that allows us to compare a given value against many patterns. Clauses in a `case` expression are evaluated from top to bottom, until a match is found.
 
 In many cases, using `case` is interchangeable with defining multiple function clauses. Pattern matching and guards can be used in `case` clauses.

--- a/concepts/case/introduction.md
+++ b/concepts/case/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 `case` is a control flow structure that allows us to compare a given value against many patterns. Clauses in a `case` statement are evaluated from top to bottom, until a match is found.
 
 ```elixir

--- a/concepts/charlists/about.md
+++ b/concepts/charlists/about.md
@@ -1,3 +1,5 @@
+# About
+
 Charlists are created using single quotes.
 
 ```elixir

--- a/concepts/charlists/introduction.md
+++ b/concepts/charlists/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Charlists are created using single quotes.
 
 ```elixir

--- a/concepts/closures/about.md
+++ b/concepts/closures/about.md
@@ -1,3 +1,5 @@
+# About
+
 Anonymous functions in Elixir are [closures][closure]. They can access variables that are in scope when the function is defined.
 
 ```elixir

--- a/concepts/closures/introduction.md
+++ b/concepts/closures/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Anonymous functions in Elixir are [closures][closure]. They can access variables that are in scope when the function is defined.
 
 ```elixir

--- a/concepts/cond/about.md
+++ b/concepts/cond/about.md
@@ -1,3 +1,5 @@
+# About
+
 When we want to have branching code, we can use [`cond/1`][cond]:
 
 ```elixir

--- a/concepts/cond/introduction.md
+++ b/concepts/cond/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Often, we want to write code that can branch based on a condition. While there are many ways to do this in Elixir, one of the simplest ways is using `cond/1`.
 
 At its simplest, `cond` follows the first path that evaluates to `true` with one or more branches:

--- a/concepts/default-arguments/about.md
+++ b/concepts/default-arguments/about.md
@@ -1,3 +1,5 @@
+# About
+
 Functions may declare [default values][default-arguments] for one or more arguments.
 
 ```elixir

--- a/concepts/default-arguments/introduction.md
+++ b/concepts/default-arguments/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Functions may declare default values for one or more arguments. Let's consider this function:
 
 ```elixir

--- a/concepts/dynamic-dispatch/about.md
+++ b/concepts/dynamic-dispatch/about.md
@@ -1,3 +1,5 @@
+# About
+
 Functions in Elixir can be dispatched dynamically.
 
 All module names are atoms. All Elixir module names are automatically prefixed with `Elixir.` when compiled.

--- a/concepts/dynamic-dispatch/introduction.md
+++ b/concepts/dynamic-dispatch/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 When Elixir resolves the function to be invoked, it uses the Module's name to perform a lookup. The lookup can be done dynamically if the Module's name is bound to a variable.
 
 ```elixir

--- a/concepts/enum/about.md
+++ b/concepts/enum/about.md
@@ -1,3 +1,5 @@
+# About
+
 `Enum` is a very useful module that provides a set of algorithms for working with enumerables. It offers:
 
 - sorting ([`sort/2`][enum-sort/2], [`sort_by/2`][enum-sort_by/2]),

--- a/concepts/enum/introduction.md
+++ b/concepts/enum/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 `Enum` is a very useful module that provides a set of algorithms for working with enumerables. It offers sorting, filtering, grouping, counting, searching, finding min/max values, and much more.
 
 In general, an _enumerable_ is any data that can be iterated over, a collection. In Elixir, an enumerable is any data type that implements the `Enumerable` protocol. The most common of those are lists and maps.

--- a/concepts/erlang-libraries/about.md
+++ b/concepts/erlang-libraries/about.md
@@ -1,3 +1,5 @@
+# About
+
 Elixir code runs in the [BEAM virtual machine][beam]. BEAM is part of the [Erlang][erlang] Run-Time System. Being inspired by Erlang, and sharing its run environment, Elixir provides great interoperability with Erlang libraries. This means that Elixir developers can use Erlang libraries from within their Elixir code. In fact, writing Elixir libraries for functionality already provided by Erlang libraries is discouraged in the Elixir community.
 
 As a result, certain functionality, like mathematical operations or timer functions, is only available in Elixir via Erlang.

--- a/concepts/erlang-libraries/introduction.md
+++ b/concepts/erlang-libraries/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Elixir code runs in the BEAM virtual machine. BEAM is part of the Erlang Run-Time System. Being inspired by Erlang, and sharing its run environment, Elixir provides great interoperability with Erlang libraries. This means that Elixir developers can use Erlang libraries from within their Elixir code. In fact, writing Elixir libraries for functionality already provided by Erlang libraries is discouraged in the Elixir community.
 
 As a result, certain functionality, like mathematical operations or timer functions, is only available in Elixir via Erlang.

--- a/concepts/errors/about.md
+++ b/concepts/errors/about.md
@@ -1,3 +1,5 @@
+# About
+
 While Elixir programmers often say ["let it crash"][let-it-crash] and code for the ["happy path"][happy-path], there are often times we need to rescue the function call to return a specific value, message or release system resources.
 
 - Functions that raise errors under normal circumstances should have `!` at the end of their name.

--- a/concepts/errors/introduction.md
+++ b/concepts/errors/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Errors happen. In Elixir, while people often say to "let it crash", there are times when we need to rescue the function call to a known good state to fulfil a software contract. In some languages, errors are used as method of control flow, but in Elixir, this pattern is discouraged. We can often recognize functions that may raise an error just by their name: functions that raise errors are to have `!` at the end of their name. This is in comparison with functions that return `{:ok, value}` or `:error`. Look at these library examples:
 
 ```elixir

--- a/concepts/exceptions/about.md
+++ b/concepts/exceptions/about.md
@@ -1,3 +1,5 @@
+# About
+
 The [_Exception Behaviour_][exception-behaviour] defines how [`errors`][getting-started-errors] are raised and displayed.
 
 It includes two optional callbacks:

--- a/concepts/exceptions/introduction.md
+++ b/concepts/exceptions/introduction.md
@@ -9,7 +9,7 @@ All errors in Elixir implement the _Exception Behaviour_. Just like the _Access 
 
 The _Exception Behaviour_ also specifies two callbacks: `message/1` and `exception/1`. If unimplemented, default implementations will be used. `message/1` transforms the error-struct to a readable message when called with `raise`. `exception/1` allows additional context to be added to the message when it is called with `raise/2`
 
-### Defining an exception
+## Defining an exception
 
 To define an exception from an error module, we use the `defexception` macro:
 
@@ -35,7 +35,7 @@ defmodule MyCustomizedError do
 end
 ```
 
-### Using exceptions
+## Using exceptions
 
 Defined errors may be used like a built in error using either `raise/1` or `raise/2`.
 

--- a/concepts/exceptions/introduction.md
+++ b/concepts/exceptions/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 All errors in Elixir implement the _Exception Behaviour_. Just like the _Access Behaviour_, the _Exception Behaviour_ defines callback functions that a module must implement to fulfill the software contract of the behaviour. Once an error is defined, it has the following properties:
 
 - The module's name defines the error's name.

--- a/concepts/file/about.md
+++ b/concepts/file/about.md
@@ -1,3 +1,5 @@
+# About
+
 Functions for working with files are provided by the [`File`][file] module.
 
 To read a whole file, use [`File.read/1`][file-read]. To write to a file, use [`File.write/2`][file-write].

--- a/concepts/file/introduction.md
+++ b/concepts/file/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Functions for working with files are provided by the `File` module.
 
 To read a whole file, use `File.read/1`. To write to a file, use `File.write/2`.

--- a/concepts/floating-point-numbers/about.md
+++ b/concepts/floating-point-numbers/about.md
@@ -1,3 +1,5 @@
+# About
+
 There are two different kinds of numbers in Elixir - integers and floats.
 
 Floats are numbers with one or more digits behind the decimal separator. They use the 64-bit double precision floating-point format.

--- a/concepts/floating-point-numbers/introduction.md
+++ b/concepts/floating-point-numbers/introduction.md
@@ -7,11 +7,11 @@ float = 3.45
 # => 3.45
 ```
 
-### Working with numbers
+## Working with numbers
 
 In the [`Integer`][integer-functions] and [`Float`][float-functions] modules you can find some useful functions for working with those types. Basic arithmetic operators are defined in the [`Kernel`][kernel-arithmetic-operators] module.
 
-### Conversion
+## Conversion
 
 Integers and floats can be mixed together in a single arithmetic expression. Using a float in an expression ensures the result will be a float too.
 

--- a/concepts/floating-point-numbers/introduction.md
+++ b/concepts/floating-point-numbers/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Floats are numbers with one or more digits behind the decimal separator. They use the 64-bit double precision floating-point format.
 
 ```elixir

--- a/concepts/guards/about.md
+++ b/concepts/guards/about.md
@@ -1,3 +1,5 @@
+# About
+
 [Guards][guards] are used as a complement to pattern matching. They allow for more complex checks. They can be used in [some, but not all situations][where-guards-can-be-used] where pattern matching can be used, for example in function clauses or case clauses.
 
 ```elixir

--- a/concepts/guards/introduction.md
+++ b/concepts/guards/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Guards are used to prevent Elixir from invoking functions based on evaluation of the arguments by guard functions. Guards begin with the `when` keyword, followed by a boolean expression. Guard functions are special functions which:
 
 - Must be pure and not mutate any global states.

--- a/concepts/if/about.md
+++ b/concepts/if/about.md
@@ -1,3 +1,5 @@
+# About
+
 Besides `cond`, Elixir also provides the macros [`if/2` and `unless/2`][getting-started-if-unless] which are useful when you need to check for only one condition.
 
 [`if/2`][kernel-if] accepts a condition and two options. It returns the first option if the condition is _truthy_, and the second option if the condition is _falsy_. [`unless/2`][kernel-unless] does the opposite.

--- a/concepts/if/introduction.md
+++ b/concepts/if/introduction.md
@@ -24,7 +24,7 @@ if age > 16, do: "beer", else: "no beer"
 
 This syntax is helpful for very short expressions, but should be avoided if the expression won't fit on a single line.
 
-### _Truthy_ and _falsy_
+## _Truthy_ and _falsy_
 
 In Elixir, all datatypes evaluate to a _truthy_ or _falsy_ value when they are encountered in a boolean context (like an `if` expression). All data is considered _truthy_ **except** for _false_ and _nil_.
 

--- a/concepts/if/introduction.md
+++ b/concepts/if/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Besides `cond`, Elixir also provides the macro [`if/2`][getting-started-if-unless] which is useful when you need to check for only one condition.
 
 [`if/2`][kernel-if] accepts a condition and two options. It returns the first option if the condition is _truthy_, and the second option if the condition is _falsy_.

--- a/concepts/integers/about.md
+++ b/concepts/integers/about.md
@@ -1,3 +1,5 @@
+# About
+
 There are two different kinds of numbers in Elixir - integers and floats.
 
 Integers are whole numbers.

--- a/concepts/integers/introduction.md
+++ b/concepts/integers/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 There are two different kinds of numbers in Elixir - integers and floats.
 
 Integers are whole numbers.

--- a/concepts/io/about.md
+++ b/concepts/io/about.md
@@ -1,3 +1,5 @@
+# About
+
 Functions for handling input and output are provided by the [`IO` module][module-io].
 
 - [`IO.puts/2`][io-puts] writes a string to the standard output, followed by a newline. Returns `:ok`.

--- a/concepts/io/introduction.md
+++ b/concepts/io/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Functions for handling input and output are provided by the `IO` module.
 
 ### Output

--- a/concepts/io/introduction.md
+++ b/concepts/io/introduction.md
@@ -2,7 +2,7 @@
 
 Functions for handling input and output are provided by the `IO` module.
 
-### Output
+## Output
 
 To write a string to the standard output, use `IO.puts`. `IO.puts` always adds a new line at the end of the string. If you don't want that behavior, use `IO.write` instead. Both functions return the atom `:ok` if they succeed.
 
@@ -14,7 +14,7 @@ IO.puts("Hi!")
 
 `IO.puts` is useful for writing strings, but not much else. If you need a tool for debugging that will allow you to write any value to standard output, use `IO.inspect` instead. `IO.inspect` returns the value it was passed unchanged, so it can be inserted in any point in your code. It also accepts many options, for example `:label`, that will allow you to distinguish it form other `IO.inspect` calls.
 
-### Input
+## Input
 
 To read a line from the standard input, use `IO.gets`. `IO.gets` accepts one argument - a string that it will print as a prompt for the input. `IO.gets` doesn't add a new line after the prompt, you need it include it yourself if you need it.
 

--- a/concepts/keyword-lists/about.md
+++ b/concepts/keyword-lists/about.md
@@ -1,3 +1,5 @@
+# About
+
 A keyword list is a list of `{key, value}` tuples. There are two way to write a keyword list:
 
 ```elixir

--- a/concepts/keyword-lists/introduction.md
+++ b/concepts/keyword-lists/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Keyword lists are a key-value data structure.
 
 ```elixir

--- a/concepts/list-comprehensions/about.md
+++ b/concepts/list-comprehensions/about.md
@@ -1,3 +1,5 @@
+# About
+
 [Comprehension][for] provide a facility for transforming _Enumerables_ easily and declaratively. They are _syntactic sugar_ for iterating through enumerables in Elixir.
 
 ```elixir

--- a/concepts/list-comprehensions/introduction.md
+++ b/concepts/list-comprehensions/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Comprehensions provide a facility for transforming _Enumerables_ easily and declaratively.
 
 To declare a very simple comprehension, we can use the `for` keyword followed by a _generator_ and a _do-block_ which creates the new values from the enumerated values.

--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -1,3 +1,5 @@
+# About
+
 [Lists][list] are a basic data type in Elixir for holding a collection of values. Lists are _immutable_, meaning they cannot be modified. Any operation that changes a list returns a new list. Lists implement the [Enumerable protocol][enum-protocol], which allows the use of [Enum][enum] and [Stream][stream] module functions.
 
 Lists in Elixir are implemented as [linked lists][linked-list-wiki], and not as arrays of contiguous memory location. Therefore, accessing an element in a list takes linear time depending on the length of the list.

--- a/concepts/lists/introduction.md
+++ b/concepts/lists/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Lists are built-in to the Elixir language. They are considered a basic type, denoted by square brackets. Lists may be empty or hold any number of items of any type. For example:
 
 ```elixir

--- a/concepts/maps/about.md
+++ b/concepts/maps/about.md
@@ -1,3 +1,5 @@
+# About
+
 [Maps][maps] are a data structure that holds key-value pairs.
 
 - Keys can be of any type, but must be unique.

--- a/concepts/maps/introduction.md
+++ b/concepts/maps/introduction.md
@@ -4,7 +4,7 @@ Maps in Elixir are the data structure for storing information in key-value pairs
 
 Keys and values can be of any data type, but if the key is an atom we can use a shorthand syntax. Maps do not guarantee the order of their entries when accessed or returned.
 
-### Literal forms
+## Literal forms
 
 An empty map is simply declared with `%{}`. If we want to add items to a map literal, we can use two forms:
 
@@ -21,7 +21,7 @@ An empty map is simply declared with `%{}`. If we want to add items to a map lit
 
 While there is no canonical format, choose a consistent way to represent the key-value literal pairs.
 
-### Map module functions
+## Map module functions
 
 Elixir provides many functions for working with maps in the _Map module_. Some _Map module_ functions require an _anonymous_ or _captured function_ to be passed into the function to assist with the map transformation.
 

--- a/concepts/maps/introduction.md
+++ b/concepts/maps/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Maps in Elixir are the data structure for storing information in key-value pairs. In other languages, these might also be known as associative arrays (PHP), hashes (Perl 5, Raku), or dictionaries (Python).
 
 Keys and values can be of any data type, but if the key is an atom we can use a shorthand syntax. Maps do not guarantee the order of their entries when accessed or returned.

--- a/concepts/module-attributes-as-constants/about.md
+++ b/concepts/module-attributes-as-constants/about.md
@@ -1,3 +1,5 @@
+# About
+
 [Module attributes][module-attr] may be used like ["constants"][attr-as-const] which are evaluated at compile-time.
 
 ```elixir

--- a/concepts/module-attributes-as-constants/introduction.md
+++ b/concepts/module-attributes-as-constants/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Elixir, we can define module attributes which can be used as constants in our functions.
 
 ```elixir

--- a/concepts/multiple-clause-functions/about.md
+++ b/concepts/multiple-clause-functions/about.md
@@ -1,3 +1,5 @@
+# About
+
 In Elixir, a single function can have multiple clauses. This is achieved by pattern matching the function's arguments and by using guards.
 
 ```elixir

--- a/concepts/multiple-clause-functions/introduction.md
+++ b/concepts/multiple-clause-functions/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Elixir facilitates **Open-Close Principle** practices by allowing functions to have multiple clauses, so instead of sprawling and hard-coded control-logic, pointed functions can be written to add/remove behavior easily.
 
 Elixir offers _multiple function clauses_ and _guards_ to write:

--- a/concepts/nil/about.md
+++ b/concepts/nil/about.md
@@ -1,3 +1,5 @@
+# About
+
 [Nil][nil-dictionary] is an English word meaning "nothing" or "zero". In Elixir, `nil` is a special value that means an _absence_ of a value.
 
 ```elixir

--- a/concepts/nil/introduction.md
+++ b/concepts/nil/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 [Nil][nil-dictionary] is an English word meaning "nothing" or "zero". In Elixir, `nil` is a special value that means an _absence_ of a value.
 
 ```elixir

--- a/concepts/pattern-matching/about.md
+++ b/concepts/pattern-matching/about.md
@@ -1,3 +1,5 @@
+# About
+
 When writing Elixir functions, we can make use of an [assertive style][assertive-style] with [pattern matching][pattern-match-doc]:
 
 ```elixir

--- a/concepts/pattern-matching/introduction.md
+++ b/concepts/pattern-matching/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 The use of pattern matching is dominant in assertive, idiomatic Elixir code. You might recall that `=/2` is described as a match operator rather than as an assignment operator. When using the match operator, if the pattern on the left matches the right, any variables on the left are bound, and the value of the right side is returned. A `MatchError` is raised if there is no match.
 
 ```elixir

--- a/concepts/pattern-matching/introduction.md
+++ b/concepts/pattern-matching/introduction.md
@@ -19,7 +19,7 @@ Remember, matches occur from the right side to the left side.
 
 In the last example if we don't need a variable in a pattern match, we can discard it by referencing `_`. Any variable starting with an `_` is not tracked by the runtime.
 
-### Pattern matching in named functions
+## Pattern matching in named functions
 
 Pattern matching is also a useful tool when creating multiple function clauses. Pattern matching can be used on the functions' arguments which then determines which function clause to invoke -- starting from the top of the file down until the first match. Variables may be bound in a function head and used in the function body.
 

--- a/concepts/pids/about.md
+++ b/concepts/pids/about.md
@@ -1,3 +1,5 @@
+# About
+
 Each Elixir process has its own unique identifier - a _PID_ (process identifier).
 
 - PIDs are their own data type.

--- a/concepts/pids/introduction.md
+++ b/concepts/pids/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 Process identifiers are their own data type. They function as _mailbox addresses_ - if you have a process' PID, you can send a message to that process. PIDs are usually created indirectly, as a return value of functions that create new processes, like `spawn`.

--- a/concepts/pipe-operator/about.md
+++ b/concepts/pipe-operator/about.md
@@ -1,3 +1,5 @@
+# About
+
 The `|>` operator is called [the pipe operator][pipe]. It can be used to chain function calls together in such a way that the value returned by the previous function call is passed as the first argument to the next function call.
 
 ```elixir

--- a/concepts/pipe-operator/introduction.md
+++ b/concepts/pipe-operator/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 The `|>` operator is called the pipe operator. It can be used to chain function calls together in such a way that the value returned by the previous function call is passed as the first argument to the next function call.
 
 ```elixir

--- a/concepts/processes/about.md
+++ b/concepts/processes/about.md
@@ -1,3 +1,5 @@
+# About
+
 In Elixir, all code runs inside processes. Elixir processes:
 
 - Should not be confused with system processes.

--- a/concepts/processes/introduction.md
+++ b/concepts/processes/introduction.md
@@ -13,7 +13,7 @@ spawn(fn -> 2 + 2 end)
 
 Elixir's processes should not be confused with operating system processes. Elixir's processes use much less memory and CPU. It's perfectly fine to have Elixir applications that run hundreds of Elixir processes.
 
-### Messages
+## Messages
 
 Processes do not directly share information with one another. Processes _send and receive messages_ to share data.
 
@@ -34,6 +34,6 @@ end
 
 `receive/1` will take _one message_ from the mailbox that matches any of the given patterns and execute the expression given for that pattern. If there are no messages in the mailbox, or none of messages in the mailbox match any of the patterns, `receive/1` is going to wait for one.
 
-### Receive loop
+## Receive loop
 
 If you want to receive more than one message, you need to call `receive/1` recursively. It is a common pattern to implement a recursive function, for example named `loop`, that calls `receive/1`, does something with the message, and then calls itself to wait for more messages. If you need to carry some state from one `receive/1` call to another, you can do it by passing an argument to that `loop` function.

--- a/concepts/processes/introduction.md
+++ b/concepts/processes/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Elixir, all code runs inside processes.
 
 By default, a function will execute in the same process from which it was called. When you need to explicitly run a certain function in a new process, use `spawn/1`:

--- a/concepts/protocols/about.md
+++ b/concepts/protocols/about.md
@@ -1,3 +1,5 @@
+# About
+
 Protocols are:
 
 - A mechanism to achieve polymorphism.

--- a/concepts/protocols/introduction.md
+++ b/concepts/protocols/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Protocols are a mechanism to achieve polymorphism in Elixir when you want behavior to vary depending on the data type.
 
 Protocols are defined using `defprotocol` and contain one or more function header.

--- a/concepts/randomness/about.md
+++ b/concepts/randomness/about.md
@@ -1,3 +1,5 @@
+# About
+
 In Elixir, to choose a random element from an enumerable data structure (e.g. list, range), we use [`Enum.random/1`][enum-random]. This function will pick a single element, with every element having equal probability of being picked. Picking a single random value from a range is executed in constant time, without traversing the whole range.
 
 ## Random integers and letters

--- a/concepts/randomness/introduction.md
+++ b/concepts/randomness/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Elixir, to choose a random element from an enumerable data structure (e.g. list, range), we use `Enum.random`. This function will pick a single element, with every element having equal probability of being picked.
 
 Elixir does not have its own functions for picking a random float. To do that, we have to use Erlang directly.

--- a/concepts/ranges/about.md
+++ b/concepts/ranges/about.md
@@ -1,3 +1,5 @@
+# About
+
 [Ranges][range] represent a sequence of one or many consecutive integers. They:
 
 - Are created using the [`..` operator][range-operator] and can be both ascending or descending.

--- a/concepts/ranges/introduction.md
+++ b/concepts/ranges/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Ranges represent a sequence of one or many consecutive integers. They are created by connecting two integers with `..`.
 
 ```elixir

--- a/concepts/recursion/about.md
+++ b/concepts/recursion/about.md
@@ -1,3 +1,5 @@
+# About
+
 Recursive functions are functions that call themselves.
 
 A recursive function needs to have at least one _base case_ and at least one _recursive case_.

--- a/concepts/recursion/introduction.md
+++ b/concepts/recursion/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Recursive functions are functions that call themselves.
 
 A recursive function needs to have at least one _base case_ and at least one _recursive case_.

--- a/concepts/regular-expressions/about.md
+++ b/concepts/regular-expressions/about.md
@@ -1,3 +1,5 @@
+# About
+
 Regular expressions (regex) are a powerful tool for working with strings in Elixir. Regular expressions in Elixir follow the **PCRE** specification (**P**erl **C**ompatible **R**egular **E**xpressions). String patterns representing the regular expression's meaning are first compiled then used for matching all or part of a string.
 
 In Elixir, the most common way to create regular expressions is using [the `~r` sigil][sigils-regex]. Sigils provide _syntactic sugar_ shortcuts for common tasks in Elixir. In this case, `~r` is a shortcut for using [`Regex.compile!/2`][regex-compile].

--- a/concepts/regular-expressions/introduction.md
+++ b/concepts/regular-expressions/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Regular expressions (regex) are a powerful tool for working with strings in Elixir. Regular expressions in Elixir follow the **PCRE** specification (**P**erl **C**ompatible **R**egular **E**xpressions). String patterns representing the regular expression's meaning are first compiled then used for matching all or part of a string.
 
 In Elixir, the most common way to create regular expressions is using the `~r` sigil. Sigils provide _syntactic sugar_ shortcuts for common tasks in Elixir. To match a _string literal_, we can use the string itself as a pattern following the sigil.

--- a/concepts/streams/about.md
+++ b/concepts/streams/about.md
@@ -1,3 +1,5 @@
+# About
+
 The [`Stream` module][stream] is a _lazy_ alternative to the _eager_ [`Enum` module][enum]. Streams:
 
 - Implement the [_Enumerable protocol_][enumerable].

--- a/concepts/streams/introduction.md
+++ b/concepts/streams/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 All functions in the `Enum` module are _eager_. When performing multiple operations on enumerables with the `Enum` module, each operation is going to generate an intermediate result.
 
 The `Stream` module is a _lazy_ alternative to the _eager_ `Enum` module. It offers many of the same functions as `Enum`, but instead of generating intermediate results, it builds a series of computations that are only executed once the stream is passed to a function from the `Enum` module.

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -1,3 +1,5 @@
+# About
+
 [Strings][getting-started-strings] in Elixir are delimited by double quotes, and they are encoded in UTF-8:
 
 ```elixir

--- a/concepts/strings/introduction.md
+++ b/concepts/strings/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Strings in Elixir are delimited by double quotes, and they are encoded in UTF-8:
 
 ```elixir

--- a/concepts/structs/about.md
+++ b/concepts/structs/about.md
@@ -1,3 +1,5 @@
+# About
+
 [Structs][getting-started] are special [maps][maps] with a defined set of keys.
 
 - Structs provide compile-time checks and default values.

--- a/concepts/structs/introduction.md
+++ b/concepts/structs/introduction.md
@@ -11,7 +11,7 @@ plane = %Plane{}
 # => %Plane{engine: nil, wings: 2}
 ```
 
-### Accessing fields and updating
+## Accessing fields and updating
 
 Since structs are built on maps, we can use most map functions to get and manipulate values. The _Access Behaviour_ is **not** implemented for structs. It is recommended to use the _static access operator_ `.` to access struct fields instead.
 
@@ -33,7 +33,7 @@ Since structs are built on maps, we can use most map functions to get and manipu
   # => %Plane{engine: nil, wings: 4}
   ```
 
-### Enforcing field value initialization
+## Enforcing field value initialization
 
 We can use the `@enforce_keys` module attribute with a list of the field keys to ensure that the values are initialized when the struct is created. If a key is not listed, its value will be `nil` as seen in the above example. If an enforced key is not initialized, an error is raised.
 

--- a/concepts/structs/introduction.md
+++ b/concepts/structs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Structs are an extension built on top of maps which provide compile-time checks and default values. A struct is named after the module it is defined in. To define a struct use the `defstruct` construct. The construct usually immediately follows after the module definition. `defstruct` accepts either a list of atoms (for `nil` default values) or a keyword list (for specified default values). The fields without defaults must precede the fields with default values.
 
 ```elixir

--- a/concepts/tail-call-recursion/about.md
+++ b/concepts/tail-call-recursion/about.md
@@ -1,3 +1,5 @@
+# About
+
 A function is [tail-recursive][recursion-tc] if the _last_ thing executed by the function is a call to itself.
 
 Each time any function is called, a _stack frame_ with its local variables, arguments etc. is put on top of [the function call stack][call-stack]. When a function returns, the stack frame is removed from the stack.

--- a/concepts/tail-call-recursion/introduction.md
+++ b/concepts/tail-call-recursion/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 When recursing through enumerables (lists, bitstrings, strings), there are often two concerns:
 
 - how much memory is required to store the trail of recursive function calls

--- a/concepts/try-rescue-else-after/about.md
+++ b/concepts/try-rescue-else-after/about.md
@@ -1,3 +1,5 @@
+# About
+
 The basic `try .. rescue` concept can be extended to support `else` and `after` clauses:
 
 - The `else` block:

--- a/concepts/try-rescue-else-after/introduction.md
+++ b/concepts/try-rescue-else-after/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Using `try..rescue` is a powerful construct for catching errors when they occur. Rescuing errors allows functions to return defined values when it is necessary. The `try..rescue` construct also offers us two additional features we can make use of:
 
 - the `else` block:

--- a/concepts/try-rescue/about.md
+++ b/concepts/try-rescue/about.md
@@ -1,3 +1,5 @@
+# About
+
 [`try .. rescue`][docs-try] can be used to capture and evaluate [errors][errors] that are raised inside a block.
 
 For example:

--- a/concepts/try-rescue/introduction.md
+++ b/concepts/try-rescue/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Elixir provides a construct for rescuing from errors using `try .. rescue`
 
 ```elixir

--- a/concepts/tuples/about.md
+++ b/concepts/tuples/about.md
@@ -1,3 +1,5 @@
+# About
+
 Tuples are used commonly to group information informally. A common pattern in Elixir is to group function return values with a status.
 
 ```elixir

--- a/concepts/tuples/introduction.md
+++ b/concepts/tuples/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Elixir, a tuple is a data structure which organizes data, holding a fixed number of items of any type, but without explicit names for each element. Tuples are often used in Elixir for memory read-intensive operations, since read-access of an element is a constant-time operation. They are not usually used when elements may need to be added/removed dynamically because rather than modifying the existing tuple, a new tuple is created which requires memory to be allocated upfront.
 
 In practice, tuples are created in Elixir using curly braces. Elements in a tuple can be individually accessed using the `elem/1` function using 0-based indexing:

--- a/concepts/tuples/introduction.md
+++ b/concepts/tuples/introduction.md
@@ -13,7 +13,7 @@ elem(multiple_element_tuple, 2)
 # => "hello"
 ```
 
-### Tuples as grouped information
+## Tuples as grouped information
 
 Tuples are often used in practice to represent grouped information.
 

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 [Elixir](http://elixir-lang.org/), initially released in 2012, extends upon the already robust features of Erlang while also being easier for beginners to access, read, test, and write.
 
 José Valim, the creator of Elixir, explains [here](https://vimeo.com/53221562) how he built the language for applications to be:

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,6 +1,6 @@
 # Installation
 
-### Installation
+## Installation
 
 Detailed installation instructions can be found at [http://elixir-lang.org/install.html](http://elixir-lang.org/install.html).
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 ### Installation
 
 Detailed installation instructions can be found at [http://elixir-lang.org/install.html](http://elixir-lang.org/install.html).

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 Exercism provides exercises and feedback but can be difficult to jump into for
 those learning Elixir for the first time. These resources can help you get
 started:

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 ## Elixir Documentation
 
 * [Elixir Docs](http://elixir-lang.org/docs.html)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,4 +1,4 @@
-## Running tests
+# Running tests
 
 From the terminal, change to the base directory of the problem then execute the tests with:
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -8,7 +8,7 @@ $ mix test
 
 This will execute the test file found in the `test` subfolder -- a file ending in `_test.exs`
 
-### Pending tests
+## Pending tests
 
 In the test suites, all but the first test have been skipped.
 
@@ -31,7 +31,7 @@ Or, you can enable all the tests by commenting out the
 # ExUnit.configure exclude: :pending, trace: true
 ```
 
-### Typespecs and Dialyzer (DIscrepancy AnalYZer for ERlang programs)
+## Typespecs and Dialyzer (DIscrepancy AnalYZer for ERlang programs)
 
 Elixir exercises include a skeleton implementation file in the `lib`
 subdirectory. This file outlines the module and functions that you are

--- a/exercises/concept/basketball-website/.docs/hints.md
+++ b/exercises/concept/basketball-website/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about the [`Access` behaviour][access-behaviour] in the documentation.

--- a/exercises/concept/basketball-website/.docs/instructions.md
+++ b/exercises/concept/basketball-website/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 You are working with a web development team to maintain a website for a local basketball team. The web development team is less familiar with Elixir and is asking for a function to be able to extract data from a series of nested maps to facilitate rapid development.
 
 ## 1. Extract data from a nested map structure

--- a/exercises/concept/basketball-website/.docs/introduction.md
+++ b/exercises/concept/basketball-website/.docs/introduction.md
@@ -1,4 +1,4 @@
-## Access Behaviour
+# Access Behaviour
 
 Elixir uses code _Behaviours_ to provide common generic interfaces while facilitating specific implementations for each module which implements it. One such common example is the _Access Behaviour_.
 

--- a/exercises/concept/basketball-website/.meta/design.md
+++ b/exercises/concept/basketball-website/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know of the access _behaviour_ (Note the UK spelling.)

--- a/exercises/concept/bird-count/.docs/hints.md
+++ b/exercises/concept/bird-count/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about recursion in the official [Getting Started guide][getting-started-recursion].

--- a/exercises/concept/bird-count/.docs/instructions.md
+++ b/exercises/concept/bird-count/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 You're an avid bird watcher that keeps track of how many birds have visited your garden on any given day.
 
 You decided to bring your bird watching to a new level and implement a few tools that will help you track and process the data.

--- a/exercises/concept/bird-count/.docs/introduction.md
+++ b/exercises/concept/bird-count/.docs/introduction.md
@@ -1,4 +1,4 @@
-## Recursion
+# Recursion
 
 Recursive functions are functions that call themselves.
 

--- a/exercises/concept/bird-count/.meta/design.md
+++ b/exercises/concept/bird-count/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know how write a recursive function.

--- a/exercises/concept/boutique-inventory/.docs/hints.md
+++ b/exercises/concept/boutique-inventory/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about the `Enum` module in the [official Getting Started guide][getting-started-enum] or on [elixirschool.com][elixir-school-enum].

--- a/exercises/concept/boutique-inventory/.docs/instructions.md
+++ b/exercises/concept/boutique-inventory/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 You are running an online fashion boutique. Your big annual sale is coming up, so you need to take stock of your inventory to make sure you're ready.
 
 A single item in the inventory is represented by a map, and the whole inventory is a list of such maps.

--- a/exercises/concept/boutique-inventory/.docs/introduction.md
+++ b/exercises/concept/boutique-inventory/.docs/introduction.md
@@ -1,4 +1,4 @@
-## Enum
+# Enum
 
 `Enum` is a very useful module that provides a set of algorithms for working with enumerables. It offers sorting, filtering, grouping, counting, searching, finding min/max values, and much more.
 

--- a/exercises/concept/boutique-inventory/.meta/design.md
+++ b/exercises/concept/boutique-inventory/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know about the `Enum` module.

--- a/exercises/concept/boutique-suggestions/.docs/hints.md
+++ b/exercises/concept/boutique-suggestions/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about [comprehensions][elixir-comprehensions] in the Getting Started guide.

--- a/exercises/concept/boutique-suggestions/.docs/instructions.md
+++ b/exercises/concept/boutique-suggestions/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 Your work at the online fashion boutique store continues. You come up with the idea for a website feature where an outfit is suggested to the user. While you want to give lots of suggestions, you don't want to give bad suggestions, so you decide to use a list comprehension since you can easily _generate_ outfit combinations, then _filter_ them by some criteria.
 
 Clothing items are stored as a map:

--- a/exercises/concept/boutique-suggestions/.docs/introduction.md
+++ b/exercises/concept/boutique-suggestions/.docs/introduction.md
@@ -1,4 +1,4 @@
-## List Comprehensions
+# List Comprehensions
 
 Comprehensions provide a facility for transforming _Enumerables_ easily and declaratively.
 

--- a/exercises/concept/boutique-suggestions/.meta/design.md
+++ b/exercises/concept/boutique-suggestions/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what a _comprehension_ is

--- a/exercises/concept/bread-and-potions/.docs/hints.md
+++ b/exercises/concept/bread-and-potions/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about protocols in the [official Getting Started guide][getting-started-protocols] or on [elixirschool.com][elixir-school-enum].

--- a/exercises/concept/bread-and-potions/.docs/instructions.md
+++ b/exercises/concept/bread-and-potions/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 You're developing your own role-playing video game. In your game, there are _characters_ and _items_. One of the many actions that you can do with an item is to make a character eat it.
 
 Not all items are edible, and not all edible items have the same effects on the character. Some items, when eaten, turn into a different item (e.g. if you eat an apple, you are left with an apple core).

--- a/exercises/concept/bread-and-potions/.docs/introduction.md
+++ b/exercises/concept/bread-and-potions/.docs/introduction.md
@@ -1,4 +1,4 @@
-## Protocols
+# Protocols
 
 Protocols are a mechanism to achieve polymorphism in Elixir when you want behavior to vary depending on the data type.
 

--- a/exercises/concept/bread-and-potions/.meta/design.md
+++ b/exercises/concept/bread-and-potions/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know how to write a protocol.

--- a/exercises/concept/captains-log/.docs/hints.md
+++ b/exercises/concept/captains-log/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about using Erlang libraries in the [official Getting Started guide][getting-started-erlang-libraries], and in particular about [formatting strings][getting-started-formatted-text-output].

--- a/exercises/concept/captains-log/.docs/instructions.md
+++ b/exercises/concept/captains-log/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 Mary is a big fan of the TV series _Star Trek: The Next Generation_. She often plays pen-and-paper role playing games, where she and her friends pretend to be the crew of the _Starship Enterprise_. Mary's character is Captain Picard, which means she has to keep the captain's log. She loves the creative part of the game, but doesn't like to generate random data on the spot.
 
 Help Mary by creating random generators for data commonly appearing in the captain's log.

--- a/exercises/concept/captains-log/.docs/introduction.md
+++ b/exercises/concept/captains-log/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Randomness
 
 In Elixir, to choose a random element from an enumerable data structure (e.g. list, range), we use `Enum.random`. This function will pick a single element, with every element having equal probability of being picked.

--- a/exercises/concept/captains-log/.meta/design.md
+++ b/exercises/concept/captains-log/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know how to call an Erlang function

--- a/exercises/concept/chessboard/.docs/hints.md
+++ b/exercises/concept/chessboard/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read the official documentation for [ranges][range].

--- a/exercises/concept/chessboard/.docs/instructions.md
+++ b/exercises/concept/chessboard/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 As a chess enthusiast, you would like to write your own version of the game. Yes, there maybe plenty of implementations of chess available online already, but yours will be unique!
 
 But before you can let your imagination run wild, you need to take care of the basics. Let's start by generating the board.

--- a/exercises/concept/chessboard/.docs/introduction.md
+++ b/exercises/concept/chessboard/.docs/introduction.md
@@ -1,4 +1,4 @@
-## Ranges
+# Ranges
 
 Ranges represent a sequence of one or many consecutive integers. They are created by connecting two integers with `..`.
 

--- a/exercises/concept/chessboard/.meta/design.md
+++ b/exercises/concept/chessboard/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know about ranges.

--- a/exercises/concept/community-garden/.docs/hints.md
+++ b/exercises/concept/community-garden/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about the [`Agent` module][getting-started-agent] in the Getting Started guide.

--- a/exercises/concept/community-garden/.docs/instructions.md
+++ b/exercises/concept/community-garden/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 Your community association has asked you to implement a simple registry application to manage the community garden registrations. The `Plot` struct has already been provided for you.
 
 ## 1. Open the garden

--- a/exercises/concept/community-garden/.docs/introduction.md
+++ b/exercises/concept/community-garden/.docs/introduction.md
@@ -1,4 +1,4 @@
-## Agent
+# Agent
 
 The `Agent` module facilitates an abstraction for spawning processes and the _receive-send_ loop. From here, we will call processes started using the `Agent` module _'agent processes'_. An _agent process_ might be chosen to represent a central shared state.
 

--- a/exercises/concept/community-garden/.meta/design.md
+++ b/exercises/concept/community-garden/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Review processes, send receive as a _raw_ form of an Agent

--- a/exercises/concept/date-parser/.docs/hints.md
+++ b/exercises/concept/date-parser/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Review regular expression patterns from the introduction. Remember, when creating the pattern a string, you must escape some characters.

--- a/exercises/concept/date-parser/.docs/instructions.md
+++ b/exercises/concept/date-parser/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 You have been tasked to write a service which ingests events. Each event has a date associated with it, but you notice that 3 different formats are being submitted to your service's endpoint:
 
 - `"01/01/1970"`

--- a/exercises/concept/date-parser/.docs/introduction.md
+++ b/exercises/concept/date-parser/.docs/introduction.md
@@ -1,4 +1,4 @@
-## Regular Expressions
+# Regular Expressions
 
 Regular expressions (regex) are a powerful tool for working with strings in Elixir. Regular expressions in Elixir follow the **PCRE** specification (**P**erl **C**ompatible **R**egular **E**xpressions). String patterns representing the regular expression's meaning are first compiled then used for matching all or part of a string.
 

--- a/exercises/concept/date-parser/.meta/design.md
+++ b/exercises/concept/date-parser/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Learn basic regular expression patterns

--- a/exercises/concept/dna-encoding/.docs/hints.md
+++ b/exercises/concept/dna-encoding/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Use `?` to work with the character [code points][codepoint].

--- a/exercises/concept/dna-encoding/.docs/instructions.md
+++ b/exercises/concept/dna-encoding/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In your DNA research lab, you have been working through various ways to compress your research data to save storage space. One teammate suggests converting the DNA data to a binary representation:
 
 | Nucleic Acid | Code   |

--- a/exercises/concept/dna-encoding/.docs/introduction.md
+++ b/exercises/concept/dna-encoding/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Bitstrings
 
 Working with binary data is an important concept in any language, and Elixir provides an elegant syntax to write, match, and construct binary data.

--- a/exercises/concept/dna-encoding/.meta/design.md
+++ b/exercises/concept/dna-encoding/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what a bitstring is

--- a/exercises/concept/file-sniffer/.docs/hints.md
+++ b/exercises/concept/file-sniffer/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Remember to reference the table in the instructions.

--- a/exercises/concept/file-sniffer/.docs/instructions.md
+++ b/exercises/concept/file-sniffer/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 You have been working on a project which allows users to upload files to the server to be shared with other users. You have been tasked with writing a function to verify that an upload matches its [media type][mimetype]. You do some research and discover that the first few bytes of a file are generally unique to that filetype, giving it a sort of signature.
 
 Use the following table for reference:

--- a/exercises/concept/file-sniffer/.docs/introduction.md
+++ b/exercises/concept/file-sniffer/.docs/introduction.md
@@ -14,7 +14,7 @@ Binary literals are defined using the bitstring special form `<<>>`. When defini
 
 A _null-byte_ is another name for `<<0>>`.
 
-### Pattern matching on binary data
+## Pattern matching on binary data
 
 Pattern matching is even extended to binaries, and we can pattern match on a portion of binary data much like we could for a list.
 

--- a/exercises/concept/file-sniffer/.docs/introduction.md
+++ b/exercises/concept/file-sniffer/.docs/introduction.md
@@ -1,4 +1,4 @@
-## Binaries
+# Binaries
 
 Elixir provides an elegant syntax for working with binary data as we have seen with the `<<>>` special form provided for working with _bitstrings_.
 

--- a/exercises/concept/file-sniffer/.meta/design.md
+++ b/exercises/concept/file-sniffer/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 After completing this exercise, the student should:

--- a/exercises/concept/freelancer-rates/.docs/hints.md
+++ b/exercises/concept/freelancer-rates/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about basic arithmetic in the official [Getting Started guide][getting-started-basic-arithmetic].

--- a/exercises/concept/freelancer-rates/.docs/instructions.md
+++ b/exercises/concept/freelancer-rates/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you'll be writing code to help a freelancer communicate with a project manager by providing a few utilities to quickly calculate daily and
 monthly rates, optionally with a given discount.
 

--- a/exercises/concept/freelancer-rates/.docs/introduction.md
+++ b/exercises/concept/freelancer-rates/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Integers
 
 There are two different kinds of numbers in Elixir - integers and floats.

--- a/exercises/concept/freelancer-rates/.meta/design.md
+++ b/exercises/concept/freelancer-rates/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know how to write floating point literals.

--- a/exercises/concept/german-sysadmin/.docs/hints.md
+++ b/exercises/concept/german-sysadmin/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about [charlists][getting-started-charlists], [Unicode and code points][getting-started-code-points], and [`case`][getting-started-case] in the official Getting Started guide.

--- a/exercises/concept/german-sysadmin/.docs/instructions.md
+++ b/exercises/concept/german-sysadmin/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 You are working as a system administrator for a big company in Münich, Germany. One of your responsibilities is managing email accounts.
 
 You have been hearing complaints from people saying they are unable to write emails to Mr. Müller. You quickly realize that most of the company uses an old email client that doesn't recognize `müller@firma.de` as a valid email address because of the non-latin character.

--- a/exercises/concept/german-sysadmin/.docs/introduction.md
+++ b/exercises/concept/german-sysadmin/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Charlists
 
 Charlists are created using single quotes.

--- a/exercises/concept/german-sysadmin/.meta/design.md
+++ b/exercises/concept/german-sysadmin/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 After completing this exercise, the student should:

--- a/exercises/concept/guessing-game/.docs/hints.md
+++ b/exercises/concept/guessing-game/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - In Elixir's ['Getting Started Guide'][guide] there is a nice refresher about named functions.

--- a/exercises/concept/guessing-game/.docs/instructions.md
+++ b/exercises/concept/guessing-game/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 You are creating a trivial online game where a friend can guess a secret number. You want to give some feedback, but not give away the answer with a guess. You need to devise a function to provide different responses depending on how the guess relates to the secret number.
 
 | Condition                                                     | Response       |

--- a/exercises/concept/guessing-game/.docs/introduction.md
+++ b/exercises/concept/guessing-game/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Multiple Clause Functions
 
 Elixir facilitates **Open-Close Principle** practices by allowing functions to have multiple clauses, so instead of sprawling and hard-coded control-logic, pointed functions can be written to add/remove behavior easily.

--- a/exercises/concept/guessing-game/.meta/design.md
+++ b/exercises/concept/guessing-game/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 A student upon completion will:

--- a/exercises/concept/high-school-sweetheart/.docs/hints.md
+++ b/exercises/concept/high-school-sweetheart/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about strings in the official [Getting Started guide][getting-started-strings].

--- a/exercises/concept/high-school-sweetheart/.docs/instructions.md
+++ b/exercises/concept/high-school-sweetheart/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise, you are going to help high school sweethearts profess their love on social media by generating an ASCII heart with their initials:
 
 ```

--- a/exercises/concept/high-school-sweetheart/.docs/introduction.md
+++ b/exercises/concept/high-school-sweetheart/.docs/introduction.md
@@ -1,4 +1,4 @@
-## Strings
+# Strings
 
 Strings in Elixir are delimited by double quotes, and they are encoded in UTF-8:
 

--- a/exercises/concept/high-school-sweetheart/.meta/design.md
+++ b/exercises/concept/high-school-sweetheart/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 After completing this exercise, the student should:

--- a/exercises/concept/high-score/.docs/hints.md
+++ b/exercises/concept/high-score/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - A [map][maps] is an associative data structure of key-value pairs.

--- a/exercises/concept/high-score/.docs/instructions.md
+++ b/exercises/concept/high-score/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise, you're implementing a way to keep track of the high scores for the most popular game in your local arcade hall.
 
 ## 1. Define a new high score map

--- a/exercises/concept/high-score/.docs/introduction.md
+++ b/exercises/concept/high-score/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Maps
 
 Maps in Elixir are the data structure for storing information in key-value pairs. In other languages, these might also be known as associative arrays (PHP), hashes (Perl 5, Raku), or dictionaries (Python).

--- a/exercises/concept/high-score/.meta/design.md
+++ b/exercises/concept/high-score/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what a map is.

--- a/exercises/concept/kitchen-calculator/.docs/hints.md
+++ b/exercises/concept/kitchen-calculator/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - [Tuples][tuple-module] are data structures which are arranged in contiguous memory and can hold any data-type.

--- a/exercises/concept/kitchen-calculator/.docs/instructions.md
+++ b/exercises/concept/kitchen-calculator/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 While preparing to bake cookies for your friends, you have found that you have to convert some of the ingredients used in the recipe for your friends. Being only familiar with the metric system, you need to come up with a way to convert common US baking measurements to milliliters (mL) for your own ease.
 
 Use this conversion chart for your solution:

--- a/exercises/concept/kitchen-calculator/.docs/introduction.md
+++ b/exercises/concept/kitchen-calculator/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Tuples
 
 In Elixir, a tuple is a data structure which organizes data, holding a fixed number of items of any type, but without explicit names for each element. Tuples are often used in Elixir for memory read-intensive operations, since read-access of an element is a constant-time operation. They are not usually used when elements may need to be added/removed dynamically because rather than modifying the existing tuple, a new tuple is created which requires memory to be allocated upfront.

--- a/exercises/concept/kitchen-calculator/.meta/design.md
+++ b/exercises/concept/kitchen-calculator/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what a tuple is

--- a/exercises/concept/language-list/.docs/hints.md
+++ b/exercises/concept/language-list/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Use the built-in [(linked) list type][list].

--- a/exercises/concept/language-list/.docs/instructions.md
+++ b/exercises/concept/language-list/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you need to implement some functions to manipulate a list of programming languages.
 
 ## 1. Define a function to return an empty language list

--- a/exercises/concept/language-list/.docs/introduction.md
+++ b/exercises/concept/language-list/.docs/introduction.md
@@ -1,4 +1,4 @@
-## Lists
+# Lists
 
 Lists are built-in to the Elixir language. They are considered a basic type, denoted by square brackets. Lists may be empty or hold any number of items of any type. For example:
 

--- a/exercises/concept/language-list/.meta/design.md
+++ b/exercises/concept/language-list/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know of the existence of the `list` type.

--- a/exercises/concept/lasagna/.docs/hints.md
+++ b/exercises/concept/lasagna/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - An [integer value][integers] can be defined as one or more consecutive digits.

--- a/exercises/concept/lasagna/.docs/instructions.md
+++ b/exercises/concept/lasagna/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you're going to write some code to help you cook a brilliant lasagna from your favorite cooking book.
 
 You have five tasks, all related to the time spent cooking the lasagna.

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -11,7 +11,7 @@ count = false # You may re-bind any type to a variable
 message = "Success!" # Strings can be created by enclosing characters within double quotes
 ```
 
-### Modules
+## Modules
 
 Elixir is an [functional-programming language][functional-programming] and requires all named functions to be defined in a _module_. The `defmodule` keyword is used to define a module. All modules are available to all other modules at runtime and do not require an _access modifier_ to make them visible to other parts of the program. A _module_ is analogous to a _class_ in other programming languages.
 
@@ -21,7 +21,7 @@ defmodule Calculator do
 end
 ```
 
-### Named functions
+## Named functions
 
 _Named Functions_ must be defined in a module. Each function can have zero or more arguments. All arguments are dynamically-typed, and the return type is not explicitly declared, it is the type of the value returned. An _access modifier_ can be specified for functions, making only desired functions available for use external to the module. In a function, the value of the last line is _implicitly returned_ to the calling function.
 
@@ -44,7 +44,7 @@ sum = Calculator.short_add(2, 2)
 # => 4
 ```
 
-### Arity of functions
+## Arity of functions
 
 It is common to refer to functions with their _arity_. The _arity_ of a function is the number of arguments it accepts.
 
@@ -55,7 +55,7 @@ def add(x, y, z) do
 end
 ```
 
-### Standard library
+## Standard library
 
 Elixir has a very rich and well-documented standard library. The documentation is available online at [hexdocs.pm/elixir][docs]. Save this link somewhere - you will use it a lot!
 
@@ -63,7 +63,7 @@ Most built-in data types have a corresponding module that offers functions for w
 
 A notable module is the `Kernel` module. It provides the basic capabilities on top of which the rest of the standard library is built, like arithmetic operators, control-flow macros, and much more. Functions for the `Kernel` module are automatically imported, so you can use them without the `Kernel.` prefix.
 
-### Documentation
+## Documentation
 
 Documentation is a priority in high-quality Elixir code bases, and there are 3 ways to write inline documentation:
 

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -1,4 +1,4 @@
-## Basics
+# Basics
 
 Elixir is a dynamically-typed language, meaning that the type of a variable is only checked at runtime. Using the match `=` operator, we can bind a value of any type to a variable name:
 

--- a/exercises/concept/lasagna/.meta/design.md
+++ b/exercises/concept/lasagna/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what a variable is.

--- a/exercises/concept/log-level/.docs/hints.md
+++ b/exercises/concept/log-level/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - The [atom type is described here][atom].

--- a/exercises/concept/log-level/.docs/instructions.md
+++ b/exercises/concept/log-level/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 You are running a system that consist of a few applications producing many logs. You want to write a small program that will aggregate those logs and give them labels according to their severity level. All applications in your system use the same log codes, but some of the legacy applications don't support all the codes.
 
 | Log code | Log label | Supported in legacy apps? |

--- a/exercises/concept/log-level/.docs/introduction.md
+++ b/exercises/concept/log-level/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Atoms
 
 Elixir's `atom` type represents a fixed constant. An atom's value is simply its own name. This gives us a type-safe way to interact with data. Atoms can be defined as follows:

--- a/exercises/concept/log-level/.meta/design.md
+++ b/exercises/concept/log-level/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 After completing this exercise, the student should:

--- a/exercises/concept/mensch-aergere-dich-nicht/.docs/hints.md
+++ b/exercises/concept/mensch-aergere-dich-nicht/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about enumerables and streams in the [official Getting Started guide][getting-started-streams].

--- a/exercises/concept/mensch-aergere-dich-nicht/.docs/instructions.md
+++ b/exercises/concept/mensch-aergere-dich-nicht/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 While planning a games night with friends, the group decides they will revisit their childhood favorites. Your German friend proposes _Mensch ärgere Dich nicht_ (_Man, Don't Get Angry_), a classic in many European countries (similar to the English _Ludo_ or the North American _Parcheesi_).
 
 To prepare for the game, you decide to implement the dice rolling function in Elixir.

--- a/exercises/concept/mensch-aergere-dich-nicht/.docs/introduction.md
+++ b/exercises/concept/mensch-aergere-dich-nicht/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Pipe Operator
 
 The `|>` operator is called the pipe operator. It can be used to chain function calls together in such a way that the value returned by the previous function call is passed as the first argument to the next function call.

--- a/exercises/concept/mensch-aergere-dich-nicht/.meta/design.md
+++ b/exercises/concept/mensch-aergere-dich-nicht/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know about the `|>` pipe operator for chaining function calls.

--- a/exercises/concept/name-badge/.docs/hints.md
+++ b/exercises/concept/name-badge/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about `if` in the official [Getting Started guide][getting-started-if-unless] or on [elixirschool.com][elixirschool-if-unless].

--- a/exercises/concept/name-badge/.docs/instructions.md
+++ b/exercises/concept/name-badge/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you'll be writing code to print name badges for factory employees. Employees have an ID, name, and department name. Employee badge labels are formatted as follows: `"[id] - [name] - [DEPARTMENT]"`.
 
 ## 1. Print a badge for an employee

--- a/exercises/concept/name-badge/.docs/introduction.md
+++ b/exercises/concept/name-badge/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Nil
 
 [Nil][nil-dictionary] is an English word meaning "nothing" or "zero". In Elixir, `nil` is a special value that means an _absence_ of a value.

--- a/exercises/concept/name-badge/.meta/design.md
+++ b/exercises/concept/name-badge/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what `nil` represents

--- a/exercises/concept/newsletter/.docs/hints.md
+++ b/exercises/concept/newsletter/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## 1. General
 
 - Read about files in the official [Getting Started guide][getting-started-file].

--- a/exercises/concept/newsletter/.docs/instructions.md
+++ b/exercises/concept/newsletter/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 You're a big model train enthusiast and have decided to share your passion with the world by starting a newsletter. You'll start by sending the first issue of your newsletter to your friends and acquaintances that share your hobby. You have a text file with a list of their email addresses.
 
 ## 1. Read email addresses from a file

--- a/exercises/concept/newsletter/.docs/introduction.md
+++ b/exercises/concept/newsletter/.docs/introduction.md
@@ -1,4 +1,4 @@
-## File
+# File
 
 Functions for working with files are provided by the `File` module.
 

--- a/exercises/concept/newsletter/.meta/design.md
+++ b/exercises/concept/newsletter/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know about the `File` module

--- a/exercises/concept/pacman-rules/.docs/hints.md
+++ b/exercises/concept/pacman-rules/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Don't worry about how the arguments are derived, just focus on combining the arguments to return the intended result.

--- a/exercises/concept/pacman-rules/.docs/instructions.md
+++ b/exercises/concept/pacman-rules/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise, you need to translate some rules from the classic game Pac-Man into Elixir functions.
 
 You have four rules to translate, all related to the game states.

--- a/exercises/concept/pacman-rules/.docs/introduction.md
+++ b/exercises/concept/pacman-rules/.docs/introduction.md
@@ -1,4 +1,4 @@
-## Booleans
+# Booleans
 
 Elixir represents true and false values with the boolean type. There are only two values: _true_ and _false_. These values can be bound to a variable:
 

--- a/exercises/concept/pacman-rules/.meta/design.md
+++ b/exercises/concept/pacman-rules/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what a variable is.

--- a/exercises/concept/remote-control-car/.docs/hints.md
+++ b/exercises/concept/remote-control-car/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about [structs][getting-started-structs] in the Getting Started guide.

--- a/exercises/concept/remote-control-car/.docs/instructions.md
+++ b/exercises/concept/remote-control-car/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you'll be playing around with a remote controlled car, which you've finally saved enough money for to buy.
 
 Cars start with full (100%) batteries. Each time you drive the car using the remote control, it covers 20 meters and drains one percent of the battery. The car's nickname is not known until it is created.

--- a/exercises/concept/remote-control-car/.docs/introduction.md
+++ b/exercises/concept/remote-control-car/.docs/introduction.md
@@ -11,7 +11,7 @@ plane = %Plane{}
 # => %Plane{engine: nil, wings: 2}
 ```
 
-### Accessing fields and updating
+## Accessing fields and updating
 
 Since structs are built on maps, we can use most map functions to get and manipulate values. The _Access Behaviour_ is **not** implemented for structs. It is recommended to use the _static access operator_ `.` to access struct fields instead.
 
@@ -33,7 +33,7 @@ Since structs are built on maps, we can use most map functions to get and manipu
   # => %Plane{engine: nil, wings: 4}
   ```
 
-### Enforcing field value initialization
+## Enforcing field value initialization
 
 We can use the `@enforce_keys` module attribute with a list of the field keys to ensure that the values are initialized when the struct is created. If a key is not listed, its value will be `nil` as seen in the above example. If an enforced key is not initialized, an error is raised.
 

--- a/exercises/concept/remote-control-car/.docs/introduction.md
+++ b/exercises/concept/remote-control-car/.docs/introduction.md
@@ -1,4 +1,4 @@
-## Structs
+# Structs
 
 Structs are an extension built on top of maps which provide compile-time checks and default values. A struct is named after the module it is defined in. To define a struct use the `defstruct` construct. The construct usually immediately follows after the module definition. `defstruct` accepts either a list of atoms (for `nil` default values) or key-value tuples (for specified default values). The fields without defaults must precede the fields with default values.
 

--- a/exercises/concept/remote-control-car/.meta/design.md
+++ b/exercises/concept/remote-control-car/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what a struct is

--- a/exercises/concept/rpg-character-sheet/.docs/hints.md
+++ b/exercises/concept/rpg-character-sheet/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about [IO][getting-started-io] in the Getting Started guide.

--- a/exercises/concept/rpg-character-sheet/.docs/instructions.md
+++ b/exercises/concept/rpg-character-sheet/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 You and your friends love to play pen-and-paper role-playing games, but you noticed that it's difficult to get new people to join your group. They often struggle with character creation. They don't know where to start. To help new players out, you decided to write a small program that will guide them through the process.
 
 ## 1. Welcome the new player

--- a/exercises/concept/rpg-character-sheet/.docs/introduction.md
+++ b/exercises/concept/rpg-character-sheet/.docs/introduction.md
@@ -1,4 +1,4 @@
-## IO
+# IO
 
 Functions for handling input and output are provided by the `IO` module.
 

--- a/exercises/concept/rpg-character-sheet/.docs/introduction.md
+++ b/exercises/concept/rpg-character-sheet/.docs/introduction.md
@@ -2,7 +2,7 @@
 
 Functions for handling input and output are provided by the `IO` module.
 
-### Output
+## Output
 
 To write a string to the standard output, use `IO.puts`. `IO.puts` always adds a new line at the end of the string. If you don't want that behavior, use `IO.write` instead. Both functions return the atom `:ok` if they succeed.
 
@@ -14,7 +14,7 @@ IO.puts("Hi!")
 
 `IO.puts` is useful for writing strings, but not much else. If you need a tool for debugging that will allow you to write any value to standard output, use `IO.inspect` instead. `IO.inspect` returns the value it was passed unchanged, so it can be inserted in any point in your code. It also accepts many options, for example `:label`, that will allow you to distinguish it form other `IO.inspect` calls.
 
-### Input
+## Input
 
 To read a line from the standard input, use `IO.gets`. `IO.gets` accepts one argument - a string that it will print as a prompt for the input. `IO.gets` doesn't add a new line after the prompt, you need it include it yourself if you need it.
 

--- a/exercises/concept/rpg-character-sheet/.meta/design.md
+++ b/exercises/concept/rpg-character-sheet/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know how to write a string to stdio or stderr

--- a/exercises/concept/rpn-calculator-output/.docs/hints.md
+++ b/exercises/concept/rpn-calculator-output/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about [errors][getting-started-errors] in the Getting Started guide.

--- a/exercises/concept/rpn-calculator-output/.docs/instructions.md
+++ b/exercises/concept/rpn-calculator-output/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 Work is progressing well at _Instruments of Texas_ on the RPN Calculator. Your team now wants to be able to write a string version of the equation to an _IO_ resource.
 
 ## 1. Open a file

--- a/exercises/concept/rpn-calculator-output/.docs/introduction.md
+++ b/exercises/concept/rpn-calculator-output/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Try Rescue Else After
 
 Using `try..rescue` is a powerful construct for catching errors when they occur. Rescuing errors allows functions to return defined values when it is necessary. The `try..rescue` construct also offers us two additional features we can make use of:

--- a/exercises/concept/rpn-calculator-output/.meta/design.md
+++ b/exercises/concept/rpn-calculator-output/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know of `try..rescue`'s additional options:

--- a/exercises/concept/rpn-calculator/.docs/hints.md
+++ b/exercises/concept/rpn-calculator/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about [errors][errors] in the Getting Started guide.

--- a/exercises/concept/rpn-calculator/.docs/instructions.md
+++ b/exercises/concept/rpn-calculator/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 While working at _Instruments of Texas_, you are tasked to work on an experimental calculator written in Elixir. Your team is having a problem with some operations raising errors and crashing the process. You have been tasked to write a function which wraps the operation function so that the errors can be handled more elegantly with idiomatic Elixir code.
 
 ## 1. Warn the team

--- a/exercises/concept/rpn-calculator/.docs/introduction.md
+++ b/exercises/concept/rpn-calculator/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Errors
 
 Errors happen. In Elixir, while people often say to "let it crash", there are times when we need to rescue the function call to a known good state to fulfil a software contract. In some languages, errors are used as method of control flow, but in Elixir, this pattern is discouraged. We can often recognize functions that may raise an error just by their name: functions that raise errors are to have `!` at the end of their name. This is in comparison with functions that return `{:ok, value}` or `:error`. Look at these library examples:

--- a/exercises/concept/rpn-calculator/.meta/design.md
+++ b/exercises/concept/rpn-calculator/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what an error is

--- a/exercises/concept/secrets/.docs/hints.md
+++ b/exercises/concept/secrets/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Make use of [anonymous functions][anon-fns].

--- a/exercises/concept/secrets/.docs/instructions.md
+++ b/exercises/concept/secrets/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise, you've been tasked with writing the software for an encryption device that works by performing transformations on data. You need a way to flexibly create complicated functions by combining simpler functions together.
 
 For each task, make use of a closure and return a function that can be invoked from the calling scope.

--- a/exercises/concept/secrets/.docs/introduction.md
+++ b/exercises/concept/secrets/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Anonymous Functions
 
 Functions are treated as first class citizens in Elixir. This means functions:

--- a/exercises/concept/secrets/.meta/design.md
+++ b/exercises/concept/secrets/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 After completing this exercise, the student should:

--- a/exercises/concept/stack-underflow/.docs/hints.md
+++ b/exercises/concept/stack-underflow/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about [errors][getting-started-errors] in the Getting Started guide.

--- a/exercises/concept/stack-underflow/.docs/instructions.md
+++ b/exercises/concept/stack-underflow/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 While continuing your work at _Instruments of Texas_, there is progress being made on the Elixir implementation of the RPN calculator. Your team would like to be able to raise errors that are more specific than the generic errors provided by the standard library. You are doing some research, but you have decided to implement two new errors which implement the _Exception Behaviour_.
 
 ## 1. Error for Division by Zero

--- a/exercises/concept/stack-underflow/.docs/introduction.md
+++ b/exercises/concept/stack-underflow/.docs/introduction.md
@@ -9,7 +9,7 @@ All errors in Elixir implement the _Exception Behaviour_. Just like the _Access 
 
 The _Exception Behaviour_ also specifies two callbacks: `message/1` and `exception/1`. If unimplemented, default implementations will be used. `message/1` transforms the error-struct to a readable message when called with `raise`. `exception/1` allows additional context to be added to the message when it is called with `raise/2`
 
-### Defining an exception
+## Defining an exception
 
 To define an exception from an error module, we use the `defexception` macro:
 
@@ -35,7 +35,7 @@ defmodule MyCustomizedError do
 end
 ```
 
-### Using exceptions
+## Using exceptions
 
 Defined errors may be used like a built in error using either `raise/1` or `raise/2`.
 

--- a/exercises/concept/stack-underflow/.docs/introduction.md
+++ b/exercises/concept/stack-underflow/.docs/introduction.md
@@ -1,4 +1,4 @@
-## Exceptions
+# Exceptions
 
 All errors in Elixir implement the _Exception Behaviour_. Just like the _Access Behaviour_, the _Exception Behaviour_ defines callback functions that a module must implement to fulfill the software contract of the behaviour. Once an error is defined, it has the following properties:
 

--- a/exercises/concept/stack-underflow/.meta/design.md
+++ b/exercises/concept/stack-underflow/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what the _Exception behaviour_ is

--- a/exercises/concept/take-a-number/.docs/hints.md
+++ b/exercises/concept/take-a-number/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about processes in the official [Getting Started guide][getting-started-processes].

--- a/exercises/concept/take-a-number/.docs/instructions.md
+++ b/exercises/concept/take-a-number/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 You are writing an embedded system for a Take-A-Number machine. It is a very simple model. It can give out consecutive numbers and report what was the last number given out.
 
 ## 1. Start the machine

--- a/exercises/concept/take-a-number/.docs/introduction.md
+++ b/exercises/concept/take-a-number/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Processes
 
 In Elixir, all code runs inside processes.

--- a/exercises/concept/take-a-number/.meta/design.md
+++ b/exercises/concept/take-a-number/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know what a process is.

--- a/exercises/concept/wine-cellar/.docs/hints.md
+++ b/exercises/concept/wine-cellar/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Read about keyword lists in the official [Getting Started guide][getting-started-keyword-lists].

--- a/exercises/concept/wine-cellar/.docs/instructions.md
+++ b/exercises/concept/wine-cellar/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 You are the manager of a fancy restaurant that has a sizable wine cellar. A lot of your customers are demanding wine enthusiasts. Finding the right bottle of wine for a particular customer is not an easy task.
 
 As a tech-savvy restaurant owner, you decided to speed up the wine selection process by writing an app that will let guests filter your wines by their preferences.

--- a/exercises/concept/wine-cellar/.docs/introduction.md
+++ b/exercises/concept/wine-cellar/.docs/introduction.md
@@ -1,4 +1,4 @@
-## Keyword Lists
+# Keyword Lists
 
 Keyword lists are a key-value data structure.
 

--- a/exercises/concept/wine-cellar/.meta/design.md
+++ b/exercises/concept/wine-cellar/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know that keyword lists are key-value storage.

--- a/exercises/practice/diffie-hellman/.docs/hints.md
+++ b/exercises/practice/diffie-hellman/.docs/hints.md
@@ -1,4 +1,4 @@
-## General
+# General
 
 - For generating random numbers, Erlang's `:rand.uniform` or `Enum.random` are
 good places to start.

--- a/exercises/practice/secret-handshake/.docs/hints.md
+++ b/exercises/practice/secret-handshake/.docs/hints.md
@@ -1,4 +1,4 @@
-## General
+# General
 
 - Use `Bitwise` (or div/rem).
 - If you use `Bitwise`, an easy way to see if a particular bit is set is to compare

--- a/exercises/practice/strain/.docs/hints.md
+++ b/exercises/practice/strain/.docs/hints.md
@@ -1,3 +1,3 @@
-## General
+# General
 
 - `apply` will let you pass arguments to a function, as will `fun.(args)`.

--- a/exercises/practice/tournament/.docs/hints.md
+++ b/exercises/practice/tournament/.docs/hints.md
@@ -1,4 +1,4 @@
-## General
+# General
 
 - Formatting the output is easy with `String`'s padding functions. All number
 columns can be left-padded with spaces to a width of 2 characters, while the

--- a/exercises/practice/zipper/hints/README.md
+++ b/exercises/practice/zipper/hints/README.md
@@ -1,2 +1,4 @@
+# Readme
+
 This directory contains some hints to help you complete this exercise. The
 higher the number of a hint file, the most explicit the hint.

--- a/exercises/practice/zipper/hints/hint_1.md
+++ b/exercises/practice/zipper/hints/hint_1.md
@@ -1,1 +1,3 @@
+# hint 1
+
 The difficult part is not getting there but remembering how you got there.

--- a/exercises/practice/zipper/hints/hint_2.md
+++ b/exercises/practice/zipper/hints/hint_2.md
@@ -1,2 +1,4 @@
+# hint 2
+
 Keep a trail of what choices you made. Be sure to include alternative branches,
 lest you forget them.

--- a/exercises/practice/zipper/hints/hint_3.md
+++ b/exercises/practice/zipper/hints/hint_3.md
@@ -1,3 +1,5 @@
+# hint 3
+
 ```elixir
 @type trail :: { :left, any, BinTree.t, trail }
              | { :right, any, BinTree.t, trail }


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
