### PR TITLE
Bring `palindrome-products` up to date with canonical data (tests passing) 

### DIFF
--- a/exercises/practice/palindrome-products/.meta/example.ex
+++ b/exercises/practice/palindrome-products/.meta/example.ex
@@ -2,27 +2,25 @@ defmodule PalindromeProducts do
   @doc """
   Generates all palindrome products from an optionally given min factor (or 1) to a given max factor.
   """
-  @spec generate(non_neg_integer) :: map
   @spec generate(non_neg_integer, non_neg_integer) :: map
   def generate(max_factor, min_factor \\ 1)
-  def generate(max_factor, min_factor) when max_factor < min_factor do
-    raise ArgumentError
-  end
+  def generate(max_factor, min_factor) when min_factor > max_factor, do: raise(ArgumentError)
 
   def generate(max_factor, min_factor) do
-    Enum.reduce(min_factor..max_factor, %{}, fn x, map ->
-      Enum.reduce(x..max_factor, map, fn y, products ->
-        if palindrome?(x * y), do: add_factor(products, x, y), else: products
-      end)
-    end)
+    palindromes(max_factor, min_factor)
+    |> Enum.reverse()
+    |> Enum.group_by(fn [f1, f2] -> f1 * f2 end)
   end
 
-  defp palindrome?(number) do
-    String.reverse(to_string(number)) == to_string(number)
+  defp palindromes(max_factor, min_factor) do
+    for f1 <- min_factor..max_factor,
+        f2 <- f1..max_factor,
+        palindrome?(f1 * f2),
+        do: [f1, f2]
   end
 
-  defp add_factor(map, x, y) do
-    product = x * y
-    Map.update(map, product, [[x, y]], fn val -> Enum.concat(val, [[x, y]]) end)
+  defp palindrome?(n) do
+    list = Integer.digits(n)
+    list == Enum.reverse(list)
   end
 end

--- a/exercises/practice/palindrome-products/lib/palindrome_products.ex
+++ b/exercises/practice/palindrome-products/lib/palindrome_products.ex
@@ -3,25 +3,6 @@ defmodule PalindromeProducts do
   Generates all palindrome products from an optionally given min factor (or 1) to a given max factor.
   """
   @spec generate(non_neg_integer, non_neg_integer) :: map
-  def generate(max_factor, min_factor \\ 1)
-  def generate(max_factor, min_factor) when min_factor > max_factor, do: raise ArgumentError
-  def generate(max_factor, min_factor) do
-    palindromes(max_factor, min_factor)
-    |> Enum.reverse
-    |> Enum.group_by(fn([f1, f2]) -> f1 * f2 end)
+  def generate(max_factor, min_factor \\ 1) do
   end
-
-  defp palindromes(max_factor, min_factor) do
-    for f1 <- min_factor..max_factor,
-        f2 <- f1..max_factor,
-        palindrome?(f1 * f2),
-        do: [f1, f2]
-  end
-
-  defp palindrome?(n) do
-    list = Integer.digits(n)
-    list == Enum.reverse(list)
-  end
-
-
 end

--- a/exercises/practice/palindrome-products/lib/palindrome_products.ex
+++ b/exercises/practice/palindrome-products/lib/palindrome_products.ex
@@ -3,6 +3,25 @@ defmodule PalindromeProducts do
   Generates all palindrome products from an optionally given min factor (or 1) to a given max factor.
   """
   @spec generate(non_neg_integer, non_neg_integer) :: map
-  def generate(max_factor, min_factor \\ 1) do
+  def generate(max_factor, min_factor \\ 1)
+  def generate(max_factor, min_factor) when min_factor > max_factor, do: raise ArgumentError
+  def generate(max_factor, min_factor) do
+    palindromes(max_factor, min_factor)
+    |> Enum.reverse
+    |> Enum.group_by(fn([f1, f2]) -> f1 * f2 end)
   end
+
+  defp palindromes(max_factor, min_factor) do
+    for f1 <- min_factor..max_factor,
+        f2 <- f1..max_factor,
+        palindrome?(f1 * f2),
+        do: [f1, f2]
+  end
+
+  defp palindrome?(n) do
+    list = Integer.digits(n)
+    list == Enum.reverse(list)
+  end
+
+
 end


### PR DESCRIPTION
```
PalindromeProductsTest [test/palindrome_products_test.exs]
  * test largest palindrome from single digit factors (4.3ms) [L#12]
  * test smallest palindrome from triple digit factors (129.4ms) [L#33]
  * test largest palindrome from triple digit factors (125.7ms) [L#40]
  * test empty result if no palindrome in the range, smaller range (0.00ms) [L#67]
  * test largest palindrome from double digit factors (1.3ms) [L#26]
  * test smallest palindrome from double digit factors (1.0ms) [L#19]
  * test largest palindrome from four digit factors (17973.3ms) [L#54]
  * test smallest palindrome from four digit factors (18231.1ms) [L#47]
  * test raises argument error if max < min (2.3ms) [L#73]
  * test smallest palindrome from single digit factors (0.03ms) [L#5]
  * test empty result if no palindrome in the range (0.00ms) [L#61]


Finished in 36.5 seconds
11 tests, 0 failures
```

Taken from [here](https://exercism.io/tracks/elixir/exercises/palindrome-products/solutions/f307194ada734640a2777328915688b1), I changed only `palindrome?`