### PR TITLE
Update `dot-dsl` `practices`

### DIFF
--- a/config.json
+++ b/config.json
@@ -2350,7 +2350,6 @@
         ],
         "practices": [
           "keyword-lists",
-          "structs",
           "macros"
         ],
         "difficulty": 8


### PR DESCRIPTION
After the changes to `dot-dsl` from https://github.com/exercism/elixir/pull/708, I am pretty sure it no longer practices structs because the struct creation and updating is already provided to the student in the `Graph` module.