### PR TITLE
Set up sync-labels github action

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,79 @@
+- name: "CI 🤖",
+  color: "d2e1f2",
+  description: "Changes related to continuous integration"
+
+- name: "bug 🐛",
+  color: "8e2c2c",
+  description: ""
+
+- name: "canonical sync 🔄",
+  color: "99C8EA",
+  description: "For issues/changes related to synchronization between test suites and the canonical data"
+
+- name: "concept-exercise",
+  color: "dbf2a2",
+  description: "Adding or improving a concept exercise"
+
+- name: "dependencies",
+  color: "0366d6",
+  description: "Pull requests that update a dependency file"
+
+- name: "discussion 💬",
+  color: "23296d",
+  description: ""
+
+- name: "documentation 📖",
+  color: "23296d",
+  description: "Changing the documentation only, no coding involved"
+
+- name: "duplicate",
+  color: "cccccc",
+  description: null
+
+- name: "enhancement ⭐️",
+  color: "c3dcf7",
+  description: "A nice-to-have"
+
+- name: "good first issue 🐥",
+  color: "C2E0C6",
+  description: ""
+
+- name: "help wanted 🤝",
+  color: "ccd4fc",
+  description: ""
+
+- name: "in progress 🚧",
+  color: "FEF6EE",
+  description: "Already being worked on"
+
+- name: "question ❔",
+  color: "23296d",
+  description: ""
+
+- name: "reputation/contributed_code/major",
+  color: "fcfa9f",
+  description: "Increases the number of reputation points awarded by this PR"
+
+- name: "reputation/contributed_code/minor",
+  color: "fcfa9f",
+  description: "Decreases the number of reputation points awarded by this PR"
+
+- name: "v3",
+  color: "dbf2a2",
+  description: "Related to Exercism v3"
+
+- name: "v3-migration 🤖",
+  color: "E99695",
+  description: "Preparing for Exercism v3"
+
+- name: "waiting ⏳",
+  color: "FEF6EE",
+  description: "Waiting for something else to happen first"
+
+- name: "won't fix ⛔️",
+  color: "fce0e2",
+  description: ""
+
+- name: "xyz️ test label",
+  color: "631d66",
+  description: "this is a test label to check if the label syncer works"

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,4 +1,4 @@
-name: Tools
+name: sync-labels
 
 on:
   push:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,20 @@
+name: Tools
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+      - .github/workflows/sync-labels.yml
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  sync-labels:
+    name: Sync labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout
+      - uses: micnncim/action-label-syncer@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I'm trying to set up https://github.com/marketplace/actions/label-syncer for this repository. I would like to do this so that we have more overview of the existing labels and how they change in time via git history.

The label list is exactly as they currently are (exported via the REST API), no changes, plus one extra "test" label to prove that this works. 

If it proves to work after merging to main, I will open a new PR that refines the list of labels (removes the test one, adds nicer descriptions etc.).

Maybe it would also work to use this option https://github.com/marketplace/actions/label-syncer#sync-labels-on-another-repository to make all Elixir-related repositories share labels via this repository? I would love to have that kind of consistency for the whole track, but I'm not sure at the moment if all labels would make sense for all repositories.