### PR TITLE
Move `pipe-operator` from `streams` to `strings`

### DIFF
--- a/concepts/pipe-operator/about.md
+++ b/concepts/pipe-operator/about.md
@@ -3,28 +3,23 @@
 The `|>` operator is called [the pipe operator][pipe]. It can be used to chain function calls together in such a way that the value returned by the previous function call is passed as the first argument to the next function call.
 
 ```elixir
-Enum.filter(
-  Enum.map(
-    1..5,
-    fn n -> n * n end
-  ),
-  fn n -> rem(n, 2) == 0 end
-)
+String.replace_suffix(String.upcase(String.duplicate("go ", 3)), " ", "!")
 
 # versus
 
-1..5
-|> Enum.map(fn n -> n * n end)
-|> Enum.filter(fn n -> rem(n, 2) == 0 end)
+"go "
+|> String.duplicate(3)
+|> String.upcase()
+|> String.replace_suffix(" ", "!")
 ```
 
 It can also be used on a single line:
 
 ```elixir
-"hello" |> String.split("") |> Enum.frequencies()
+"go " |> String.duplicate(3) |> String.upcase() |> String.replace_suffix(" ", "!")
 ```
 
-`Kernel` functions are usually used everywhere without the `Kernel` module name, but the module name needed when using those functions in a pipe chain. For example, `2 * 3 == 6` can also be written as:
+`Kernel` functions are usually used everywhere without the `Kernel` module name, but the module name is needed when using those functions in a pipe chain. For example, `2 * 3 == 6` can also be written as:
 
 ```elixir
 2 |> Kernel.*(3) |> Kernel.==(6)
@@ -57,10 +52,10 @@ It is a matter of personal preference when to use the pipe operator and when not
 
   ```elixir
   # do
-  "hello" |> String.split("") |> Enum.frequencies()
+  "hello" |> String.upcase() |> String.split("")
 
   # don't
-  String.split("hello", "") |> Enum.frequencies()
+  String.upcase("hello") |> String.split("")
   ```
 
 [pipe]: https://hexdocs.pm/elixir/Kernel.html#%7C%3E/2

--- a/concepts/pipe-operator/introduction.md
+++ b/concepts/pipe-operator/introduction.md
@@ -3,8 +3,8 @@
 The `|>` operator is called the pipe operator. It can be used to chain function calls together in such a way that the value returned by the previous function call is passed as the first argument to the next function call.
 
 ```elixir
-1..5
-|> Enum.map(fn n -> n * n end)
-|> Enum.filter(fn n -> rem(n, 2) == 0 end)
-# => [4, 16]
+"hello"
+|> String.upcase()
+|> Kernel.<>("?!")
+# => "HELLO?!"
 ```

--- a/config.json
+++ b/config.json
@@ -138,7 +138,8 @@
         "name": "High School Sweetheart",
         "uuid": "335df1cf-6aba-4ab6-b5c3-b4305ade09a4",
         "concepts": [
-          "strings"
+          "strings",
+          "pipe-operator"
         ],
         "prerequisites": [
           "lists",
@@ -366,8 +367,7 @@
         "name": "Mensch Ärgere Dich Nicht",
         "uuid": "3e2f8bc6-20b4-4e8f-a658-9c270342208e",
         "concepts": [
-          "streams",
-          "pipe-operator"
+          "streams"
         ],
         "prerequisites": [
           "enum",

--- a/exercises/concept/high-school-sweetheart/.docs/introduction.md
+++ b/exercises/concept/high-school-sweetheart/.docs/introduction.md
@@ -37,3 +37,14 @@ To comfortably work with texts with a lot of newlines, use the triple-double-quo
 ```
 
 Elixir provides many functions for working with strings in the `String` module.
+
+## Pipe Operator
+
+The `|>` operator is called the pipe operator. It can be used to chain function calls together in such a way that the value returned by the previous function call is passed as the first argument to the next function call.
+
+```elixir
+"hello"
+|> String.upcase()
+|> Kernel.<>("?!")
+# => "HELLO?!"
+```

--- a/exercises/concept/high-school-sweetheart/.meta/design.md
+++ b/exercises/concept/high-school-sweetheart/.meta/design.md
@@ -8,6 +8,7 @@ After completing this exercise, the student should:
 - Know how to manipulate strings.
 - Know how to perform string interpolation.
 - Know how to create multiline strings (heredocs).
+- Know about the `|>` pipe operator for chaining function calls.
 
 ## Out of scope
 
@@ -25,6 +26,7 @@ After completing this exercise, the student should:
 ## Concepts
 
 - `strings`: knows how to concatenate strings, interpolate expressions inside of strings, create multiline strings, and modify strings using the _String module_.
+- `pipe-operator`
 
 ## Analyzer
 

--- a/exercises/concept/high-school-sweetheart/.meta/exemplar.ex
+++ b/exercises/concept/high-school-sweetheart/.meta/exemplar.ex
@@ -1,10 +1,15 @@
 defmodule HighSchoolSweetheart do
   def first_letter(name) do
-    String.first(String.trim(name))
+    name
+    |> String.trim()
+    |> String.first()
   end
 
   def initial(name) do
-    String.upcase(first_letter(name)) <> "."
+    name
+    |> first_letter()
+    |> String.upcase()
+    |> Kernel.<>(".")
   end
 
   def initials(full_name) do

--- a/exercises/concept/mensch-aergere-dich-nicht/.docs/introduction.md
+++ b/exercises/concept/mensch-aergere-dich-nicht/.docs/introduction.md
@@ -1,16 +1,5 @@
 # Introduction
 
-## Pipe Operator
-
-The `|>` operator is called the pipe operator. It can be used to chain function calls together in such a way that the value returned by the previous function call is passed as the first argument to the next function call.
-
-```elixir
-1..5
-|> Enum.map(fn n -> n * n end)
-|> Enum.filter(fn n -> rem(n, 2) == 0 end)
-# => [4, 16]
-```
-
 ## Streams
 
 All functions in the `Enum` module are _eager_. When performing multiple operations on enumerables with the `Enum` module, each operation is going to generate an intermediate result.

--- a/exercises/concept/mensch-aergere-dich-nicht/.meta/design.md
+++ b/exercises/concept/mensch-aergere-dich-nicht/.meta/design.md
@@ -2,7 +2,6 @@
 
 ## Learning objectives
 
-- Know about the `|>` pipe operator for chaining function calls.
 - Know about streams.
   - `Enum` functions are eager, `Stream` functions are lazy.
   - Potentially infinite.
@@ -13,7 +12,6 @@
 ## Concepts
 
 - `streams`
-- `pipe-operator`
 
 ## Prerequisites
 


### PR DESCRIPTION
I would like to move the `pipe-operator` concept earlier in the concept tree. Right now, it's inside the `streams` exercise, and the `streams` exercise is far in the concept tree, and isn't even ready for students because it needs to be completely replaced.

I think that `pipe-operator` should be pretty early in the concept tree because you see this operator all over idiomatic Elixir code. It would also be a shame if students couldn't learn about it because of the `streams` exercise not being ready, a topic that is not only rather advanced, but that rarely is ever needed on Exercism for the practice exercises.

I looked through the existing early concept exercises and found that `integers` (`freelancer-rates`) and `strings` (`high-school-sweetheart`) both could be solved using the pipe operator. I decided to go with `strings` because I think that forcing the pipe operator into integer calculations doesn't necessarily make them more idiomatic, but with string transformations it works pretty well :)