### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "4450bb26-4bd7-4eee-878d-07a287bf3169",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Elixir locally",
+      "blurb": "Learn how to install Elixir locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "eb148270-24b7-4f51-b0ad-b1c67a692a70",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Elixir",
+      "blurb": "An overview of how to get started from scratch with Elixir"
+    },
+    {
+      "uuid": "554258a2-7e2e-418c-93de-2b19986261e8",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Elixir track",
+      "blurb": "Learn how to test your Elixir exercises on Exercism"
+    },
+    {
+      "uuid": "e8a6e945-1d3c-43ba-a73a-27f530c6588e",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Elixir resources",
+      "blurb": "A collection of useful resources to help you master Elixir"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
