### PR TITLE
Drop 1.6 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,9 @@ jobs:
 
     strategy:
       matrix:
-        #Note: pick a canonical set of supported versions
-        elixir: ['1.6.0', '1.7.0']
-        otp: ['20.0']
         include:
+          - elixir: '1.7.0'
+            otp: '20.0'
           - elixir: '1.8.0'
             otp: '20.0'
           - elixir: '1.9.0'

--- a/.github/workflows/pr.ci.yml
+++ b/.github/workflows/pr.ci.yml
@@ -61,9 +61,9 @@ jobs:
 
     strategy:
       matrix:
-        elixir: ['1.6.0', '1.7.0']
-        otp: ['20.0']
         include:
+          - elixir: '1.7.0'
+            otp: '20.0'
           - elixir: '1.8.0'
             otp: '20.0'
           - elixir: '1.9.0'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Exercism Exercises in Elixir
 
 ## Setup
 
-The exercises currently target Elixir >= 1.6 and Erlang/OTP >= 20. Detailed
+The exercises currently target Elixir >= 1.7 and Erlang/OTP >= 20. Detailed
 installation instructions can be found at
 [http://elixir-lang.org/install.html](http://elixir-lang.org/install.html).
 
@@ -57,4 +57,3 @@ To check formatting of all exercises and all documents, run `./bin/check_formatt
 If you want to help maintain the Elixir track, take a look at [HELLO.md](https://github.com/exercism/elixir/blob/master/HELLO.md). You will find there an introduction to all the possible ways you can help us.
 
 If you want to contribute to this repository specifically, please see [CONTRIBUTING.md](https://github.com/exercism/elixir/blob/master/CONTRIBUTING.md).
-


### PR DESCRIPTION
Introducing a concept exercise for documentation and typespecs requires use of a function not present in 1.6.

1.6 is reasonably old at this point and not part of any default package repo that I have been able to find, therefore I think it is safe to drop this version from being supported if it allows us to have a better concept course of study.