### PR TITLE
🤖 Flatten authors and contributors in .meta/config.json files

### DIFF
--- a/exercises/concept/basketball-website/.meta/config.json
+++ b/exercises/concept/basketball-website/.meta/config.json
@@ -1,20 +1,11 @@
 {
   "blurb": "Learn about Access Behaviour by helping extract deeply nested data for the basketball team's website.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    },
-    {
-      "github_username": "NobbZ",
-      "exercism_username": "NobbZ"
-    }
+    "angelikatyborska",
+    "NobbZ"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/bird-count/.meta/config.json
+++ b/exercises/concept/bird-count/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about recursion by keeping track of how many birds visit your garden each day.",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "contributors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/boutique-inventory/.meta/config.json
+++ b/exercises/concept/boutique-inventory/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about the Enum module by preparing your fashion boutique for the big annual sale.",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "contributors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/boutique-suggestions/.meta/config.json
+++ b/exercises/concept/boutique-suggestions/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about list comprehensions by generating outfit suggestions for the clients of your fashion boutique.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/bread-and-potions/.meta/config.json
+++ b/exercises/concept/bread-and-potions/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about protocols by developing your own role-playing video game.",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "contributors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/captains-log/.meta/config.json
+++ b/exercises/concept/captains-log/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about randomness and using Erlang libraries from Elixir by helping Mary generate stardates and starship registry numbers for her Star Trek themed pen-and-paper role playing sessions.",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "contributors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/chessboard/.meta/config.json
+++ b/exercises/concept/chessboard/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about ranges by generating a chessboard.",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "contributors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/community-garden/.meta/config.json
+++ b/exercises/concept/community-garden/.meta/config.json
@@ -1,24 +1,12 @@
 {
   "blurb": "Learn about the Agent module by helping your local community handle community garden registrations.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    },
-    {
-      "github_username": "jrr",
-      "exercism_username": "jrr"
-    },
-    {
-      "github_username": "efx",
-      "exercism_username": "efx"
-    }
+    "angelikatyborska",
+    "jrr",
+    "efx"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/date-parser/.meta/config.json
+++ b/exercises/concept/date-parser/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about regular expressions by parsing dates.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/dna-encoding/.meta/config.json
+++ b/exercises/concept/dna-encoding/.meta/config.json
@@ -1,20 +1,11 @@
 {
   "blurb": "Learn about bitstrings and tail call recursion by encoding DNA sequences as binary data.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    },
-    {
-      "github_username": "NobbZ",
-      "exercism_username": "NobbZ"
-    }
+    "angelikatyborska",
+    "NobbZ"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/file-sniffer/.meta/config.json
+++ b/exercises/concept/file-sniffer/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about binaries by verifying the mime type of files uploaded to your server.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/freelancer-rates/.meta/config.json
+++ b/exercises/concept/freelancer-rates/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about integers and floating point numbers by helping a freelancer communicate with a project manager about billing.",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "contributors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/german-sysadmin/.meta/config.json
+++ b/exercises/concept/german-sysadmin/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about charlists and the case conditional expression by sanitizing usernames of employees in a German company.",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "contributors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/guessing-game/.meta/config.json
+++ b/exercises/concept/guessing-game/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about multiple clause functions, guards, and default arguments by implementing a simple game in which the player needs to guess a secret number.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/high-school-sweetheart/.meta/config.json
+++ b/exercises/concept/high-school-sweetheart/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about strings and the pipe operator by helping high school sweethearts profess their love on social media via ASCII art.",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "contributors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/high-score/.meta/config.json
+++ b/exercises/concept/high-score/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "Learn about maps by keeping track of the high scores in your local arcade hall.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/kitchen-calculator/.meta/config.json
+++ b/exercises/concept/kitchen-calculator/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about tuples and pattern matching by converting common US baking measurements to the metric system.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/language-list/.meta/config.json
+++ b/exercises/concept/language-list/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about lists by keeping track of the programing languages you're currently learning on Exercism.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "fireproofsocks",
-      "exercism_username": "fireproofsocks"
-    }
+    "fireproofsocks"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/lasagna/.meta/config.json
+++ b/exercises/concept/lasagna/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about the basics of Elixir by following a lasagna recipe.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/library-fees/.meta/config.json
+++ b/exercises/concept/library-fees/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about dates and time by calculating late fees for the local library.",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "contributors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/log-level/.meta/config.json
+++ b/exercises/concept/log-level/.meta/config.json
@@ -1,16 +1,21 @@
 {
   "blurb": "Learn about atoms and the cond conditional expression by aggregating application logs.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
-    "solution": ["lib/log_level.ex"],
-    "test": ["test/log_level_test.exs"],
-    "exemplar": [".meta/exemplar.ex"]
+    "solution": [
+      "lib/log_level.ex"
+    ],
+    "test": [
+      "test/log_level_test.exs"
+    ],
+    "exemplar": [
+      ".meta/exemplar.ex"
+    ]
   },
-  "forked_from": ["csharp/logs-logs-logs"],
+  "forked_from": [
+    "csharp/logs-logs-logs"
+  ],
   "language_versions": ">=1.10"
 }

--- a/exercises/concept/lucas-numbers/.meta/config.json
+++ b/exercises/concept/lucas-numbers/.meta/config.json
@@ -1,21 +1,21 @@
 {
   "blurb": "Learn about streams by generating the Lucas number sequence.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "files": {
-    "solution": ["lib/lucas_numbers.ex"],
-    "test": ["test/lucas_numbers_test.exs"],
-    "exemplar": [".meta/exemplar.ex"]
+    "solution": [
+      "lib/lucas_numbers.ex"
+    ],
+    "test": [
+      "test/lucas_numbers_test.exs"
+    ],
+    "exemplar": [
+      ".meta/exemplar.ex"
+    ]
   },
   "forked_from": [],
   "language_versions": ">=1.10"

--- a/exercises/concept/mensch-aergere-dich-nicht/.meta/config.json
+++ b/exercises/concept/mensch-aergere-dich-nicht/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "no-op",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "contributors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/name-badge/.meta/config.json
+++ b/exercises/concept/name-badge/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about nil and the if conditional expression by printing name badges for factory employees.",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "contributors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/newsletter/.meta/config.json
+++ b/exercises/concept/newsletter/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "Learn about working with files by sending out a newsletter.",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/pacman-rules/.meta/config.json
+++ b/exercises/concept/pacman-rules/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about booleans by implementing the rules of the Pac-Man game.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "Cohen-Carlisle",
-      "exercism_username": "Cohen-Carlisle"
-    }
+    "Cohen-Carlisle"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/remote-control-car/.meta/config.json
+++ b/exercises/concept/remote-control-car/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about structs by playing around with a remote controlled car.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/rpg-character-sheet/.meta/config.json
+++ b/exercises/concept/rpg-character-sheet/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about IO (input/output) by guiding your friends through the character creation process for your pen-and-paper role-playing game.",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "contributors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/rpn-calculator-inspection/.meta/config.json
+++ b/exercises/concept/rpn-calculator-inspection/.meta/config.json
@@ -1,21 +1,21 @@
 {
   "blurb": "Learn about tasks and links by inspecting a working prototype of your experimental Reverse Polish Notation calculator.",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "contributors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
-    "solution": ["lib/rpn_calculator_inspection.ex"],
-    "test": ["test/rpn_calculator_inspection_test.exs"],
-    "exemplar": [".meta/exemplar.ex"]
+    "solution": [
+      "lib/rpn_calculator_inspection.ex"
+    ],
+    "test": [
+      "test/rpn_calculator_inspection_test.exs"
+    ],
+    "exemplar": [
+      ".meta/exemplar.ex"
+    ]
   },
   "language_versions": ">=1.10"
 }

--- a/exercises/concept/rpn-calculator-output/.meta/config.json
+++ b/exercises/concept/rpn-calculator-output/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about dynamic dispatch and advanced options for rescuing errors by implementing an output in your experimental Reverse Polish Notation calculator.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/rpn-calculator/.meta/config.json
+++ b/exercises/concept/rpn-calculator/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about errors and rescuing them by working on an experimental Reverse Polish Notation calculator.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/secrets/.meta/config.json
+++ b/exercises/concept/secrets/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "Learn about bit manipulation and anonymous functions by writing the software for an encryption device.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/stack-underflow/.meta/config.json
+++ b/exercises/concept/stack-underflow/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about defining custom exceptions by continuing work on your experimental Reverse Polish Notation calculator.",
   "authors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "contributors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/take-a-number/.meta/config.json
+++ b/exercises/concept/take-a-number/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about processes and process identifiers by writing an embedded system for a Take-A-Number machine.",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "contributors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/wine-cellar/.meta/config.json
+++ b/exercises/concept/wine-cellar/.meta/config.json
@@ -1,16 +1,10 @@
 {
   "blurb": "Learn about keyword lists by providing wine suggestions to the customers in your restaurant.",
   "authors": [
-    {
-      "github_username": "angelikatyborska",
-      "exercism_username": "angelikatyborska"
-    }
+    "angelikatyborska"
   ],
   "contributors": [
-    {
-      "github_username": "neenjaw",
-      "exercism_username": "neenjaw"
-    }
+    "neenjaw"
   ],
   "files": {
     "solution": [


### PR DESCRIPTION
The authors and contributors of exercises are stored in an array of objects in the exercises' `.meta/config.json` files.
Each author/contributor used to have two properties: their GitHub username _and_ their Exercism username.
As we're only using the GitHub username, we're flattening the `authors` and `contributors` array to an array of strings representing the GitHub usernames.

We will update `configlet` to validate the new structure, so you might be seeing build failures once we've implemented this change. 

See https://github.com/exercism/docs/pull/90/files

## Automatic Merging

We will automatically merge this PR immediately to be able to submit a different PR in which we'll add the authors/contributors for practice exercises.

## Tracking

https://github.com/exercism/v3-launch/issues/26
