### PR TITLE
Fix bowling typespecs

### DIFF
--- a/exercises/practice/bowling/.meta/example.ex
+++ b/exercises/practice/bowling/.meta/example.ex
@@ -25,7 +25,7 @@ defmodule Bowling do
         {:error, "Cannot roll after game is over"}
 
       valid_updates?(updates) ->
-        updates
+        {:ok, updates}
 
       true ->
         {:error, "Pin count exceeds pins on the lane"}
@@ -67,7 +67,7 @@ defmodule Bowling do
         {:error, "Score cannot be taken until the end of the game"}
 
       true ->
-        parse_scores(game.scores)
+        {:ok, parse_scores(game.scores)}
     end
   end
 

--- a/exercises/practice/bowling/lib/bowling.ex
+++ b/exercises/practice/bowling/lib/bowling.ex
@@ -11,19 +11,19 @@ defmodule Bowling do
   @doc """
     Records the number of pins knocked down on a single roll. Returns `any`
     unless there is something wrong with the given number of pins, in which
-    case it returns a helpful message.
+    case it returns a helpful error tuple.
   """
 
-  @spec roll(any, integer) :: any | String.t()
+  @spec roll(any, integer) :: {:ok, any} | {:error, String.t()}
   def roll(game, roll) do
   end
 
   @doc """
     Returns the score of a given game of bowling if the game is complete.
-    If the game isn't complete, it returns a helpful message.
+    If the game isn't complete, it returns a helpful error tuple.
   """
 
-  @spec score(any) :: integer | String.t()
+  @spec score(any) :: {:ok, integer} | {:error, String.t()}
   def score(game) do
   end
 end

--- a/exercises/practice/bowling/test/bowling_test.exs
+++ b/exercises/practice/bowling/test/bowling_test.exs
@@ -2,14 +2,17 @@ defmodule BowlingTest do
   use ExUnit.Case
 
   defp roll_reduce(game, rolls) do
-    Enum.reduce(rolls, game, fn roll, game -> Bowling.roll(game, roll) end)
+    Enum.reduce(rolls, game, fn roll, game ->
+      {:ok, game} = Bowling.roll(game, roll)
+      game
+    end)
   end
 
   test "should be able to score a game with all zeros" do
     game = Bowling.start()
     rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     game = roll_reduce(game, rolls)
-    assert Bowling.score(game) == 0
+    assert Bowling.score(game) == {:ok, 0}
   end
 
   @tag :pending
@@ -17,7 +20,7 @@ defmodule BowlingTest do
     game = Bowling.start()
     rolls = [3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6]
     game = roll_reduce(game, rolls)
-    assert Bowling.score(game) == 90
+    assert Bowling.score(game) == {:ok, 90}
   end
 
   @tag :pending
@@ -25,7 +28,7 @@ defmodule BowlingTest do
     game = Bowling.start()
     rolls = [6, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     game = roll_reduce(game, rolls)
-    assert Bowling.score(game) == 10
+    assert Bowling.score(game) == {:ok, 10}
   end
 
   @tag :pending
@@ -33,7 +36,7 @@ defmodule BowlingTest do
     game = Bowling.start()
     rolls = [6, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     game = roll_reduce(game, rolls)
-    assert Bowling.score(game) == 16
+    assert Bowling.score(game) == {:ok, 16}
   end
 
   @tag :pending
@@ -41,7 +44,7 @@ defmodule BowlingTest do
     game = Bowling.start()
     rolls = [5, 5, 3, 7, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     game = roll_reduce(game, rolls)
-    assert Bowling.score(game) == 31
+    assert Bowling.score(game) == {:ok, 31}
   end
 
   @tag :pending
@@ -49,7 +52,7 @@ defmodule BowlingTest do
     game = Bowling.start()
     rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 7]
     game = roll_reduce(game, rolls)
-    assert Bowling.score(game) == 17
+    assert Bowling.score(game) == {:ok, 17}
   end
 
   @tag :pending
@@ -57,7 +60,7 @@ defmodule BowlingTest do
     game = Bowling.start()
     rolls = [10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     game = roll_reduce(game, rolls)
-    assert Bowling.score(game) == 10
+    assert Bowling.score(game) == {:ok, 10}
   end
 
   @tag :pending
@@ -65,7 +68,7 @@ defmodule BowlingTest do
     game = Bowling.start()
     rolls = [10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     game = roll_reduce(game, rolls)
-    assert Bowling.score(game) == 26
+    assert Bowling.score(game) == {:ok, 26}
   end
 
   @tag :pending
@@ -73,7 +76,7 @@ defmodule BowlingTest do
     game = Bowling.start()
     rolls = [10, 10, 10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     game = roll_reduce(game, rolls)
-    assert Bowling.score(game) == 81
+    assert Bowling.score(game) == {:ok, 81}
   end
 
   @tag :pending
@@ -81,7 +84,7 @@ defmodule BowlingTest do
     game = Bowling.start()
     rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 1]
     game = roll_reduce(game, rolls)
-    assert Bowling.score(game) == 18
+    assert Bowling.score(game) == {:ok, 18}
   end
 
   @tag :pending
@@ -89,7 +92,7 @@ defmodule BowlingTest do
     game = Bowling.start()
     rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 3]
     game = roll_reduce(game, rolls)
-    assert Bowling.score(game) == 20
+    assert Bowling.score(game) == {:ok, 20}
   end
 
   @tag :pending
@@ -97,7 +100,7 @@ defmodule BowlingTest do
     game = Bowling.start()
     rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 10]
     game = roll_reduce(game, rolls)
-    assert Bowling.score(game) == 30
+    assert Bowling.score(game) == {:ok, 30}
   end
 
   @tag :pending
@@ -105,7 +108,7 @@ defmodule BowlingTest do
     game = Bowling.start()
     rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 10]
     game = roll_reduce(game, rolls)
-    assert Bowling.score(game) == 20
+    assert Bowling.score(game) == {:ok, 20}
   end
 
   @tag :pending
@@ -113,7 +116,7 @@ defmodule BowlingTest do
     game = Bowling.start()
     rolls = [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]
     game = roll_reduce(game, rolls)
-    assert Bowling.score(game) == 300
+    assert Bowling.score(game) == {:ok, 300}
   end
 
   @tag :pending
@@ -131,7 +134,7 @@ defmodule BowlingTest do
   @tag :pending
   test "two rolls in a frame cannot score more than 10 points" do
     game = Bowling.start()
-    game = Bowling.roll(game, 5)
+    {:ok, game} = Bowling.roll(game, 5)
     assert Bowling.roll(game, 6) == {:error, "Pin count exceeds pins on the lane"}
   end
 
@@ -156,7 +159,7 @@ defmodule BowlingTest do
     game = Bowling.start()
     rolls = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 6]
     game = roll_reduce(game, rolls)
-    assert Bowling.score(game) == 26
+    assert Bowling.score(game) == {:ok, 26}
   end
 
   @tag :pending


### PR DESCRIPTION
This is a continuation of https://github.com/exercism/elixir/pull/456

Before this PR, the typespecs for bowling were incorrect. They said `any | String.t()` but in reality, in case of errors it would be `{:error, String.t()}`. Instead of only fixing the typespecs, let's also update the return values to follow the pattern of `{:ok, _} | {:error, _}`