### PR TITLE
Update bob stub

### DIFF
--- a/exercises/practice/bob/.meta/example.ex
+++ b/exercises/practice/bob/.meta/example.ex
@@ -1,22 +1,5 @@
 defmodule Bob do
-  @doc """
-  Answers to `hey` like a teenager.
-
-  ## Examples
-
-    iex> Bob.hey("")
-    "Fine. Be that way!"
-
-    iex> Bob.hey("Do you like math?")
-    "Sure."
-
-    iex> Bob.hey("HELLO!")
-    "Whoa, chill out!"
-
-    iex> Bob.hey("Coding is cool.")
-    "Whatever."
-  """
-
+  @spec String.t() :: String.t()
   def hey(input) do
     input = String.trim(input)
 

--- a/exercises/practice/bob/.meta/example.ex
+++ b/exercises/practice/bob/.meta/example.ex
@@ -1,5 +1,5 @@
 defmodule Bob do
-  @spec String.t() :: String.t()
+  @spec hey(String.t()) :: String.t()
   def hey(input) do
     input = String.trim(input)
 

--- a/exercises/practice/bob/lib/bob.ex
+++ b/exercises/practice/bob/lib/bob.ex
@@ -1,7 +1,5 @@
 defmodule Bob do
+  @spec String.t() :: String.t()
   def hey(input) do
-    cond do
-      true -> raise "Your implementation goes here"
-    end
   end
 end

--- a/exercises/practice/bob/lib/bob.ex
+++ b/exercises/practice/bob/lib/bob.ex
@@ -1,5 +1,5 @@
 defmodule Bob do
-  @spec String.t() :: String.t()
+  @spec hey(String.t()) :: String.t()
   def hey(input) do
   end
 end


### PR DESCRIPTION
I didn't notice this before, but for some reason `bob`'s stub is the only one that hardcodes the usage of `cond` and uses `raise`. All of our other stubs for practice exercises leave out the functions completely empty. I don't see why `bob` should be different 🤷 