### PR TITLE
Add fetch_configlet.sh

### DIFF
--- a/bin/fetch_configlet.sh
+++ b/bin/fetch_configlet.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+curlopts=(
+  --silent
+  --show-error
+  --fail
+  --location
+  --retry 3
+)
+
+get_download_url() {
+  # Returns the download URL of the latest configlet Linux release from the GitHub API
+  local api_url='https://api.github.com/repos/exercism/configlet/releases/latest'
+  local asset_name="configlet-${1}-64bit.tgz"
+  curl "${curlopts[@]}" --header "Accept: application/vnd.github.v3+json" "${api_url}" |
+    jq --arg name "${asset_name}" -r '.assets[] | select(.name==$name).browser_download_url'
+}
+
+case ${1-} in
+
+  mac)
+    download_url="$(get_download_url 'mac' )"
+    ;;
+
+  linux)
+    download_url="$(get_download_url 'linux' )"
+    ;;
+
+  windows)
+    download_url="$(get_download_url 'windows' )"
+    ;;
+
+  *)
+    echo 'usage: fetch_configlet.sh mac | linux | windows'
+    exit 1
+    ;;
+esac
+
+curl "${curlopts[@]}" "${download_url}" | tar xz -C bin/
+echo 'done'


### PR DESCRIPTION
Copied from https://github.com/exercism/github-actions/blob/main/configlet-ci/fetch-configlet, added a case statement to allow choosing the platform.

To be used by maintainers manually, when they want to lint the track before submitting a PR, for example.