### PR TITLE
Typos typos typos

### DIFF
--- a/concepts/anonymous-functions/about.md
+++ b/concepts/anonymous-functions/about.md
@@ -22,7 +22,7 @@ function_variable.(1)
 # => 2
 ```
 
-Anonymous functions may be created with the [`&` capture shorthand][kernal-capture].
+Anonymous functions may be created with the [`&` capture shorthand][kernel-capture].
 
 - The initial `&` declares the start of the capture expression.
 - `&1`, `&2`, and so on refer to the positional arguments of the anonymous function.
@@ -64,6 +64,6 @@ x
 
 [anon-fns]: https://elixir-lang.org/getting-started/basic-types.html#anonymous-functions
 [kernel-fn]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#fn/1
-[kernal-capture]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#&/1
+[kernel-capture]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#&/1
 [capture]: https://dockyard.com/blog/2016/08/05/understand-capture-operator-in-elixir
 [closure]: https://en.wikipedia.org/wiki/Closure_(computer_programming)

--- a/concepts/links/about.md
+++ b/concepts/links/about.md
@@ -103,7 +103,7 @@ Process.alive?(parent_pid)
 # => true
 ```
 
-Note that trapping exits makes the process immune to crashes in _all_ of its linked processes, and exit messages might accumulate in the process' mailbox if left unread. For this reason, you should keep track of all the processes linked to a process that traps exits. Usually, processes that trap exits are only responsible for supervising other processes and don't do anything else.
+Note that trapping exits makes the process immune to crashes in _all_ of its linked processes, and exit messages might accumulate in the process's mailbox if left unread. For this reason, you should keep track of all the processes linked to a process that traps exits. Usually, processes that trap exits are only responsible for supervising other processes and don't do anything else.
 
 In practice, you wouldn't implement a supervisor process from scratch yourself. Elixir provides an abstraction for this kind of functionality in the form of the [`Supervisor` behaviour][supervisor].
 

--- a/concepts/pids/about.md
+++ b/concepts/pids/about.md
@@ -4,8 +4,8 @@ Each Elixir process has its own unique identifier - a _PID_ (process identifier)
 
 - PIDs are their own data type.
   - You can check if a variable is a PID with [`is_pid/1`][kernel-is-pid]
-- You can get the current process' PID with `self()`.
-- PIDs function as _mailbox addresses_ - if you have a process' PID, you can send a message to that process.
+- You can get the current process's PID with `self()`.
+- PIDs function as _mailbox addresses_ - if you have a process's PID, you can send a message to that process.
 - PIDs are usually created indirectly, as a return value of functions that create new processes, like `spawn`.
   - PIDs should not be created directly by the programmer. If it were required, Erlang has a [`list_to_pid/1`][erlang-list-to-pid] function.
 

--- a/concepts/pids/introduction.md
+++ b/concepts/pids/introduction.md
@@ -1,3 +1,3 @@
 # Introduction
 
-Process identifiers are their own data type. They function as _mailbox addresses_ - if you have a process' PID, you can send a message to that process. PIDs are usually created indirectly, as a return value of functions that create new processes, like `spawn`.
+Process identifiers are their own data type. They function as _mailbox addresses_ - if you have a process's PID, you can send a message to that process. PIDs are usually created indirectly, as a return value of functions that create new processes, like `spawn`.

--- a/concepts/processes/about.md
+++ b/concepts/processes/about.md
@@ -57,9 +57,9 @@ Processes do not directly share information with one another. Processes _send me
 - You can receive a message sent to the current process using [`receive/1`][kernel-receive].
 
   - You need to pattern match on messages.
-  - `receive` waits until one message matching any given pattern is in the process' mailbox.
+  - `receive` waits until one message matching any given pattern is in the process's mailbox.
     - By default, it waits indefinitely, but can be given a timeout using an `after` block.
-  - Read messages are removed from the process' mailbox. Unread messages will stay there indefinitely.
+  - Read messages are removed from the process's mailbox. Unread messages will stay there indefinitely.
     - Always write a catch-all `_` clause in `receive/1` to avoid running of out memory due to piled up unread messages.
 
   ```elixir

--- a/concepts/tasks/about.md
+++ b/concepts/tasks/about.md
@@ -43,7 +43,7 @@ inputs
 
 It's important to be aware that `Task.await` is synchronous, and every time it is called, it starts its timeout clock from 0. That means that when it's used in this way, sequentially, the timeouts add up.
 
-The first task that is awaited will run no longer than the timout, but the second task that is awaited will get to run for however long the first task ran, plus the timeout.
+The first task that is awaited will run no longer than the timeout, but the second task that is awaited will get to run for however long the first task ran, plus the timeout.
 
 Consider a situation where each task takes a little bit longer to run than the previous one, but the difference in task run duration is smaller than the await timeout.
 
@@ -66,7 +66,7 @@ end)
 
 9004517 microseconds is 9 seconds, much more than the given timeout of 1 second (1000 milliseconds).
 
-If this is the behaviour you want - great, go for it! If not, the alternative is to use either [`Task.async_stream/3`][task-async-stream] or [`Task.await_many/2`][task-await-many].
+If this is the behavior you want - great, go for it! If not, the alternative is to use either [`Task.async_stream/3`][task-async-stream] or [`Task.await_many/2`][task-await-many].
 
 ### `Task.async_stream/3`
 

--- a/exercises/concept/date-parser/.docs/hints.md
+++ b/exercises/concept/date-parser/.docs/hints.md
@@ -5,11 +5,11 @@
 - Review regular expression patterns from the introduction. Remember, when creating the pattern a string, you must escape some characters.
 - Read about the [`Regex` module][regex-docs] in the documentation.
 - Read about the [regular expression sigil][sigils-regex] in the Getting Started guide.
-- Checck out this website about regular expressions: [Regular-Expressions.info][website-regex-info].
-- Checck out this website about regular expressions: [Rex Egg -The world's most tyrannosauical regex tutorial][website-rexegg].
-- Checck out this website about regular expressions: [RegexOne - Learn Regular Expressions with simple, interactive exercises.][website-regexone].
-- Checck out this website about regular expressions: [Regular Expressions 101 - an online regex sandbox][website-regex-101].
-- Checck out this website about regular expressions: [RegExr - an online regex sandbox][website-regexr].
+- Check out this website about regular expressions: [Regular-Expressions.info][website-regex-info].
+- Check out this website about regular expressions: [Rex Egg -The world's most tyrannosauical regex tutorial][website-rexegg].
+- Check out this website about regular expressions: [RegexOne - Learn Regular Expressions with simple, interactive exercises.][website-regexone].
+- Check out this website about regular expressions: [Regular Expressions 101 - an online regex sandbox][website-regex-101].
+- Check out this website about regular expressions: [RegExr - an online regex sandbox][website-regexr].
 
 ## 1. Match the day, month, and year from a date
 

--- a/exercises/concept/rpn-calculator-inspection/.meta/config.json
+++ b/exercises/concept/rpn-calculator-inspection/.meta/config.json
@@ -5,6 +5,12 @@
       "exercism_username": "angelikatyborska"
     }
   ],
+  "contributors": [
+    {
+      "github_username": "neenjaw",
+      "exercism_username": "neenjaw"
+    }
+  ],
   "files": {
     "solution": ["lib/rpn_calculator_inspection.ex"],
     "test": ["test/rpn_calculator_inspection_test.exs"],

--- a/exercises/concept/take-a-number/.docs/hints.md
+++ b/exercises/concept/take-a-number/.docs/hints.md
@@ -13,7 +13,7 @@
 ## 2. Report the machine state
 
 - The machine's process needs to respond to messages.
-- There is [a built-in function that waits for a message to arrive in the process' mailbox][kernel-receive].
+- There is [a built-in function that waits for a message to arrive in the process's mailbox][kernel-receive].
 - There is [a built-in function that sends a message to another process][kernel-send].
 - Use recursion to wait for more than one message.
 - Pass the machine's state as an argument to the recursive function.

--- a/exercises/concept/take-a-number/.docs/instructions.md
+++ b/exercises/concept/take-a-number/.docs/instructions.md
@@ -4,7 +4,7 @@ You are writing an embedded system for a Take-A-Number machine. It is a very sim
 
 ## 1. Start the machine
 
-Implement the `start/0` function. It should spawn a new process that has an initial state of `0` and is ready to receive messages. It should return the process' PID.
+Implement the `start/0` function. It should spawn a new process that has an initial state of `0` and is ready to receive messages. It should return the process's PID.
 
 ```elixir
 TakeANumber.start()

--- a/exercises/concept/take-a-number/.docs/introduction.md
+++ b/exercises/concept/take-a-number/.docs/introduction.md
@@ -42,4 +42,4 @@ If you want to receive more than one message, you need to call `receive/1` recur
 
 ## PIDs
 
-Process identifiers are their own data type. They function as _mailbox addresses_ - if you have a process' PID, you can send a message to that process. PIDs are usually created indirectly, as a return value of functions that create new processes, like `spawn`.
+Process identifiers are their own data type. They function as _mailbox addresses_ - if you have a process's PID, you can send a message to that process. PIDs are usually created indirectly, as a return value of functions that create new processes, like `spawn`.


### PR DESCRIPTION
After merging https://github.com/exercism/elixir/pull/682, I noticed that there are some typos and grammar errors (apparently in singular, the genitive of "process" is "process's" 🤷). And then I noticed more unrelated typos! And then I realized I forgot to credit @neenjaw for the code review :)