### PR TITLE
Fix `all-your-base` spec

### DIFF
--- a/exercises/practice/all-your-base/.meta/example.ex
+++ b/exercises/practice/all-your-base/.meta/example.ex
@@ -4,7 +4,7 @@ defmodule AllYourBase do
   or returns nil if either of the bases are less than 2
   """
 
-  @spec convert(list, integer, integer) :: list
+  @spec convert(list, integer, integer) :: {:ok, list} | {:error, String.t()}
   def convert(_, _, output_base) when output_base < 2 do
     {:error, "output base must be >= 2"}
   end
@@ -15,7 +15,7 @@ defmodule AllYourBase do
 
   def convert(digits, input_base, output_base) do
     if Enum.all?(digits, &(0 <= &1 && &1 < input_base)) do
-      do_convert(digits, input_base, output_base)
+      {:ok, do_convert(digits, input_base, output_base)}
     else
       {:error, "all digits must be >= 0 and < input base"}
     end

--- a/exercises/practice/all-your-base/lib/all_your_base.ex
+++ b/exercises/practice/all-your-base/lib/all_your_base.ex
@@ -1,10 +1,10 @@
 defmodule AllYourBase do
   @doc """
-  Given a number in base a, represented as a sequence of digits, converts it to base b,
-  or returns nil if either of the bases are less than 2
+  Given a number in input base, represented as a sequence of digits, converts it to output base,
+  or returns an error tuple if either of the bases are less than 2
   """
 
-  @spec convert(list, integer, integer) :: list | nil
+  @spec convert(list, integer, integer) :: {:ok, list} | {:error, String.t()}
   def convert(digits, input_base, output_base) do
   end
 end

--- a/exercises/practice/all-your-base/test/all_your_base_test.exs
+++ b/exercises/practice/all-your-base/test/all_your_base_test.exs
@@ -2,62 +2,62 @@ defmodule AllYourBaseTest do
   use ExUnit.Case
 
   test "convert single bit one to decimal" do
-    assert AllYourBase.convert([1], 2, 10) == [1]
+    assert AllYourBase.convert([1], 2, 10) == {:ok, [1]}
   end
 
   @tag :pending
   test "convert binary to single decimal" do
-    assert AllYourBase.convert([1, 0, 1], 2, 10) == [5]
+    assert AllYourBase.convert([1, 0, 1], 2, 10) == {:ok, [5]}
   end
 
   @tag :pending
   test "convert single decimal to binary" do
-    assert AllYourBase.convert([5], 10, 2) == [1, 0, 1]
+    assert AllYourBase.convert([5], 10, 2) == {:ok, [1, 0, 1]}
   end
 
   @tag :pending
   test "convert binary to multiple decimal" do
-    assert AllYourBase.convert([1, 0, 1, 0, 1, 0], 2, 10) == [4, 2]
+    assert AllYourBase.convert([1, 0, 1, 0, 1, 0], 2, 10) == {:ok, [4, 2]}
   end
 
   @tag :pending
   test "convert decimal to binary" do
-    assert AllYourBase.convert([4, 2], 10, 2) == [1, 0, 1, 0, 1, 0]
+    assert AllYourBase.convert([4, 2], 10, 2) == {:ok, [1, 0, 1, 0, 1, 0]}
   end
 
   @tag :pending
   test "convert trinary to hexadecimal" do
-    assert AllYourBase.convert([1, 1, 2, 0], 3, 16) == [2, 10]
+    assert AllYourBase.convert([1, 1, 2, 0], 3, 16) == {:ok, [2, 10]}
   end
 
   @tag :pending
   test "convert hexadecimal to trinary" do
-    assert AllYourBase.convert([2, 10], 16, 3) == [1, 1, 2, 0]
+    assert AllYourBase.convert([2, 10], 16, 3) == {:ok, [1, 1, 2, 0]}
   end
 
   @tag :pending
   test "convert 15-bit integer" do
-    assert AllYourBase.convert([3, 46, 60], 97, 73) == [6, 10, 45]
+    assert AllYourBase.convert([3, 46, 60], 97, 73) == {:ok, [6, 10, 45]}
   end
 
   @tag :pending
   test "convert empty list" do
-    assert AllYourBase.convert([], 2, 10) == [0]
+    assert AllYourBase.convert([], 2, 10) == {:ok, [0]}
   end
 
   @tag :pending
   test "convert single zero" do
-    assert AllYourBase.convert([0], 10, 2) == [0]
+    assert AllYourBase.convert([0], 10, 2) == {:ok, [0]}
   end
 
   @tag :pending
   test "convert multiple zeros" do
-    assert AllYourBase.convert([0, 0, 0], 10, 2) == [0]
+    assert AllYourBase.convert([0, 0, 0], 10, 2) == {:ok, [0]}
   end
 
   @tag :pending
   test "convert leading zeros" do
-    assert AllYourBase.convert([0, 6, 0], 7, 10) == [4, 2]
+    assert AllYourBase.convert([0, 6, 0], 7, 10) == {:ok, [4, 2]}
   end
 
   @tag :pending


### PR DESCRIPTION
In https://github.com/exercism/elixir/pull/597, I committed changes to `all-your-base` that changed its return value and input arguments, but I forgot to update the spec or the comment. I also realized that if a function returns an error tuple on failure, it should return an ok tuple on success instead of the plain value.

We have dialyzer running on CI... if it doesn't catch those problems, I'm not sure what it's doing?