### PR TITLE
Fix sync-labels syntax error

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -14,7 +14,7 @@ jobs:
     name: Sync labels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout
+      - uses: actions/checkout@v2.3.4
       - uses: micnncim/action-label-syncer@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The error is:
>  Invalid workflow file

> The workflow is not valid. .github/workflows/sync-labels.yml (Line: 17, Col: 15): Expected format {org}/{repo}[/path]@ref. Actual 'actions/checkout' Input string was not in a correct format.

I copied the file from https://github.com/exercism/julia/blob/main/.github/workflows/sync-labels.yml and accidentally introduced the error because I didn't know you have to specify versions.



