### PR TITLE
Use `Map` instead of `List` to store vertices in `dot-dsl`

### DIFF
--- a/exercises/practice/dot-dsl/.meta/example.ex
+++ b/exercises/practice/dot-dsl/.meta/example.ex
@@ -1,5 +1,5 @@
 defmodule Graph do
-  defstruct attrs: [], nodes: [], edges: []
+  defstruct attrs: [], nodes: %{}, edges: []
 end
 
 defmodule Dot do
@@ -9,10 +9,10 @@ defmodule Dot do
   defmacro graph(do: ast) do
     g = do_graph(ast)
 
-    Macro.escape(%Graph{
-      attrs: Enum.sort(g.attrs),
-      nodes: Enum.sort(g.nodes),
-      edges: Enum.sort(g.edges)
+    Macro.escape(%{
+      g
+      | attrs: Enum.sort(g.attrs),
+        edges: Enum.sort(g.edges)
     })
   end
 
@@ -37,13 +37,13 @@ defmodule Dot do
   end
 
   defp do_stmt({atom, _, nil}, g) when is_atom(atom) and atom != :-- do
-    %{g | nodes: [{atom, []} | g.nodes]}
+    %{g | nodes: Map.put(g.nodes, atom, [])}
   end
 
   defp do_stmt(stmt = {atom, _, [kws]}, g)
        when is_atom(atom) and atom != :-- and is_list(kws) do
     if Keyword.keyword?(kws) do
-      %{g | nodes: [{atom, kws} | g.nodes]}
+      %{g | nodes: Map.put(g.nodes, atom, kws)}
     else
       raise_invalid_stmt(stmt)
     end

--- a/exercises/practice/dot-dsl/lib/graph.ex
+++ b/exercises/practice/dot-dsl/lib/graph.ex
@@ -1,3 +1,3 @@
 defmodule Graph do
-  defstruct attrs: [], nodes: [], edges: []
+  defstruct attrs: [], nodes: %{}, edges: []
 end

--- a/exercises/practice/dot-dsl/test/dot_test.exs
+++ b/exercises/practice/dot-dsl/test/dot_test.exs
@@ -25,7 +25,7 @@ defmodule DotTest do
 
   @tag :pending
   test "graph with one node" do
-    assert %Graph{nodes: [{:a, []}]} ==
+    assert %Graph{nodes: %{a: []}} ==
              exprt(
                Dot.graph do
                  a
@@ -35,7 +35,7 @@ defmodule DotTest do
 
   @tag :pending
   test "graph with one node with keywords" do
-    assert %Graph{nodes: [{:a, [color: :green]}]} ==
+    assert %Graph{nodes: %{a: [color: :green]}} ==
              exprt(
                Dot.graph do
                  a(color: :green)
@@ -67,7 +67,7 @@ defmodule DotTest do
   test "graph with attributes" do
     assert %Graph{
              attrs: [bar: true, foo: 1, title: "Testing Attrs"],
-             nodes: [{:a, [color: :green]}, {:b, [label: "Beta!"]}, {:c, []}],
+             nodes: %{a: [color: :green], b: [label: "Beta!"], c: []},
              edges: [{:a, :b, [color: :blue]}, {:b, :c, []}]
            } ==
              exprt(


### PR DESCRIPTION
I enjoyed doing the `dot-dsl` exercise quite a bit.

I realize the focus was on macro & ast handling, not on the actual graph, but I thought it was quite odd that the nodes of a graph would be stored in a list, and not in a map.

The test suite doesn't check what happens if a node is specified more than once, but it still makes no sense to have a graph with multiple nodes with the same label. By contrast, duplicate edges are not an issue.

It also seems natural that any actual use of the graph would require efficient lookup of nodes.

I don't know if that kind of trivial change is worth it or not, but I thought I'd submit it nevertheless. I won't mind if the powers that be prefer to keep the exercise as is.