### PR TITLE
`dates-and-time` - fix about.md h1

### DIFF
--- a/concepts/dates-and-time/about.md
+++ b/concepts/dates-and-time/about.md
@@ -1,4 +1,4 @@
-# Introduction
+# About
 
 Elixir's standard library offers 4 different modules for working with dates and time, each with its own struct.
 


### PR DESCRIPTION
The concept causes exercism.lol to crash for some reason. This is the only error that I found, but I doubt that this is the reason.