### PR TITLE
Add test for `list-ops`

### DIFF
--- a/exercises/practice/list-ops/test/list_ops_test.exs
+++ b/exercises/practice/list-ops/test/list_ops_test.exs
@@ -76,6 +76,11 @@ defmodule ListOpsTest do
     test "huge list" do
       assert L.filter(Enum.to_list(1..1_000_000), &odd?/1) == Enum.map(1..500_000, &(&1 * 2 - 1))
     end
+
+    @tag :pending
+    test "truthy values filter the list" do
+      assert L.filter([true, false, nil, 0, 1, ""], & &1) == [true, 0, 1, ""]
+    end
   end
 
   describe "foldl" do


### PR DESCRIPTION
I noticed the test suite did not catch an error I made because all tests have functions that return actual booleans.