### PR TITLE
Run doctests on CI

### DIFF
--- a/.github/workflows/pr.ci.yml
+++ b/.github/workflows/pr.ci.yml
@@ -56,13 +56,8 @@ jobs:
           mkdir -p priv/plts
           mix dialyzer --plt
 
-        # Replace <code-extensions> with file extensions that should trigger this check. Replace with .* to allow anything.
-      - name: Run exercism/elixir ci pre-check (stub files, config integrity) for changed exercises
-        run: |
-          PULL_REQUEST_URL=$(jq -r ".pull_request.url" "$GITHUB_EVENT_PATH")
-          curl --url $"${PULL_REQUEST_URL}/files" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | \
-            jq -c '.[] | select(.status == "added" or .status == "modified") | select(.filename | match("\\.(ex|exs|md|json)$")) | .filename' | \
-            xargs -r bin/pr-check.sh
+      - name: Run exercism/elixir ci pre-check (stub files, config integrity)
+        run: bin/pr-check.sh
 
   ci:
     runs-on: ubuntu-latest
@@ -108,10 +103,5 @@ jobs:
       - name: Build Project
         run: mix
 
-        # Replace <code-extensions> with file extensions that should trigger running tests. Replace with .* to allow anything.
-      - name: Run exercism/elixir ci (runs tests) for changed/added exercises
-        run: |
-          PULL_REQUEST_URL=$(jq -r ".pull_request.url" "$GITHUB_EVENT_PATH")
-          curl --url $"${PULL_REQUEST_URL}/files" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | \
-            jq -c '.[] | select(.status == "added" or .status == "modified") | select(.filename | match("\\.(ex|exs|md|json)$")) | .filename' | \
-            xargs -r bin/pr.sh
+      - name: Run exercism/elixir ci (runs tests)
+        run: bin/pr.sh

--- a/bin/test_exercises.sh
+++ b/bin/test_exercises.sh
@@ -78,7 +78,8 @@ do
       module_name=`cat $test_file | sed -rn 's/^defmodule (.*)Test do$/\1 /p'`
       doctest_code="doctest ${module_name}"
 
-      sed -i "" 's/use ExUnit.Case\(.*\)/use ExUnit.Case\1\n'" ${doctest_code}"'\n/g' $test_file
+      # Warning: GNU sed necessary, BSD (macOS) sed has incompatible options
+      sed -i 's/use ExUnit.Case\(.*\)/use ExUnit.Case\1\n'" ${doctest_code}"'\n/g' $test_file
 
       # perform unit tests
       test_results=$(mix test --color --no-elixir-version-check --include pending 2> /dev/null)

--- a/bin/test_exercises.sh
+++ b/bin/test_exercises.sh
@@ -78,7 +78,7 @@ do
       module_name=`cat $test_file | sed -rn 's/^defmodule (.*)Test do$/\1 /p'`
       doctest_code="doctest ${module_name}"
 
-      sed -I "" 's/use ExUnit.Case\(.*\)/use ExUnit.Case\1\n'" ${doctest_code}"'\n/g' $test_file
+      sed -i "" 's/use ExUnit.Case\(.*\)/use ExUnit.Case\1\n'" ${doctest_code}"'\n/g' $test_file
 
       # perform unit tests
       test_results=$(mix test --color --no-elixir-version-check --include pending 2> /dev/null)

--- a/bin/test_exercises.sh
+++ b/bin/test_exercises.sh
@@ -73,6 +73,13 @@ do
 
     if [ "$compile_exit_code" -eq 0 ]
     then
+      # turn on doctests
+      test_file=`find . -name \*_test.exs`
+      module_name=`cat $test_file | sed -rn 's/^defmodule (.*)Test do$/\1 /p'`
+      doctest_code="doctest ${module_name}"
+
+      sed -I "" 's/use ExUnit.Case\(.*\)/use ExUnit.Case\1\n'" ${doctest_code}"'\n/g' $test_file
+
       # perform unit tests
       test_results=$(mix test --color --no-elixir-version-check --include pending 2> /dev/null)
       test_exit_code="$?"

--- a/bin/test_exercises.sh
+++ b/bin/test_exercises.sh
@@ -92,19 +92,19 @@ do
     # based on compiler and unit test, print results
     if [ "$compile_exit_code" -eq 0 -a "$test_exit_code" -eq 0 ]
     then
-      printf "-- \\033[32mPass\\033[0m\n"
+      printf "\\033[32mPass\\033[0m\n"
       pass_count=$((pass_count+1))
     else
-      printf "-- \\033[31mFail\\033[0m\n"
+      printf "\\033[31mFail\\033[0m\n"
 
       if [ "$compile_exit_code" -ne 0 ]
       then
-        printf -- "-- \\033[36mcompiler output\\033[0m "; printf -- '-%.0s' {1..61}; echo ""
+        printf "\\033[36mcompiler output\\033[0m "; printf -- '-%.0s' {1..61}; echo ""
         printf "${compiler_results}\n"
       fi
       if [ "$test_exit_code" -ne 0 -a "$test_exit_code" -ne 5 ]
       then
-        printf -- "-- \\033[36mtest output\\033[0m "; printf -- '-%.0s' {1..65}; echo ""
+        printf "\\033[36mtest output\\033[0m "; printf -- '-%.0s' {1..65}; echo ""
         printf "${test_results}\n"
       fi
       printf -- '-%.0s' {1..80}; echo ""

--- a/exercises/practice/alphametics/.meta/example.ex
+++ b/exercises/practice/alphametics/.meta/example.ex
@@ -9,11 +9,11 @@ defmodule Alphametics do
 
   ## Examples
 
-      iex> Alphametics.solve("I + BB == ILL")
-      %{?I => 1, ?B => 9, ?L => 0}
+    iex> Alphametics.solve("I + BB == ILL")
+    %{?I => 1, ?B => 9, ?L => 0}
 
-      iex> Alphametics.solve("A == B")
-      nil
+    iex> Alphametics.solve("A == B")
+    nil
   """
   @spec solve(puzzle) :: solution | nil
   def solve(puzzle) do

--- a/exercises/practice/alphametics/lib/alphametics.ex
+++ b/exercises/practice/alphametics/lib/alphametics.ex
@@ -9,11 +9,11 @@ defmodule Alphametics do
 
   ## Examples
 
-      iex> Alphametics.solve("I + BB == ILL")
-      %{?I => 1, ?B => 9, ?L => 0}
+    iex> Alphametics.solve("I + BB == ILL")
+    %{?I => 1, ?B => 9, ?L => 0}
 
-      iex> Alphametics.solve("A == B")
-      nil
+    iex> Alphametics.solve("A == B")
+    nil
   """
   @spec solve(puzzle) :: solution | nil
   def solve(puzzle) do

--- a/exercises/practice/binary-search/.meta/example.ex
+++ b/exercises/practice/binary-search/.meta/example.ex
@@ -6,13 +6,13 @@ defmodule BinarySearch do
 
     ## Examples
 
-      iex> BinarySearch.search([], 2)
+      iex> BinarySearch.search({}, 2)
       :not_found
 
-      iex> BinarySearch.search([1, 3, 5], 2)
+      iex> BinarySearch.search({1, 3, 5}, 2)
       :not_found
 
-      iex> BinarySearch.search([1, 3, 5], 5)
+      iex> BinarySearch.search({1, 3, 5}, 5)
       {:ok, 2}
 
   """

--- a/exercises/practice/bob/.meta/example.ex
+++ b/exercises/practice/bob/.meta/example.ex
@@ -4,17 +4,17 @@ defmodule Bob do
 
   ## Examples
 
-  iex> Bob.hey("")
-  "Fine. Be that way!"
+    iex> Bob.hey("")
+    "Fine. Be that way!"
 
-  iex> Bob.hey("Do you like math?")
-  "Sure."
+    iex> Bob.hey("Do you like math?")
+    "Sure."
 
-  iex> Bob.hey("HELLO!")
-  "Whoa, chill out!"
+    iex> Bob.hey("HELLO!")
+    "Whoa, chill out!"
 
-  iex> Bob.hey("Coding is cool.")
-  "Whatever."
+    iex> Bob.hey("Coding is cool.")
+    "Whatever."
   """
 
   def hey(input) do

--- a/exercises/practice/crypto-square/.meta/example.ex
+++ b/exercises/practice/crypto-square/.meta/example.ex
@@ -1,6 +1,7 @@
 defmodule CryptoSquare do
   @doc """
   Encode string square methods
+
   ## Examples
 
     iex> CryptoSquare.encode("abcd")

--- a/exercises/practice/difference-of-squares/test/squares_test.exs
+++ b/exercises/practice/difference-of-squares/test/squares_test.exs
@@ -1,4 +1,4 @@
-defmodule DifferenceOfSquaresTest do
+defmodule SquaresTest do
   use ExUnit.Case
 
   describe "square_of_sum" do

--- a/exercises/practice/etl/.meta/example.ex
+++ b/exercises/practice/etl/.meta/example.ex
@@ -4,8 +4,8 @@ defmodule ETL do
 
   ## Examples
 
-  iex> ETL.transform(%{1 => ["A", "E"], "2 => ["D", "G"]})
-  %{"a" => 1, "d" => 2, "e" => 1, "g" => 2}
+    iex> ETL.transform(%{1 => ["A", "E"], 2 => ["D", "G"]})
+    %{"a" => 1, "d" => 2, "e" => 1, "g" => 2}
   """
   def transform(input) do
     input

--- a/exercises/practice/etl/lib/etl.ex
+++ b/exercises/practice/etl/lib/etl.ex
@@ -4,8 +4,8 @@ defmodule ETL do
 
   ## Examples
 
-  iex> ETL.transform(%{1 => ["A", "E"], "2 => ["D", "G"]})
-  %{"a" => 1, "d" => 2, "e" => 1, "g" => 2}
+    iex> ETL.transform(%{1 => ["A", "E"], 2 => ["D", "G"]})
+    %{"a" => 1, "d" => 2, "e" => 1, "g" => 2}
   """
   @spec transform(map) :: map
   def transform(input) do

--- a/exercises/practice/etl/test/etl_test.exs
+++ b/exercises/practice/etl/test/etl_test.exs
@@ -1,4 +1,4 @@
-defmodule TransformTest do
+defmodule ETLTest do
   use ExUnit.Case
 
   # @tag :pending

--- a/exercises/practice/isbn-verifier/.meta/example.ex
+++ b/exercises/practice/isbn-verifier/.meta/example.ex
@@ -4,10 +4,10 @@ defmodule IsbnVerifier do
 
     ## Examples
 
-      iex> ISBNVerifier.isbn?("3-598-21507-X")
+      iex> IsbnVerifier.isbn?("3-598-21507-X")
       true
 
-      iex> ISBNVerifier.isbn?("3-598-2K507-0")
+      iex> IsbnVerifier.isbn?("3-598-2K507-0")
       false
 
   """

--- a/exercises/practice/largest-series-product/test/series_test.exs
+++ b/exercises/practice/largest-series-product/test/series_test.exs
@@ -1,4 +1,4 @@
-defmodule LargestSeriesProductTest do
+defmodule SeriesTest do
   use ExUnit.Case
 
   # @tag :pending

--- a/exercises/practice/markdown/.meta/example.ex
+++ b/exercises/practice/markdown/.meta/example.ex
@@ -7,8 +7,8 @@ defmodule Markdown do
     iex> Markdown.parse("This is a paragraph")
     "<p>This is a paragraph</p>"
 
-    iex> Markdown.parse("#Header!\n* __Bold Item__\n* _Italic Item_")
-    "<h1>Header!</h1><ul><li><em>Bold Item</em></li><li><i>Italic Item</i></li></ul>"
+    iex> Markdown.parse("# Header!\n* __Bold Item__\n* _Italic Item_")
+    "<h1>Header!</h1><ul><li><strong>Bold Item</strong></li><li><em>Italic Item</em></li></ul>"
   """
   @spec parse(String.t()) :: String.t()
   def parse(m) do

--- a/exercises/practice/markdown/.meta/example.ex
+++ b/exercises/practice/markdown/.meta/example.ex
@@ -4,11 +4,11 @@ defmodule Markdown do
 
     ## Examples
 
-    iex> Markdown.parse("This is a paragraph")
-    "<p>This is a paragraph</p>"
+      iex> Markdown.parse("This is a paragraph")
+      "<p>This is a paragraph</p>"
 
-    iex> Markdown.parse("# Header!\n* __Bold Item__\n* _Italic Item_")
-    "<h1>Header!</h1><ul><li><strong>Bold Item</strong></li><li><em>Italic Item</em></li></ul>"
+      iex> Markdown.parse("# Header!\\n* __Bold Item__\\n* _Italic Item_")
+      "<h1>Header!</h1><ul><li><strong>Bold Item</strong></li><li><em>Italic Item</em></li></ul>"
   """
   @spec parse(String.t()) :: String.t()
   def parse(m) do

--- a/exercises/practice/markdown/lib/markdown.ex
+++ b/exercises/practice/markdown/lib/markdown.ex
@@ -7,8 +7,8 @@ defmodule Markdown do
     iex> Markdown.parse("This is a paragraph")
     "<p>This is a paragraph</p>"
 
-    iex> Markdown.parse("#Header!\n* __Bold Item__\n* _Italic Item_")
-    "<h1>Header!</h1><ul><li><em>Bold Item</em></li><li><i>Italic Item</i></li></ul>"
+    iex> Markdown.parse("# Header!\n* __Bold Item__\n* _Italic Item_")
+    "<h1>Header!</h1><ul><li><strong>Bold Item</strong></li><li><em>Italic Item</em></li></ul>"
   """
   @spec parse(String.t()) :: String.t()
   def parse(m) do

--- a/exercises/practice/markdown/lib/markdown.ex
+++ b/exercises/practice/markdown/lib/markdown.ex
@@ -4,11 +4,11 @@ defmodule Markdown do
 
     ## Examples
 
-    iex> Markdown.parse("This is a paragraph")
-    "<p>This is a paragraph</p>"
+      iex> Markdown.parse("This is a paragraph")
+      "<p>This is a paragraph</p>"
 
-    iex> Markdown.parse("# Header!\n* __Bold Item__\n* _Italic Item_")
-    "<h1>Header!</h1><ul><li><strong>Bold Item</strong></li><li><em>Italic Item</em></li></ul>"
+      iex> Markdown.parse("# Header!\\n* __Bold Item__\\n* _Italic Item_")
+      "<h1>Header!</h1><ul><li><strong>Bold Item</strong></li><li><em>Italic Item</em></li></ul>"
   """
   @spec parse(String.t()) :: String.t()
   def parse(m) do

--- a/exercises/practice/nth-prime/test/prime_test.exs
+++ b/exercises/practice/nth-prime/test/prime_test.exs
@@ -1,4 +1,4 @@
-defmodule NthPrimeTest do
+defmodule PrimeTest do
   use ExUnit.Case
 
   # @tag :pending

--- a/exercises/practice/rna-transcription/.meta/example.ex
+++ b/exercises/practice/rna-transcription/.meta/example.ex
@@ -1,10 +1,10 @@
 defmodule RnaTranscription do
   @doc """
-  Transcribes a character list representing RNATranscription nucleotides to RNA
+  Transcribes a character list representing DNA nucleotides to RNA
 
   ## Examples
 
-  iex> RNATranscription.to_rna('ACTG')
+  iex> RnaTranscription.to_rna('ACTG')
   'UGAC'
   """
   def to_rna(dna) do

--- a/exercises/practice/rna-transcription/.meta/example.ex
+++ b/exercises/practice/rna-transcription/.meta/example.ex
@@ -4,8 +4,8 @@ defmodule RnaTranscription do
 
   ## Examples
 
-  iex> RnaTranscription.to_rna('ACTG')
-  'UGAC'
+    iex> RnaTranscription.to_rna('ACTG')
+    'UGAC'
   """
   def to_rna(dna) do
     Enum.map(dna, &transcribe(&1))

--- a/exercises/practice/rotational-cipher/.meta/example.ex
+++ b/exercises/practice/rotational-cipher/.meta/example.ex
@@ -26,9 +26,10 @@ defmodule RotationalCipher do
   @doc """
   Given a plaintext and amount to shift by, return a rotated string.
 
-  Example:
-  iex> RotationalCipher.rotate("Attack at dawn", 13)
-  "Nggnpx ng qnja"
+  ## Examples
+
+    iex> RotationalCipher.rotate("Attack at dawn", 13)
+    "Nggnpx ng qnja"
   """
   @spec rotate(text :: String.t(), shift :: integer) :: String.t()
   def rotate(text, shift) do

--- a/exercises/practice/space-age/test/space_age_test.exs
+++ b/exercises/practice/space-age/test/space_age_test.exs
@@ -1,4 +1,4 @@
-defmodule SpageAgeTest do
+defmodule SpaceAgeTest do
   use ExUnit.Case
 
   # @tag :pending

--- a/exercises/practice/transpose/.meta/example.ex
+++ b/exercises/practice/transpose/.meta/example.ex
@@ -9,11 +9,11 @@ defmodule Transpose do
     * Don't pad to the right.
 
   ## Examples
-  iex> Transpose.transpose("ABC\nDE")
-  "AD\nBE\nC"
+  iex> Transpose.transpose("ABC\\nDE")
+  "AD\\nBE\\nC"
 
-  iex> Transpose.transpose("AB\nDEF")
-  "AD\nBE\n F"
+  iex> Transpose.transpose("AB\\nDEF")
+  "AD\\nBE\\n F"
   """
 
   @spec transpose(String.t()) :: String.t()

--- a/exercises/practice/transpose/.meta/example.ex
+++ b/exercises/practice/transpose/.meta/example.ex
@@ -9,11 +9,12 @@ defmodule Transpose do
     * Don't pad to the right.
 
   ## Examples
-  iex> Transpose.transpose("ABC\\nDE")
-  "AD\\nBE\\nC"
 
-  iex> Transpose.transpose("AB\\nDEF")
-  "AD\\nBE\\n F"
+    iex> Transpose.transpose("ABC\\nDE")
+    "AD\\nBE\\nC"
+
+    iex> Transpose.transpose("AB\\nDEF")
+    "AD\\nBE\\n F"
   """
 
   @spec transpose(String.t()) :: String.t()

--- a/exercises/practice/transpose/lib/transpose.ex
+++ b/exercises/practice/transpose/lib/transpose.ex
@@ -9,11 +9,11 @@ defmodule Transpose do
     * Don't pad to the right.
 
   ## Examples
-  iex> Transpose.transpose("ABC\nDE")
-  "AD\nBE\nC"
+  iex> Transpose.transpose("ABC\\nDE")
+  "AD\\nBE\\nC"
 
-  iex> Transpose.transpose("AB\nDEF")
-  "AD\nBE\n F"
+  iex> Transpose.transpose("AB\\nDEF")
+  "AD\\nBE\\n F"
   """
 
   @spec transpose(String.t()) :: String.t()

--- a/exercises/practice/transpose/lib/transpose.ex
+++ b/exercises/practice/transpose/lib/transpose.ex
@@ -9,11 +9,12 @@ defmodule Transpose do
     * Don't pad to the right.
 
   ## Examples
-  iex> Transpose.transpose("ABC\\nDE")
-  "AD\\nBE\\nC"
 
-  iex> Transpose.transpose("AB\\nDEF")
-  "AD\\nBE\\n F"
+    iex> Transpose.transpose("ABC\\nDE")
+    "AD\\nBE\\nC"
+
+    iex> Transpose.transpose("AB\\nDEF")
+    "AD\\nBE\\n F"
   """
 
   @spec transpose(String.t()) :: String.t()


### PR DESCRIPTION
I noticed that we have some doctests that are never run, and thus they become out of date. We cannot include doctests in the test files downloaded by students, but we can include them when running tests on the CI.

This tiny change will also catch instances of the test module and lib module having different names, as it extracts the module-under-test name from the test module name.

Failures at the moment:
```
10 tests failing:
 - binary-search
 - difference-of-squares
 - etl
 - isbn-verifier
 - largest-series-product
 - markdown
 - nth-prime
 - rna-transcription
 - space-age
 - transpose
```

I will fix them in this PR.