### PR TITLE
Remove all skips from concept exercise tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Please keep the following in mind:
     ExUnit.configure exclude: :pending, trace: true
     ```
 
-- All but the initial test for each exercise should be tagged `:pending`.
+- All but the initial test for each practice exercise should be tagged `:pending`.
 
     ```elixir
     @tag :pending
@@ -50,6 +50,8 @@ Please keep the following in mind:
       assert Bob.hey("WATCH OUT!") == "Whoa, chill out!"
     end
     ```
+
+- No tests should be skipped for concept exercises.
 
 All the tests for Exercism Elixir Track exercises can be run from the top level of the repo
 with `$ ./bin/test_exercises.sh`. Please run this command before submitting your PR. Watch out

--- a/exercises/concept/basketball-website/test/basketball_website_test.exs
+++ b/exercises/concept/basketball-website/test/basketball_website_test.exs
@@ -2,7 +2,6 @@ defmodule BasketballWebsiteTest do
   use ExUnit.Case
 
   describe "extract_from_path retrieves from" do
-    # @tag :pending
     test "first layer" do
       team_data = %{
         "coach" => %{},
@@ -13,7 +12,6 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.extract_from_path(team_data, "team_name") == "Hoop Masters"
     end
 
-    @tag :pending
     test "second layer" do
       team_data = %{
         "coach" => %{
@@ -27,7 +25,6 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.extract_from_path(team_data, "coach.first_name") == "Jane"
     end
 
-    @tag :pending
     test "third layer" do
       team_data = %{
         "coach" => %{},
@@ -51,7 +48,6 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.extract_from_path(team_data, "players.99.first_name") == "Amalee"
     end
 
-    @tag :pending
     test "fourth layer" do
       team_data = %{
         "coach" => %{},
@@ -88,7 +84,6 @@ defmodule BasketballWebsiteTest do
   end
 
   describe "extract_from_path returns nil from nonexistent last key in" do
-    @tag :pending
     test "first layer" do
       team_data = %{
         "coach" => %{},
@@ -99,7 +94,6 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.extract_from_path(team_data, "team_song") == nil
     end
 
-    @tag :pending
     test "second layer" do
       team_data = %{
         "coach" => %{
@@ -113,7 +107,6 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.extract_from_path(team_data, "coach.age") == nil
     end
 
-    @tag :pending
     test "third layer" do
       team_data = %{
         "coach" => %{},
@@ -131,7 +124,6 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.extract_from_path(team_data, "players.32.height") == nil
     end
 
-    @tag :pending
     test "fourth layer" do
       team_data = %{
         "coach" => %{},
@@ -155,7 +147,6 @@ defmodule BasketballWebsiteTest do
     end
   end
 
-  @tag :pending
   test "extract_from_path returns nil from nonexistent path" do
     team_data = %{
       "coach" => %{},
@@ -170,7 +161,6 @@ defmodule BasketballWebsiteTest do
   end
 
   describe "get_in_path retrieves from" do
-    @tag :pending
     test "first layer" do
       team_data = %{
         "coach" => %{},
@@ -181,7 +171,6 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.get_in_path(team_data, "team_name") == "Hoop Masters"
     end
 
-    @tag :pending
     test "second layer" do
       team_data = %{
         "coach" => %{
@@ -195,7 +184,6 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.get_in_path(team_data, "coach.first_name") == "Jane"
     end
 
-    @tag :pending
     test "third layer" do
       team_data = %{
         "coach" => %{},
@@ -219,7 +207,6 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.get_in_path(team_data, "players.99.first_name") == "Amalee"
     end
 
-    @tag :pending
     test "fourth layer" do
       team_data = %{
         "coach" => %{},
@@ -256,7 +243,6 @@ defmodule BasketballWebsiteTest do
   end
 
   describe "get_in_path returns nil from nonexistent last key in" do
-    @tag :pending
     test "first layer" do
       team_data = %{
         "coach" => %{},
@@ -267,7 +253,6 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.get_in_path(team_data, "team_song") == nil
     end
 
-    @tag :pending
     test "second layer" do
       team_data = %{
         "coach" => %{
@@ -281,7 +266,6 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.get_in_path(team_data, "coach.age") == nil
     end
 
-    @tag :pending
     test "third layer" do
       team_data = %{
         "coach" => %{},
@@ -299,7 +283,6 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.get_in_path(team_data, "players.32.height") == nil
     end
 
-    @tag :pending
     test "fourth layer" do
       team_data = %{
         "coach" => %{},
@@ -321,7 +304,6 @@ defmodule BasketballWebsiteTest do
     end
   end
 
-  @tag :pending
   test "get_in_path returns nil from nonexistent path" do
     team_data = %{
       "coach" => %{},

--- a/exercises/concept/bird-count/test/bird_count_test.exs
+++ b/exercises/concept/bird-count/test/bird_count_test.exs
@@ -2,12 +2,10 @@ defmodule BirdCountTest do
   use ExUnit.Case
 
   describe "today/1" do
-    # @tag :pending
     test "returns nil if no bird watching data recorded" do
       assert BirdCount.today([]) == nil
     end
 
-    @tag :pending
     test "returns today's bird count" do
       assert BirdCount.today([7]) == 7
       assert BirdCount.today([2, 4, 11, 10, 6, 8]) == 2
@@ -15,12 +13,10 @@ defmodule BirdCountTest do
   end
 
   describe "increment_day_count/1" do
-    @tag :pending
     test "creates entry for today if no bird watching data recorded" do
       assert BirdCount.increment_day_count([]) == [1]
     end
 
-    @tag :pending
     test "adds 1 to today's bird count" do
       assert BirdCount.increment_day_count([7]) == [8]
       assert BirdCount.increment_day_count([4, 2, 1, 0, 10]) == [5, 2, 1, 0, 10]
@@ -28,18 +24,15 @@ defmodule BirdCountTest do
   end
 
   describe "has_day_without_birds?/1" do
-    @tag :pending
     test "false if no bird watching data recorded" do
       assert BirdCount.has_day_without_birds?([]) == false
     end
 
-    @tag :pending
     test "false if there are no zeros in bird watching data" do
       assert BirdCount.has_day_without_birds?([1]) == false
       assert BirdCount.has_day_without_birds?([6, 7, 10, 2, 5]) == false
     end
 
-    @tag :pending
     test "true if there are is at least one zero in bird watching data" do
       assert BirdCount.has_day_without_birds?([0]) == true
       assert BirdCount.has_day_without_birds?([4, 4, 0, 1]) == true
@@ -48,12 +41,10 @@ defmodule BirdCountTest do
   end
 
   describe "total/1" do
-    @tag :pending
     test "zero if no bird watching data recorded" do
       assert BirdCount.total([]) == 0
     end
 
-    @tag :pending
     test "sums up bird counts" do
       assert BirdCount.total([4]) == 4
       assert BirdCount.total([3, 0, 0, 4, 4, 0, 0, 10]) == 21
@@ -61,12 +52,10 @@ defmodule BirdCountTest do
   end
 
   describe "busy_days/1" do
-    @tag :pending
     test "zero if no bird watching data recorded" do
       assert BirdCount.busy_days([]) == 0
     end
 
-    @tag :pending
     test "counts days with bird count of 5 or more" do
       assert BirdCount.busy_days([1]) == 0
       assert BirdCount.busy_days([0, 5]) == 1

--- a/exercises/concept/boutique-inventory/test/boutique_inventory_test.exs
+++ b/exercises/concept/boutique-inventory/test/boutique_inventory_test.exs
@@ -2,12 +2,10 @@ defmodule BoutiqueInventoryTest do
   use ExUnit.Case
 
   describe "sort_by_price/1" do
-    # @tag :pending
     test "works for an empty inventory" do
       assert BoutiqueInventory.sort_by_price([]) == []
     end
 
-    @tag :pending
     test "sorts items by price" do
       assert BoutiqueInventory.sort_by_price([
                %{price: 65, name: "Maxi Yellow Summer Dress", quantity_by_size: %{}},
@@ -24,12 +22,10 @@ defmodule BoutiqueInventoryTest do
   end
 
   describe "with_missing_price/1" do
-    @tag :pending
     test "works for an empty inventory" do
       assert BoutiqueInventory.with_missing_price([]) == []
     end
 
-    @tag :pending
     test "filters out items that do have a price" do
       assert BoutiqueInventory.with_missing_price([
                %{name: "Red Flowery Top", price: 50, quantity_per_size: %{}},
@@ -45,7 +41,6 @@ defmodule BoutiqueInventoryTest do
   end
 
   describe "increase_quantity/2" do
-    @tag :pending
     test "works for an empty quantity map" do
       assert BoutiqueInventory.increase_quantity(
                %{
@@ -61,7 +56,6 @@ defmodule BoutiqueInventoryTest do
              }
     end
 
-    @tag :pending
     test "sorts items by price" do
       assert BoutiqueInventory.increase_quantity(
                %{
@@ -79,7 +73,6 @@ defmodule BoutiqueInventoryTest do
   end
 
   describe "total_quantity/1" do
-    @tag :pending
     test "works for an empty quantity map" do
       assert BoutiqueInventory.total_quantity(%{
                name: "Red Denim Pants",
@@ -88,7 +81,6 @@ defmodule BoutiqueInventoryTest do
              }) == 0
     end
 
-    @tag :pending
     test "sums up total quantity" do
       assert BoutiqueInventory.total_quantity(%{
                name: "Black Denim Skirt",

--- a/exercises/concept/boutique-suggestions/test/boutique_suggestions_test.exs
+++ b/exercises/concept/boutique-suggestions/test/boutique_suggestions_test.exs
@@ -1,7 +1,6 @@
 defmodule BoutiqueSuggestionsTest do
   use ExUnit.Case
 
-  # @tag :pending
   test "generates one pair from one top and one bottom" do
     top = %{
       item_name: "Long Sleeve T-shirt",
@@ -22,7 +21,6 @@ defmodule BoutiqueSuggestionsTest do
     assert BoutiqueSuggestions.get_combinations([top], [bottom]) == [{top, bottom}]
   end
 
-  @tag :pending
   test "generates all pairs from two top and two bottom" do
     top1 = %{
       item_name: "Long Sleeve T-shirt",
@@ -62,7 +60,6 @@ defmodule BoutiqueSuggestionsTest do
     assert BoutiqueSuggestions.get_combinations(tops, bottoms) == expected
   end
 
-  @tag :pending
   test "does not create suggestions that 'clash'" do
     top = %{
       item_name: "Long Sleeve T-shirt",
@@ -83,12 +80,10 @@ defmodule BoutiqueSuggestionsTest do
     assert BoutiqueSuggestions.get_combinations([top], [bottom]) == []
   end
 
-  @tag :pending
   test "accepts keyword list for third argument for options" do
     assert BoutiqueSuggestions.get_combinations([], [], maximum_price: 200.00)
   end
 
-  @tag :pending
   test "filter rejects combinations based on combined maximum price" do
     top = %{
       item_name: "Sano Long Sleeve Shirt",
@@ -109,7 +104,6 @@ defmodule BoutiqueSuggestionsTest do
     assert BoutiqueSuggestions.get_combinations([top], [bottom], maximum_price: 100.00) == []
   end
 
-  @tag :pending
   test "filter accepts combinations based on combined maximum price" do
     top = %{
       item_name: "Sano Long Sleeve Shirt",
@@ -132,7 +126,6 @@ defmodule BoutiqueSuggestionsTest do
            ]
   end
 
-  @tag :pending
   test "provides default when maximum_price option not specified" do
     top = %{
       item_name: "Sano Long Sleeve Shirt",
@@ -153,7 +146,6 @@ defmodule BoutiqueSuggestionsTest do
     assert BoutiqueSuggestions.get_combinations([top], [bottom], other_option: "test") == []
   end
 
-  @tag :pending
   test "putting it all together" do
     top1 = %{
       item_name: "Long Sleeve T-shirt",

--- a/exercises/concept/bread-and-potions/test/rpg_test.exs
+++ b/exercises/concept/bread-and-potions/test/rpg_test.exs
@@ -8,12 +8,10 @@ defmodule RPGTest do
   end
 
   describe "Edible" do
-    # @tag :pending
     test "is a protocol" do
       assert Edible.__protocol__(:functions) == [eat: 2]
     end
 
-    @tag :pending
     test "cannot eat a completely new item" do
       assert_raise Protocol.UndefinedError, fn ->
         Edible.eat(%NewItem{}, %Character{})
@@ -22,20 +20,17 @@ defmodule RPGTest do
   end
 
   describe "LoafOfBread" do
-    @tag :pending
     test "implements the Edible protocol" do
       {:consolidated, modules} = Edible.__protocol__(:impls)
       assert LoafOfBread in modules
     end
 
-    @tag :pending
     test "eating it increases health" do
       character = %Character{health: 50}
       {byproduct, %Character{} = character} = Edible.eat(%LoafOfBread{}, character)
       assert character.health == 55
     end
 
-    @tag :pending
     test "eating it has no byproduct" do
       character = %Character{}
       {byproduct, %Character{}} = Edible.eat(%LoafOfBread{}, character)
@@ -44,20 +39,17 @@ defmodule RPGTest do
   end
 
   describe "ManaPotion" do
-    @tag :pending
     test "implements the Edible protocol" do
       {:consolidated, modules} = Edible.__protocol__(:impls)
       assert ManaPotion in modules
     end
 
-    @tag :pending
     test "eating it increases mana" do
       character = %Character{mana: 10}
       {byproduct, %Character{} = character} = Edible.eat(%ManaPotion{strength: 6}, character)
       assert character.mana == 16
     end
 
-    @tag :pending
     test "eating it produces an empty bottle" do
       character = %Character{}
       {byproduct, %Character{}} = Edible.eat(%ManaPotion{}, character)
@@ -66,20 +58,17 @@ defmodule RPGTest do
   end
 
   describe "Poison" do
-    @tag :pending
     test "implements the Edible protocol" do
       {:consolidated, modules} = Edible.__protocol__(:impls)
       assert Poison in modules
     end
 
-    @tag :pending
     test "eating it brings health down to 0" do
       character = %Character{health: 120}
       {byproduct, %Character{} = character} = Edible.eat(%Poison{}, character)
       assert character.health == 0
     end
 
-    @tag :pending
     test "eating it produces an empty bottle" do
       character = %Character{}
       {byproduct, %Character{}} = Edible.eat(%Poison{}, character)
@@ -87,7 +76,6 @@ defmodule RPGTest do
     end
   end
 
-  @tag :pending
   test "eating many things one after another" do
     items = [
       %LoafOfBread{},

--- a/exercises/concept/captains-log/test/captains_log_test.exs
+++ b/exercises/concept/captains-log/test/captains_log_test.exs
@@ -2,7 +2,6 @@ defmodule CaptainsLogTest do
   use ExUnit.Case
 
   describe "random_planet_class" do
-    # @tag :pending
     test "it always returns one of the letters: D, H, J, K, L, M, N, R, T, Y" do
       planetary_classes = ["D", "H", "J", "K", "L", "M", "N", "R", "T", "Y"]
 
@@ -11,7 +10,6 @@ defmodule CaptainsLogTest do
       end)
     end
 
-    @tag :pending
     test "it will eventually return each of the letters at least once" do
       planetary_classes = ["D", "H", "J", "K", "L", "M", "N", "R", "T", "Y"]
 
@@ -29,12 +27,10 @@ defmodule CaptainsLogTest do
   end
 
   describe "random_ship_registry_number" do
-    @tag :pending
     test "start with \"NCC-\"" do
       assert String.starts_with?(CaptainsLog.random_ship_registry_number(), "NCC-")
     end
 
-    @tag :pending
     test "ends with a random integer between 1000 and 9999" do
       Enum.each(0..100, fn _ ->
         random_ship_registry_number = CaptainsLog.random_ship_registry_number()
@@ -53,26 +49,22 @@ defmodule CaptainsLogTest do
   end
 
   describe "random_stardate" do
-    @tag :pending
     test "is a float" do
       assert is_float(CaptainsLog.random_stardate())
     end
 
-    @tag :pending
     test "is equal to or greater than 41_000.0" do
       Enum.each(0..100, fn _ ->
         assert CaptainsLog.random_stardate() >= 41_000.0
       end)
     end
 
-    @tag :pending
     test "is less than 42_000.0" do
       Enum.each(0..100, fn _ ->
         assert CaptainsLog.random_stardate() < 42_000.0
       end)
     end
 
-    @tag :pending
     test "consecutive calls return floats with different fractional parts" do
       decimal_parts =
         Enum.map(0..10, fn _ ->
@@ -83,7 +75,6 @@ defmodule CaptainsLogTest do
       assert Enum.count(Enum.uniq(decimal_parts)) > 3
     end
 
-    @tag :pending
     test "returns floats with fractional parts with more than one decimal place" do
       decimal_parts =
         Enum.map(0..10, fn _ ->
@@ -96,22 +87,18 @@ defmodule CaptainsLogTest do
   end
 
   describe "format_stardate" do
-    @tag :pending
     test "returns a string" do
       assert is_bitstring(CaptainsLog.format_stardate(41010.7))
     end
 
-    @tag :pending
     test "formats floats" do
       assert CaptainsLog.format_stardate(41543.3) == "41543.3"
     end
 
-    @tag :pending
     test "rounds floats to one decimal place" do
       assert CaptainsLog.format_stardate(41032.4512) == "41032.5"
     end
 
-    @tag :pending
     test "does not accept integers" do
       assert_raise ArgumentError, fn -> CaptainsLog.format_stardate(41411) end
     end

--- a/exercises/concept/city-office/test/form_test.exs
+++ b/exercises/concept/city-office/test/form_test.exs
@@ -96,7 +96,6 @@ defmodule FormTest do
   end
 
   describe "the Form module" do
-    # @tag :pending
     test "has documentation" do
       expected_moduledoc = """
       A collection of loosely related functions helpful for filling out various forms at the city office.
@@ -107,17 +106,14 @@ defmodule FormTest do
   end
 
   describe "blanks/1" do
-    @tag :pending
     test "returns a string with Xs of a given length" do
       assert Form.blanks(5) == "XXXXX"
     end
 
-    @tag :pending
     test "returns an empty string when given length is 0" do
       assert Form.blanks(0) == ""
     end
 
-    @tag :pending
     test "has documentation" do
       expected_doc = """
       Generates a string of a given length.
@@ -129,24 +125,20 @@ defmodule FormTest do
       assert_doc({:blanks, 1}, expected_doc)
     end
 
-    @tag :pending
     test "has a correct spec" do
       assert_spec({:blanks, 1}, "non_neg_integer()", "String.t()")
     end
   end
 
   describe "letters/1" do
-    @tag :pending
     test "returns a list of upcase letters" do
       assert Form.letters("Sao Paulo") == ["S", "A", "O", " ", "P", "A", "U", "L", "O"]
     end
 
-    @tag :pending
     test "returns an empty list when given an empty string" do
       assert Form.letters("") == []
     end
 
-    @tag :pending
     test "has documentation" do
       expected_doc = """
       Splits the string into a list of uppercase letters.
@@ -158,29 +150,24 @@ defmodule FormTest do
       assert_doc({:letters, 1}, expected_doc)
     end
 
-    @tag :pending
     test "has a typespec" do
       assert_spec({:letters, 1}, "String.t()", "[String.t()]")
     end
   end
 
   describe "check_length/2" do
-    @tag :pending
     test "returns :ok is value is below max length" do
       assert Form.check_length("Ruiz", 6) == :ok
     end
 
-    @tag :pending
     test "returns :ok is value is of exactly max length" do
       assert Form.check_length("Martinez-Cooper", 15) == :ok
     end
 
-    @tag :pending
     test "returns an error tuple with the difference between max length and actual length" do
       assert Form.check_length("Martinez-Campbell", 10) == {:error, 7}
     end
 
-    @tag :pending
     test "has documentation" do
       expected_doc = """
       Checks if the value has no more than the maximum allowed number of letters.
@@ -192,7 +179,6 @@ defmodule FormTest do
       assert_doc({:check_length, 2}, expected_doc)
     end
 
-    @tag :pending
     test "has a typespec" do
       assert_spec(
         {:check_length, 2},
@@ -203,7 +189,6 @@ defmodule FormTest do
   end
 
   describe "custom types in the Form module" do
-    @tag :pending
     test "has a custom 'address_map' type" do
       expected_type_definition =
         "%{street: String.t(), postal_code: String.t(), city: String.t()}"
@@ -211,7 +196,6 @@ defmodule FormTest do
       assert_type({Form, :address_map}, expected_type_definition)
     end
 
-    @tag :pending
     test "has a custom 'address_tuple' type with named arguments" do
       expected_type_definition =
         "{street :: String.t(), postal_code :: String.t(), city :: String.t()}"
@@ -219,7 +203,6 @@ defmodule FormTest do
       assert_type({Form, :address_tuple}, expected_type_definition)
     end
 
-    @tag :pending
     test "has a custom 'address' type that is a union of 'address_map' and 'address_tuple'" do
       expected_type_definition = "address_map() | address_tuple()"
 
@@ -228,7 +211,6 @@ defmodule FormTest do
   end
 
   describe "format_address/1" do
-    @tag :pending
     test "accepts a map" do
       input = %{
         street: "Wiejska 4/6/8",
@@ -244,7 +226,6 @@ defmodule FormTest do
       assert Form.format_address(input) == result
     end
 
-    @tag :pending
     test "accepts a 3 string tuple" do
       result = """
       PLATZ DER REPUBLIK 1
@@ -254,7 +235,6 @@ defmodule FormTest do
       assert Form.format_address({"Platz der Republik 1", "11011", "Berlin"}) == result
     end
 
-    @tag :pending
     test "has documentation" do
       expected_doc = """
       Formats the address as an uppercase multiline string.
@@ -263,7 +243,6 @@ defmodule FormTest do
       assert_doc({:format_address, 1}, expected_doc)
     end
 
-    @tag :pending
     test "has a typespec" do
       assert_spec({:format_address, 1}, "address()", "String.t()")
     end

--- a/exercises/concept/community-garden/test/community_garden_test.exs
+++ b/exercises/concept/community-garden/test/community_garden_test.exs
@@ -1,32 +1,27 @@
 defmodule CommunityGardenTest do
   use ExUnit.Case
 
-  # @tag :pending
   test "start returns an alive pid" do
     assert {:ok, pid} = CommunityGarden.start()
     assert Process.alive?(pid)
   end
 
-  @tag :pending
   test "when started, the registry is empty" do
     assert {:ok, pid} = CommunityGarden.start()
     assert [] == CommunityGarden.list_registrations(pid)
   end
 
-  @tag :pending
   test "can register a new plot" do
     assert {:ok, pid} = CommunityGarden.start()
     assert %Plot{} = CommunityGarden.register(pid, "Johnny Appleseed")
   end
 
-  @tag :pending
   test "maintains a registry of plots" do
     assert {:ok, pid} = CommunityGarden.start()
     assert %Plot{} = plot = CommunityGarden.register(pid, "Johnny Appleseed")
     assert [plot] == CommunityGarden.list_registrations(pid)
   end
 
-  @tag :pending
   test "can release a plot" do
     assert {:ok, pid} = CommunityGarden.start()
     assert %Plot{} = plot = CommunityGarden.register(pid, "Johnny Appleseed")
@@ -34,14 +29,12 @@ defmodule CommunityGardenTest do
     assert [] == CommunityGarden.list_registrations(pid)
   end
 
-  @tag :pending
   test "can get a specific registration by id" do
     assert {:ok, pid} = CommunityGarden.start()
     assert %Plot{} = plot = CommunityGarden.register(pid, "Johnny Appleseed")
     assert "Johnny Appleseed" = CommunityGarden.get_registration(pid, plot.plot_id).registered_to
   end
 
-  @tag :pending
   test "can get registration of a registered plot" do
     assert {:ok, pid} = CommunityGarden.start()
     assert %Plot{} = plot = CommunityGarden.register(pid, "Johnny Appleseed")
@@ -50,7 +43,6 @@ defmodule CommunityGardenTest do
     assert registered_plot.registered_to == "Johnny Appleseed"
   end
 
-  @tag :pending
   test "return not_found when attempt to get registration of an unregistered plot" do
     assert {:ok, pid} = CommunityGarden.start()
     assert {:not_found, "plot is unregistered"} = CommunityGarden.get_registration(pid, 1)

--- a/exercises/concept/date-parser/test/date_parser_test.exs
+++ b/exercises/concept/date-parser/test/date_parser_test.exs
@@ -41,231 +41,146 @@ defmodule DateParserTest do
     test "padded 05", do: assert("05" =~ Regex.compile!(DateParser.day()))
     test "padded 06", do: assert("06" =~ Regex.compile!(DateParser.day()))
     test "padded 07", do: assert("07" =~ Regex.compile!(DateParser.day()))
-    @tag :pending
     test "padded 08", do: assert("08" =~ Regex.compile!(DateParser.day()))
-    @tag :pending
     test "padded 09", do: assert("09" =~ Regex.compile!(DateParser.day()))
   end
 
   describe "numeric pattern for day doesn't match" do
-    @tag :pending
     test "too few digits", do: refute("" =~ Regex.compile!("^#{DateParser.day()}$"))
-    @tag :pending
     test "too many digits", do: refute("111" =~ Regex.compile!("^#{DateParser.day()}$"))
-    @tag :pending
     test "one letter", do: refute("a" =~ Regex.compile!(DateParser.day()))
-    @tag :pending
     test "two letters", do: refute("bb" =~ Regex.compile!(DateParser.day()))
   end
 
   describe "numeric pattern for month matches" do
-    @tag :pending
     test "un-padded 1", do: assert("1" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "un-padded 2", do: assert("2" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "un-padded 3", do: assert("3" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "un-padded 4", do: assert("4" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "un-padded 5", do: assert("5" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "un-padded 6", do: assert("6" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "un-padded 7", do: assert("7" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "un-padded 8", do: assert("8" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "un-padded 9", do: assert("9" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "un-padded 10", do: assert("10" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "un-padded 11", do: assert("11" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "un-padded 12", do: assert("11" =~ Regex.compile!(DateParser.month()))
 
-    @tag :pending
     test "padded 01", do: assert("01" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "padded 02", do: assert("02" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "padded 03", do: assert("03" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "padded 04", do: assert("04" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "padded 05", do: assert("05" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "padded 06", do: assert("06" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "padded 07", do: assert("07" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "padded 08", do: assert("08" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "padded 09", do: assert("09" =~ Regex.compile!(DateParser.month()))
   end
 
   describe "numeric pattern for month doesn't match" do
-    @tag :pending
     test "too few digits", do: refute("" =~ Regex.compile!("^#{DateParser.month()}$"))
-    @tag :pending
     test "too many digits", do: refute("111" =~ Regex.compile!("^#{DateParser.month()}$"))
-    @tag :pending
     test "one letter", do: refute("a" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "two letters", do: refute("bb" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "short month name", do: refute("Jan" =~ Regex.compile!(DateParser.month()))
-    @tag :pending
     test "long month name", do: refute("January" =~ Regex.compile!(DateParser.month()))
   end
 
   describe "numeric pattern for year" do
-    @tag :pending
     test "matches 4 digits", do: assert("1970" =~ Regex.compile!("^#{DateParser.year()}$"))
-    @tag :pending
     test "doesn't match short year", do: refute("84" =~ Regex.compile!("^#{DateParser.year()}$"))
-    @tag :pending
     test "doesn't match letters", do: refute("198A" =~ Regex.compile!("^#{DateParser.year()}$"))
-    @tag :pending
     test "doesn't match too few", do: refute("198" =~ Regex.compile!("^#{DateParser.year()}$"))
-    @tag :pending
     test "doesn't match too many", do: refute("19701" =~ Regex.compile!("^#{DateParser.year()}$"))
   end
 
   describe "day names match" do
-    @tag :pending
     test "Sunday", do: assert("Sunday" =~ Regex.compile!(DateParser.day_names()))
-    @tag :pending
     test "Monday", do: assert("Monday" =~ Regex.compile!(DateParser.day_names()))
-    @tag :pending
     test "Tuesday", do: assert("Tuesday" =~ Regex.compile!(DateParser.day_names()))
-    @tag :pending
     test "Wednesday", do: assert("Wednesday" =~ Regex.compile!(DateParser.day_names()))
-    @tag :pending
     test "Thursday", do: assert("Thursday" =~ Regex.compile!(DateParser.day_names()))
-    @tag :pending
     test "Friday", do: assert("Friday" =~ Regex.compile!(DateParser.day_names()))
-    @tag :pending
     test "Saturday", do: assert("Saturday" =~ Regex.compile!(DateParser.day_names()))
   end
 
   describe "day names don't match with trailing or leading whitespace" do
-    @tag :pending
     test "Sunday", do: refute(" Sunday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
-    @tag :pending
     test "Monday", do: refute(" Monday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
-    @tag :pending
     test "Tuesday", do: refute(" Tuesday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
-    @tag :pending
     test "Wednesday", do: refute(" Wednesday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
-    @tag :pending
     test "Thursday", do: refute(" Thursday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
-    @tag :pending
     test "Friday", do: refute(" Friday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
-    @tag :pending
     test "Saturday", do: refute(" Saturday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
   end
 
   describe "day names don't match" do
-    @tag :pending
     test "combined" do
       refute "TuesdayWednesday" =~ Regex.compile!("^#{DateParser.day_names()}$")
     end
 
-    @tag :pending
     test "short name" do
       refute "Sun" =~ Regex.compile!("^#{DateParser.day_names()}$")
     end
 
-    @tag :pending
     test "numeric day of the week (0-indexed)" do
       refute "0" =~ Regex.compile!("^#{DateParser.day_names()}$")
     end
 
-    @tag :pending
     test "numeric day of the week (1-indexed)" do
       refute "1" =~ Regex.compile!("^#{DateParser.day_names()}$")
     end
   end
 
   describe "month names match" do
-    @tag :pending
     test "January", do: assert("January" =~ Regex.compile!(DateParser.month_names()))
-    @tag :pending
     test "February", do: assert("February" =~ Regex.compile!(DateParser.month_names()))
-    @tag :pending
     test "March", do: assert("March" =~ Regex.compile!(DateParser.month_names()))
-    @tag :pending
     test "April", do: assert("April" =~ Regex.compile!(DateParser.month_names()))
-    @tag :pending
     test "May", do: assert("May" =~ Regex.compile!(DateParser.month_names()))
-    @tag :pending
     test "June", do: assert("June" =~ Regex.compile!(DateParser.month_names()))
-    @tag :pending
     test "July", do: assert("July" =~ Regex.compile!(DateParser.month_names()))
-    @tag :pending
     test "August", do: assert("August" =~ Regex.compile!(DateParser.month_names()))
-    @tag :pending
     test "September", do: assert("September" =~ Regex.compile!(DateParser.month_names()))
-    @tag :pending
     test "October", do: assert("October" =~ Regex.compile!(DateParser.month_names()))
-    @tag :pending
     test "November", do: assert("November" =~ Regex.compile!(DateParser.month_names()))
-    @tag :pending
     test "December", do: assert("December" =~ Regex.compile!(DateParser.month_names()))
   end
 
   describe "month names don't match with trailing or leading whitespace" do
-    @tag :pending
     test "January", do: refute(" January " =~ Regex.compile!("^#{DateParser.month_names()}$"))
-    @tag :pending
     test "February", do: refute(" February " =~ Regex.compile!("^#{DateParser.month_names()}$"))
-    @tag :pending
     test "March", do: refute(" March " =~ Regex.compile!("^#{DateParser.month_names()}$"))
-    @tag :pending
     test "April", do: refute(" April " =~ Regex.compile!("^#{DateParser.month_names()}$"))
-    @tag :pending
     test "May", do: refute(" May " =~ Regex.compile!("^#{DateParser.month_names()}$"))
-    @tag :pending
     test "June", do: refute(" June " =~ Regex.compile!("^#{DateParser.month_names()}$"))
-    @tag :pending
     test "July", do: refute(" July " =~ Regex.compile!("^#{DateParser.month_names()}$"))
-    @tag :pending
     test "August", do: refute(" August " =~ Regex.compile!("^#{DateParser.month_names()}$"))
-    @tag :pending
     test "September", do: refute(" September " =~ Regex.compile!("^#{DateParser.month_names()}$"))
-    @tag :pending
     test "October", do: refute(" October " =~ Regex.compile!("^#{DateParser.month_names()}$"))
-    @tag :pending
     test "November", do: refute(" November " =~ Regex.compile!("^#{DateParser.month_names()}$"))
-    @tag :pending
     test "December", do: refute(" December " =~ Regex.compile!("^#{DateParser.month_names()}$"))
   end
 
   describe "month names don't match" do
-    @tag :pending
     test "combined" do
       refute "JanuaryFebruary" =~ Regex.compile!("^#{DateParser.month_names()}$")
     end
 
-    @tag :pending
     test "short name" do
       refute "Jan" =~ Regex.compile!("^#{DateParser.month_names()}$")
     end
 
-    @tag :pending
     test "numeric month of the year (0-indexed)" do
       refute "0" =~ Regex.compile!("^#{DateParser.month_names()}$")
     end
 
-    @tag :pending
     test "numeric month of the year (1-indexed)" do
       refute "1" =~ Regex.compile!("^#{DateParser.month_names()}$")
     end
   end
 
   describe "capture" do
-    @tag :pending
     test "numeric month" do
       assert %{"month" => "01"} =
                DateParser.capture_month()
@@ -273,7 +188,6 @@ defmodule DateParserTest do
                |> Regex.named_captures("01")
     end
 
-    @tag :pending
     test "numeric day" do
       assert %{"day" => "01"} =
                DateParser.capture_day()
@@ -281,7 +195,6 @@ defmodule DateParserTest do
                |> Regex.named_captures("01")
     end
 
-    @tag :pending
     test "numeric year" do
       assert %{"year" => "1970"} =
                DateParser.capture_year()
@@ -289,7 +202,6 @@ defmodule DateParserTest do
                |> Regex.named_captures("1970")
     end
 
-    @tag :pending
     test "capture day name" do
       assert %{"day_name" => "Monday"} =
                DateParser.capture_day_name()
@@ -297,7 +209,6 @@ defmodule DateParserTest do
                |> Regex.named_captures("Monday")
     end
 
-    @tag :pending
     test "capture month name" do
       assert %{"month_name" => "February"} =
                DateParser.capture_month_name()
@@ -305,7 +216,6 @@ defmodule DateParserTest do
                |> Regex.named_captures("February")
     end
 
-    @tag :pending
     test "numeric date" do
       assert %{"year" => "1970", "month" => "02", "day" => "01"} =
                DateParser.capture_numeric_date()
@@ -313,7 +223,6 @@ defmodule DateParserTest do
                |> Regex.named_captures("01/02/1970")
     end
 
-    @tag :pending
     test "month named date" do
       assert %{"year" => "1970", "month_name" => "January", "day" => "1"} =
                DateParser.capture_month_name_date()
@@ -321,7 +230,6 @@ defmodule DateParserTest do
                |> Regex.named_captures("January 1, 1970")
     end
 
-    @tag :pending
     test "day and month named date" do
       assert %{
                "year" => "1970",
@@ -336,56 +244,46 @@ defmodule DateParserTest do
   end
 
   describe "regex match" do
-    @tag :pending
     test "numeric date matches" do
       assert DateParser.match_numeric_date() |> Regex.match?("01/02/1970")
     end
 
-    @tag :pending
     test "numeric date has named captures" do
       assert %{"year" => "1970", "month" => "02", "day" => "01"} =
                DateParser.match_numeric_date()
                |> Regex.named_captures("01/02/1970")
     end
 
-    @tag :pending
     test "numeric date with a prefix doesn't match" do
       refute DateParser.match_numeric_date() |> Regex.match?("The day was 01/02/1970")
     end
 
-    @tag :pending
     test "numeric date with a suffix doesn't match" do
       refute DateParser.match_numeric_date() |> Regex.match?("01/02/1970 was the day")
     end
 
-    @tag :pending
     test "month named date matches" do
       assert DateParser.match_month_name_date() |> Regex.match?("January 1, 1970")
     end
 
-    @tag :pending
     test "month named date has named captures" do
       assert %{"year" => "1970", "month_name" => "January", "day" => "1"} =
                DateParser.match_month_name_date()
                |> Regex.named_captures("January 1, 1970")
     end
 
-    @tag :pending
     test "month named date with a prefix doesn't match" do
       refute DateParser.match_month_name_date() |> Regex.match?("The day was January 1, 1970")
     end
 
-    @tag :pending
     test "month named date with a suffix doesn't match" do
       refute DateParser.match_month_name_date() |> Regex.match?("January 1, 1970 was the day")
     end
 
-    @tag :pending
     test "day and month names date matches" do
       assert DateParser.match_day_month_name_date() |> Regex.match?("Thursday, January 1, 1970")
     end
 
-    @tag :pending
     test "day and month names date has named captures" do
       assert %{
                "year" => "1970",
@@ -397,13 +295,11 @@ defmodule DateParserTest do
                |> Regex.named_captures("Thursday, January 1, 1970")
     end
 
-    @tag :pending
     test "day and month names date with a prefix doesn't match" do
       refute DateParser.match_day_month_name_date()
              |> Regex.match?("The day way Thursday, January 1, 1970")
     end
 
-    @tag :pending
     test "day and month names date with a suffix doesn't match" do
       refute DateParser.match_day_month_name_date()
              |> Regex.match?("Thursday, January 1, 1970 was the day")

--- a/exercises/concept/dna-encoding/test/dna_test.exs
+++ b/exercises/concept/dna-encoding/test/dna_test.exs
@@ -2,67 +2,45 @@ defmodule DNATest do
   use ExUnit.Case
 
   describe "encode to 4-bit encoding" do
-    # @tag :pending
     test "?\\s to 0b0000", do: assert(DNA.encode_nucleotide(?\s) == 0b0000)
-    @tag :pending
     test "?A to 0b0001", do: assert(DNA.encode_nucleotide(?A) == 0b0001)
-    @tag :pending
     test "?C to 0b0010", do: assert(DNA.encode_nucleotide(?C) == 0b0010)
-    @tag :pending
     test "?G to 0b0100", do: assert(DNA.encode_nucleotide(?G) == 0b0100)
-    @tag :pending
     test "?T to 0b1000", do: assert(DNA.encode_nucleotide(?T) == 0b1000)
   end
 
   describe "decode to code point" do
-    @tag :pending
     test "0b0000 to ?\\s", do: assert(DNA.decode_nucleotide(0b0000) == ?\s)
-    @tag :pending
     test "0b0001 to ?A", do: assert(DNA.decode_nucleotide(0b0001) == ?A)
-    @tag :pending
     test "0b0010 to ?C", do: assert(DNA.decode_nucleotide(0b0010) == ?C)
-    @tag :pending
     test "0b0100 to ?G", do: assert(DNA.decode_nucleotide(0b0100) == ?G)
-    @tag :pending
     test "0b1000 to ?T", do: assert(DNA.decode_nucleotide(0b1000) == ?T)
   end
 
   describe "encoding" do
-    @tag :pending
     test "' '", do: assert(DNA.encode(' ') == <<0b0000::4>>)
-    @tag :pending
     test "'A'", do: assert(DNA.encode('A') == <<0b0001::4>>)
-    @tag :pending
     test "'C'", do: assert(DNA.encode('C') == <<0b0010::4>>)
-    @tag :pending
     test "'G'", do: assert(DNA.encode('G') == <<0b0100::4>>)
-    @tag :pending
     test "'T'", do: assert(DNA.encode('T') == <<0b1000::4>>)
-    @tag :pending
+
     test "' ACGT'",
       do: assert(DNA.encode(' ACGT') == <<0b0000::4, 0b0001::4, 0b0010::4, 0b0100::4, 0b1000::4>>)
 
-    @tag :pending
     test "'TGCA '",
       do: assert(DNA.encode('TGCA ') == <<0b1000::4, 0b0100::4, 0b0010::4, 0b0001::4, 0b0000::4>>)
   end
 
   describe "decoding" do
-    @tag :pending
     test "' '", do: assert(DNA.decode(<<0b0000::4>>) == ' ')
-    @tag :pending
     test "'A'", do: assert(DNA.decode(<<0b0001::4>>) == 'A')
-    @tag :pending
     test "'C'", do: assert(DNA.decode(<<0b0010::4>>) == 'C')
-    @tag :pending
     test "'G'", do: assert(DNA.decode(<<0b0100::4>>) == 'G')
-    @tag :pending
     test "'T'", do: assert(DNA.decode(<<0b1000::4>>) == 'T')
-    @tag :pending
+
     test "' ACGT'",
       do: assert(DNA.decode(<<0b0000::4, 0b0001::4, 0b0010::4, 0b0100::4, 0b1000::4>>) == ' ACGT')
 
-    @tag :pending
     test "'TGCA '",
       do: assert(DNA.decode(<<0b1000::4, 0b0100::4, 0b0010::4, 0b0001::4, 0b0000::4>>) == 'TGCA ')
   end

--- a/exercises/concept/file-sniffer/test/file_sniffer_test.exs
+++ b/exercises/concept/file-sniffer/test/file_sniffer_test.exs
@@ -8,112 +8,92 @@ defmodule FileSnifferTest do
   @exe_file File.read!(Path.join("assets", "elf.o"))
 
   describe "get type from extension:" do
-    # @tag :pending
     test "bmp" do
       assert FileSniffer.type_from_extension("bmp") == "image/bmp"
     end
 
-    @tag :pending
     test "gif" do
       assert FileSniffer.type_from_extension("gif") == "image/gif"
     end
 
-    @tag :pending
     test "jpg" do
       assert FileSniffer.type_from_extension("jpg") == "image/jpg"
     end
 
-    @tag :pending
     test "png" do
       assert FileSniffer.type_from_extension("png") == "image/png"
     end
 
-    @tag :pending
     test "exe" do
       assert FileSniffer.type_from_extension("exe") == "application/octet-stream"
     end
   end
 
   describe "get type from binary:" do
-    @tag :pending
     test "bmp" do
       assert FileSniffer.type_from_binary(@bmp_file) == "image/bmp"
     end
 
-    @tag :pending
     test "gif" do
       assert FileSniffer.type_from_binary(@gif_file) == "image/gif"
     end
 
-    @tag :pending
     test "jpg" do
       assert FileSniffer.type_from_binary(@jpg_file) == "image/jpg"
     end
 
-    @tag :pending
     test "png" do
       assert FileSniffer.type_from_binary(@png_file) == "image/png"
     end
 
-    @tag :pending
     test "exe" do
       assert FileSniffer.type_from_binary(@exe_file) == "application/octet-stream"
     end
   end
 
   describe "verify valid files" do
-    @tag :pending
     test "bmp" do
       assert FileSniffer.verify(@bmp_file, "bmp") == {:ok, "image/bmp"}
     end
 
-    @tag :pending
     test "gif" do
       assert FileSniffer.verify(@gif_file, "gif") == {:ok, "image/gif"}
     end
 
-    @tag :pending
     test "jpg" do
       assert FileSniffer.verify(@jpg_file, "jpg") == {:ok, "image/jpg"}
     end
 
-    @tag :pending
     test "png" do
       assert FileSniffer.verify(@png_file, "png") == {:ok, "image/png"}
     end
 
-    @tag :pending
     test "exe" do
       assert FileSniffer.verify(@exe_file, "exe") == {:ok, "application/octet-stream"}
     end
   end
 
   describe "reject invalid files" do
-    @tag :pending
     test "bmp" do
       assert FileSniffer.verify(@exe_file, "bmp") ==
                {:error, "Warning, file format and file extension do not match."}
     end
 
-    @tag :pending
     test "gif" do
       assert FileSniffer.verify(@exe_file, "gif") ==
                {:error, "Warning, file format and file extension do not match."}
     end
 
-    @tag :pending
     test "jpg" do
       assert FileSniffer.verify(@exe_file, "jpg") ==
                {:error, "Warning, file format and file extension do not match."}
     end
 
-    @tag :pending
     test "png" do
       assert FileSniffer.verify(@exe_file, "png") ==
                {:error, "Warning, file format and file extension do not match."}
     end
 
-    @tag :pending
     test "exe" do
       assert FileSniffer.verify(@png_file, "exe") ==
                {:error, "Warning, file format and file extension do not match."}

--- a/exercises/concept/freelancer-rates/test/freelancer_rates_test.exs
+++ b/exercises/concept/freelancer-rates/test/freelancer_rates_test.exs
@@ -2,34 +2,28 @@ defmodule FreelancerRatesTest do
   use ExUnit.Case
 
   describe "daily_rate/1" do
-    # @tag :pending
     test "it's the hourly_rate times 8" do
       assert FreelancerRates.daily_rate(50) == 400.0
     end
 
-    @tag :pending
     test "it always returns a float" do
       assert FreelancerRates.daily_rate(60) === 480.0
     end
 
-    @tag :pending
     test "it does not round" do
       assert FreelancerRates.daily_rate(55.1) == 440.8
     end
   end
 
   describe "monthly_rate/1" do
-    @tag :pending
     test "it's the daily_rate times 22" do
       assert FreelancerRates.monthly_rate(62, 0.0) == 10_912
     end
 
-    @tag :pending
     test "it always returns an integer" do
       assert FreelancerRates.monthly_rate(70, 0.0) === 12_320
     end
 
-    @tag :pending
     test "the result is rounded up" do
       # 11_052.8
       assert FreelancerRates.monthly_rate(62.8, 0.0) == 11_053
@@ -37,7 +31,6 @@ defmodule FreelancerRatesTest do
       assert FreelancerRates.monthly_rate(65.2, 0.0) == 11_476
     end
 
-    @tag :pending
     test "gives a discount" do
       # 11_792 - 12% * 11_792 = 10_376.96
       assert FreelancerRates.monthly_rate(67, 12.0) == 10_377
@@ -45,17 +38,14 @@ defmodule FreelancerRatesTest do
   end
 
   describe "days_in_budget/3" do
-    @tag :pending
     test "it's the budget divided by the daily rate" do
       assert FreelancerRates.days_in_budget(1_600, 50, 0.0) == 4
     end
 
-    @tag :pending
     test "it always returns a float" do
       assert FreelancerRates.days_in_budget(520, 65, 0.0) === 1.0
     end
 
-    @tag :pending
     test "it rounds down to one decimal place" do
       # 10.02273
       assert FreelancerRates.days_in_budget(4_410, 55, 0.0) == 10.0
@@ -63,7 +53,6 @@ defmodule FreelancerRatesTest do
       assert FreelancerRates.days_in_budget(4_480, 55, 0.0) == 10.1
     end
 
-    @tag :pending
     test "it applies the discount" do
       # 1.25
       assert FreelancerRates.days_in_budget(480, 60, 20) == 1.2

--- a/exercises/concept/german-sysadmin/test/username_test.exs
+++ b/exercises/concept/german-sysadmin/test/username_test.exs
@@ -2,23 +2,19 @@ defmodule UsernameTest do
   use ExUnit.Case
 
   describe "sanitize/1" do
-    # @tag :pending
     test "works for an empty charlist" do
       assert Username.sanitize('') == ''
     end
 
-    @tag :pending
     test "it keeps lowercase latin letters" do
       input = Enum.to_list(0..0x10FFFF) -- [?_, ?ß, ?ä, ?ö, ?ü]
       assert Username.sanitize(input) == 'abcdefghijklmnopqrstuvwxyz'
     end
 
-    @tag :pending
     test "it keeps underscores" do
       assert Username.sanitize('marcel_huber') == 'marcel_huber'
     end
 
-    @tag :pending
     test "it substitutes german letters" do
       assert Username.sanitize('krüger') == 'krueger'
       assert Username.sanitize('köhler') == 'koehler'

--- a/exercises/concept/guessing-game/test/guessing_game_test.exs
+++ b/exercises/concept/guessing-game/test/guessing_game_test.exs
@@ -1,37 +1,30 @@
 defmodule GuessingGameTest do
   use ExUnit.Case
 
-  # @tag :pending
   test "correct when the guessed number equals secret" do
     assert GuessingGame.compare(7, 7) == "Correct"
   end
 
-  @tag :pending
   test "too high when guessed number is greater than the secret" do
     assert GuessingGame.compare(9, 18) == "Too High"
   end
 
-  @tag :pending
   test "too low when guessed number is less than the secret" do
     assert GuessingGame.compare(42, 30) == "Too Low"
   end
 
-  @tag :pending
   test "so close when guess differs from 7 secret by -1" do
     assert GuessingGame.compare(64, 63) == "So close"
   end
 
-  @tag :pending
   test "so close when guess differs from 7 secret by +1" do
     assert GuessingGame.compare(52, 53) == "So close"
   end
 
-  @tag :pending
   test "when no guess is supplied, ask the player to make a guess" do
     assert GuessingGame.compare(15) == "Make a guess"
   end
 
-  @tag :pending
   test "when the atom :no_guess is supplied, ask the player to make a guess" do
     assert GuessingGame.compare(16, :no_guess) == "Make a guess"
   end

--- a/exercises/concept/high-school-sweetheart/test/high_school_sweetheart_test.exs
+++ b/exercises/concept/high-school-sweetheart/test/high_school_sweetheart_test.exs
@@ -2,43 +2,36 @@ defmodule HighSchoolSweetheartTest do
   use ExUnit.Case
 
   describe "first_letter/1" do
-    # @tag :pending
     test "it gets the first letter" do
       assert HighSchoolSweetheart.first_letter("Mary") == "M"
     end
 
-    @tag :pending
     test "it doesn't change the letter's case" do
       assert HighSchoolSweetheart.first_letter("john") == "j"
     end
 
-    @tag :pending
     test "it strips extra whitespace" do
       assert HighSchoolSweetheart.first_letter("\n\t   Sarah   ") == "S"
     end
   end
 
   describe "initial/1" do
-    @tag :pending
     test "it gets the first letter and appends a dot" do
       assert HighSchoolSweetheart.initial("Betty") == "B."
     end
 
-    @tag :pending
     test "it uppercases the first letter" do
       assert HighSchoolSweetheart.initial("james") == "J."
     end
   end
 
   describe "initials/1" do
-    @tag :pending
     test "returns the initials for the first name and the last name" do
       assert HighSchoolSweetheart.initials("Linda Miller") == "L. M."
     end
   end
 
   describe "pair/2" do
-    @tag :pending
     test "prints the pair's initials inside a heart" do
       assert HighSchoolSweetheart.pair("Avery Bryant", "Charlie Dixon") ==
                """

--- a/exercises/concept/high-score/test/high_score_test.exs
+++ b/exercises/concept/high-score/test/high_score_test.exs
@@ -4,20 +4,17 @@ defmodule HighScoreTest do
   # Trivia: Scores used in this test suite are based on lines of code
   # added to the elixir-lang/elixir github repository as of Apr 27, 2020.
 
-  # @tag :pending
   test "new/1 result in empty score map" do
     assert HighScore.new() == %{}
   end
 
   describe "add_player/2" do
-    @tag :pending
     test "add player without score to empty score map" do
       scores = HighScore.new()
 
       assert HighScore.add_player(scores, "José Valim") == %{"José Valim" => 0}
     end
 
-    @tag :pending
     test "add two players without score to empty map" do
       scores =
         HighScore.new()
@@ -27,7 +24,6 @@ defmodule HighScoreTest do
       assert scores == %{"Chris McCord" => 0, "José Valim" => 0}
     end
 
-    @tag :pending
     test "add player with score to empty score map" do
       scores =
         HighScore.new()
@@ -36,7 +32,6 @@ defmodule HighScoreTest do
       assert scores == %{"José Valim" => 486_373}
     end
 
-    @tag :pending
     test "add players with scores to empty score map" do
       scores =
         HighScore.new()
@@ -48,7 +43,6 @@ defmodule HighScoreTest do
   end
 
   describe "remove_player/2" do
-    @tag :pending
     test "remove from empty score map results in empty score map" do
       scores =
         HighScore.new()
@@ -57,7 +51,6 @@ defmodule HighScoreTest do
       assert scores == %{}
     end
 
-    @tag :pending
     test "remove player after adding results in empty score map" do
       map =
         HighScore.new()
@@ -67,7 +60,6 @@ defmodule HighScoreTest do
       assert map == %{}
     end
 
-    @tag :pending
     test "remove first player after adding two results in map with remaining player" do
       scores =
         HighScore.new()
@@ -78,7 +70,6 @@ defmodule HighScoreTest do
       assert scores == %{"Chris McCord" => 0}
     end
 
-    @tag :pending
     test "remove second player after adding two results in map with remaining player" do
       scores =
         HighScore.new()
@@ -91,7 +82,6 @@ defmodule HighScoreTest do
   end
 
   describe "reset_score/2" do
-    @tag :pending
     test "resetting score for non-existent player sets player score to 0" do
       scores =
         HighScore.new()
@@ -100,7 +90,6 @@ defmodule HighScoreTest do
       assert scores == %{"José Valim" => 0}
     end
 
-    @tag :pending
     test "resetting score for existing player sets previous player score to 0" do
       scores =
         HighScore.new()
@@ -113,7 +102,6 @@ defmodule HighScoreTest do
   end
 
   describe "update_score/3" do
-    @tag :pending
     test "update score for non existent player initializes value" do
       scores =
         HighScore.new()
@@ -122,7 +110,6 @@ defmodule HighScoreTest do
       assert scores == %{"José Valim" => 486_373}
     end
 
-    @tag :pending
     test "update score for existing player adds score to previous" do
       scores =
         HighScore.new()
@@ -132,7 +119,6 @@ defmodule HighScoreTest do
       assert scores == %{"José Valim" => 486_373}
     end
 
-    @tag :pending
     test "update score for existing player with non-zero score adds score to previous" do
       scores =
         HighScore.new()
@@ -145,7 +131,6 @@ defmodule HighScoreTest do
   end
 
   describe "get_players/1" do
-    @tag :pending
     test "empty score map gives empty list" do
       scores_by_player =
         HighScore.new()
@@ -154,7 +139,6 @@ defmodule HighScoreTest do
       assert scores_by_player == []
     end
 
-    @tag :pending
     test "score map with one entry gives one result" do
       players =
         HighScore.new()
@@ -165,7 +149,6 @@ defmodule HighScoreTest do
       assert players == ["José Valim"]
     end
 
-    @tag :pending
     test "score map with multiple entries gives results in unknown order" do
       players =
         HighScore.new()

--- a/exercises/concept/kitchen-calculator/test/kitchen_calculator_test.exs
+++ b/exercises/concept/kitchen-calculator/test/kitchen_calculator_test.exs
@@ -2,83 +2,68 @@ defmodule KitchenCalculatorTest do
   use ExUnit.Case
 
   describe "get volume from tuple pair" do
-    # @tag :pending
     test "get cups" do
       assert KitchenCalculator.get_volume({:cup, 1}) == 1
     end
 
-    @tag :pending
     test "get fluid ounces" do
       assert KitchenCalculator.get_volume({:fluid_ounce, 2}) == 2
     end
 
-    @tag :pending
     test "get teaspoons" do
       assert KitchenCalculator.get_volume({:teaspoons, 3}) == 3
     end
 
-    @tag :pending
     test "get tablespoons" do
       assert KitchenCalculator.get_volume({:tablespoons, 4}) == 4
     end
 
-    @tag :pending
     test "get milliliters" do
       assert KitchenCalculator.get_volume({:milliliter, 5}) == 5
     end
   end
 
   describe "convert to milliliters from" do
-    @tag :pending
     test "milliliters" do
       assert KitchenCalculator.to_milliliter({:milliliter, 3}) == {:milliliter, 3}
     end
 
-    @tag :pending
     test "cups" do
       assert KitchenCalculator.to_milliliter({:cup, 3}) == {:milliliter, 720}
     end
 
-    @tag :pending
     test "fluid ounces" do
       assert KitchenCalculator.to_milliliter({:fluid_ounce, 100}) == {:milliliter, 3000}
     end
 
-    @tag :pending
     test "teaspoon" do
       assert KitchenCalculator.to_milliliter({:teaspoon, 3}) == {:milliliter, 15}
     end
 
-    @tag :pending
     test "tablespoon" do
       assert KitchenCalculator.to_milliliter({:tablespoon, 3}) == {:milliliter, 45}
     end
   end
 
   describe "convert from milliliters to" do
-    @tag :pending
     test "milliliters" do
       assert KitchenCalculator.from_milliliter({:milliliter, 4}, :milliliter) == {:milliliter, 4}
     end
 
-    @tag :pending
     test "cups" do
       assert KitchenCalculator.from_milliliter({:milliliter, 840}, :cup) == {:cup, 3.5}
     end
 
-    @tag :pending
     test "fluid ounces" do
       assert KitchenCalculator.from_milliliter({:milliliter, 4522.5}, :fluid_ounce) ==
                {:fluid_ounce, 150.75}
     end
 
-    @tag :pending
     test "teaspoon" do
       assert KitchenCalculator.from_milliliter({:milliliter, 61.25}, :teaspoon) ==
                {:teaspoon, 12.25}
     end
 
-    @tag :pending
     test "tablespoon" do
       assert KitchenCalculator.from_milliliter({:milliliter, 71.25}, :tablespoon) ==
                {:tablespoon, 4.75}
@@ -86,22 +71,18 @@ defmodule KitchenCalculatorTest do
   end
 
   describe "convert from x to y:" do
-    @tag :pending
     test "teaspoon to tablespoon" do
       assert KitchenCalculator.convert({:teaspoon, 15}, :tablespoon) == {:tablespoon, 5}
     end
 
-    @tag :pending
     test "cups to fluid ounces" do
       assert KitchenCalculator.convert({:cup, 4}, :fluid_ounce) == {:fluid_ounce, 32}
     end
 
-    @tag :pending
     test "fluid ounces to teaspoons" do
       assert KitchenCalculator.convert({:fluid_ounce, 4}, :teaspoon) == {:teaspoon, 24}
     end
 
-    @tag :pending
     test "tablespoons to cups" do
       assert KitchenCalculator.convert({:tablespoon, 320}, :cup) == {:cup, 20}
     end

--- a/exercises/concept/language-list/test/language_list_test.exs
+++ b/exercises/concept/language-list/test/language_list_test.exs
@@ -1,17 +1,14 @@
 defmodule LanguageListTest do
   use ExUnit.Case
 
-  # @tag :pending
   test "new list" do
     assert LanguageList.new() == []
   end
 
-  @tag :pending
   test "count an empty list" do
     assert LanguageList.new() |> LanguageList.count() == 0
   end
 
-  @tag :pending
   test "add a language to a list" do
     language = "Elixir"
     list = [language]
@@ -19,7 +16,6 @@ defmodule LanguageListTest do
     assert LanguageList.new() |> LanguageList.add(language) == list
   end
 
-  @tag :pending
   test "add several languages to a list" do
     list =
       LanguageList.new()
@@ -32,12 +28,10 @@ defmodule LanguageListTest do
     assert list == ["Elixir", "F#", "Erlang", "Haskell", "Clojure"]
   end
 
-  @tag :pending
   test "remove on an empty list results in error" do
     assert_raise ArgumentError, fn -> LanguageList.new() |> LanguageList.remove() end
   end
 
-  @tag :pending
   test "add then remove results in empty list" do
     list =
       LanguageList.new()
@@ -47,7 +41,6 @@ defmodule LanguageListTest do
     assert list == []
   end
 
-  @tag :pending
   test "adding two languages, when removed, removes first item" do
     list =
       LanguageList.new()
@@ -58,17 +51,14 @@ defmodule LanguageListTest do
     assert list == ["F#"]
   end
 
-  @tag :pending
   test "first on an empty list raises an error" do
     assert_raise ArgumentError, fn -> LanguageList.new() |> LanguageList.first() end
   end
 
-  @tag :pending
   test "add one language, then get the first" do
     assert LanguageList.new() |> LanguageList.add("Elixir") |> LanguageList.first() == "Elixir"
   end
 
-  @tag :pending
   test "add a few languages, then get the first" do
     first =
       LanguageList.new()
@@ -80,12 +70,10 @@ defmodule LanguageListTest do
     assert first == "F#"
   end
 
-  @tag :pending
   test "the count of a new list is 0" do
     assert LanguageList.new() |> LanguageList.count() == 0
   end
 
-  @tag :pending
   test "the count of a one-language list is 1" do
     count =
       LanguageList.new()
@@ -95,7 +83,6 @@ defmodule LanguageListTest do
     assert count == 1
   end
 
-  @tag :pending
   test "the count of a multiple-item list is equal to its length" do
     count =
       LanguageList.new()
@@ -107,12 +94,10 @@ defmodule LanguageListTest do
     assert count == 3
   end
 
-  @tag :pending
   test "an exciting language list" do
     assert LanguageList.exciting_list?(["Clojure", "Haskell", "Erlang", "F#", "Elixir"])
   end
 
-  @tag :pending
   test "not an exciting language list" do
     refute LanguageList.exciting_list?(["Java", "C", "JavaScript"])
   end

--- a/exercises/concept/lasagna/test/lasagna_test.exs
+++ b/exercises/concept/lasagna/test/lasagna_test.exs
@@ -2,37 +2,30 @@ defmodule LasagnaTest do
   use ExUnit.Case
   doctest Lasagna
 
-  # @tag :pending
   test "expected minutes in oven" do
     assert Lasagna.expected_minutes_in_oven() === 40
   end
 
-  @tag :pending
   test "remaining minutes in oven" do
     assert Lasagna.remaining_minutes_in_oven(25) === 15
   end
 
-  @tag :pending
   test "preparation time in minutes for one layer" do
     assert Lasagna.preparation_time_in_minutes(1) === 2
   end
 
-  @tag :pending
   test "preparation time in minutes for multiple layers" do
     assert Lasagna.preparation_time_in_minutes(4) === 8
   end
 
-  @tag :pending
   test "total time in minutes for one layer" do
     assert Lasagna.total_time_in_minutes(1, 30) === 32
   end
 
-  @tag :pending
   test "total time in minutes for multiple layers" do
     assert Lasagna.total_time_in_minutes(4, 8) === 16
   end
 
-  @tag :pending
   test "notification message" do
     assert Lasagna.alarm() === "Ding!"
   end

--- a/exercises/concept/library-fees/test/library_fees_test.exs
+++ b/exercises/concept/library-fees/test/library_fees_test.exs
@@ -2,13 +2,11 @@ defmodule LibraryFeesTest do
   use ExUnit.Case
 
   describe "datetime_from_string/1" do
-    # @tag :pending
     test "returns NaiveDateTime" do
       result = LibraryFees.datetime_from_string("2021-01-01T12:00:00Z")
       assert result.__struct__ == NaiveDateTime
     end
 
-    @tag :pending
     test "parses an ISO8601 string" do
       result = LibraryFees.datetime_from_string("2019-12-24T13:15:45Z")
       assert result == ~N[2019-12-24 13:15:45Z]
@@ -16,36 +14,30 @@ defmodule LibraryFeesTest do
   end
 
   describe "before_noon?/1" do
-    @tag :pending
     test "returns true if the given NaiveDateTime is before 12:00" do
       assert LibraryFees.before_noon?(~N[2020-06-06 11:59:59Z]) == true
     end
 
-    @tag :pending
     test "returns false if the given NaiveDateTime is after 12:00" do
       assert LibraryFees.before_noon?(~N[2021-01-03 12:01:01Z]) == false
     end
 
-    @tag :pending
     test "returns false if the given NaiveDateTime is exactly at 12:00" do
       assert LibraryFees.before_noon?(~N[2018-11-17 12:00:00Z]) == false
     end
   end
 
   describe "return_datetime/1" do
-    @tag :pending
     test "adds 28 days if the given NaiveDateTime is before 12:00" do
       result = LibraryFees.return_datetime(~N[2020-02-14 11:59:59Z])
       assert result == ~N[2020-03-13 11:59:59Z]
     end
 
-    @tag :pending
     test "adds 29 days if the given NaiveDateTime is after 12:00" do
       result = LibraryFees.return_datetime(~N[2021-01-03 12:01:01Z])
       assert result == ~N[2021-02-01 12:01:01Z]
     end
 
-    @tag :pending
     test "adds 29 days if the given NaiveDateTime is exactly at 12:00" do
       result = LibraryFees.return_datetime(~N[2018-12-01 12:00:00Z])
       assert result == ~N[2018-12-30 12:00:00Z]
@@ -53,25 +45,21 @@ defmodule LibraryFeesTest do
   end
 
   describe "days_late/2" do
-    @tag :pending
     test "returns 0 when identical datetimes" do
       result = LibraryFees.days_late(~N[2021-02-01 12:00:00Z], ~N[2021-02-01 12:00:00Z])
       assert result == 0
     end
 
-    @tag :pending
     test "returns 0 when identical dates, but different times" do
       result = LibraryFees.days_late(~N[2019-03-11 13:50:00Z], ~N[2019-03-11 12:00:00Z])
       assert result == 0
     end
 
-    @tag :pending
     test "returns 0 when planned return date is later than actual return date" do
       result = LibraryFees.days_late(~N[2020-12-03 09:50:00Z], ~N[2020-11-29 16:00:00Z])
       assert result == 0
     end
 
-    @tag :pending
     test "returns date difference in numbers of days when planned return date is earlier than actual return date" do
       result = LibraryFees.days_late(~N[2020-06-12 09:50:00Z], ~N[2020-06-21 16:00:00Z])
       assert result == 9
@@ -79,81 +67,67 @@ defmodule LibraryFeesTest do
   end
 
   describe "monday?" do
-    @tag :pending
     test "2021-02-01 was a Monday" do
       assert LibraryFees.monday?(~N[2021-02-01 14:01:00Z]) == true
     end
 
-    @tag :pending
     test "2020-03-16 was a Monday" do
       assert LibraryFees.monday?(~N[2020-03-16 09:23:52Z]) == true
     end
 
-    @tag :pending
     test "2020-04-22 was a Monday" do
       assert LibraryFees.monday?(~N[2019-04-22 15:44:03Z]) == true
     end
 
-    @tag :pending
     test "2021-02-02 was a Tuesday" do
       assert LibraryFees.monday?(~N[2021-02-02 15:07:00Z]) == false
     end
 
-    @tag :pending
     test "2020-03-14 was a Friday" do
       assert LibraryFees.monday?(~N[2020-03-14 08:54:51Z]) == false
     end
 
-    @tag :pending
     test "2019-04-28 was a Sunday" do
       assert LibraryFees.monday?(~N[2019-04-28 11:37:12Z]) == false
     end
   end
 
   describe "calculate_late_fee/2" do
-    @tag :pending
     test "returns 0 if the book was returned less than 28 days after a morning checkout" do
       result = LibraryFees.calculate_late_fee("2018-11-01T09:00:00Z", "2018-11-13T14:12:00Z", 123)
       assert result == 0
     end
 
-    @tag :pending
     test "returns 0 if the book was returned exactly 28 days after a morning checkout" do
       result = LibraryFees.calculate_late_fee("2018-11-01T09:00:00Z", "2018-11-29T14:12:00Z", 123)
       assert result == 0
     end
 
-    @tag :pending
     test "returns the rate for one day if the book was returned exactly 29 days after a morning checkout" do
       result = LibraryFees.calculate_late_fee("2018-11-01T09:00:00Z", "2018-11-30T14:12:00Z", 320)
       assert result == 320
     end
 
-    @tag :pending
     test "returns 0 if the book was returned less than 29 days after an afternoon checkout" do
       result = LibraryFees.calculate_late_fee("2019-05-01T16:12:00Z", "2019-05-17T14:32:45Z", 400)
       assert result == 0
     end
 
-    @tag :pending
     test "returns 0 if the book was returned exactly 29 days after an afternoon checkout" do
       result = LibraryFees.calculate_late_fee("2019-05-01T16:12:00Z", "2019-05-30T14:32:45Z", 313)
       assert result == 0
     end
 
-    @tag :pending
     test "returns the rate for one day if the book was returned exactly 30 days after an afternoon checkout" do
       result = LibraryFees.calculate_late_fee("2019-05-01T16:12:00Z", "2019-05-31T14:32:45Z", 234)
       assert result == 234
     end
 
-    @tag :pending
     test "multiplies the number of days late by the rate for one day" do
       result = LibraryFees.calculate_late_fee("2021-01-01T08:00:00Z", "2021-02-13T08:00:00Z", 111)
       assert result == 111 * 15
     end
 
-    @tag :pending
     test "late fees are 50% off (rounded down) when the book is returned on a Monday" do
       result = LibraryFees.calculate_late_fee("2021-01-01T08:00:00Z", "2021-02-15T08:00:00Z", 111)
       assert result == trunc(111 * 17 * 0.5)

--- a/exercises/concept/log-level/test/log_level_test.exs
+++ b/exercises/concept/log-level/test/log_level_test.exs
@@ -2,49 +2,41 @@ defmodule LogLevelTest do
   use ExUnit.Case
 
   describe "LogLevel.to_label/1" do
-    # @tag :pending
     test "level 0 has label trace only in a non-legacy app" do
       assert LogLevel.to_label(0, false) == :trace
       assert LogLevel.to_label(0, true) == :unknown
     end
 
-    @tag :pending
     test "level 1 has label debug" do
       assert LogLevel.to_label(1, false) == :debug
       assert LogLevel.to_label(1, true) == :debug
     end
 
-    @tag :pending
     test "level 2 has label info" do
       assert LogLevel.to_label(2, false) == :info
       assert LogLevel.to_label(2, true) == :info
     end
 
-    @tag :pending
     test "level 3 has label warning" do
       assert LogLevel.to_label(3, false) == :warning
       assert LogLevel.to_label(3, true) == :warning
     end
 
-    @tag :pending
     test "level 4 has label error" do
       assert LogLevel.to_label(4, false) == :error
       assert LogLevel.to_label(4, true) == :error
     end
 
-    @tag :pending
     test "level 5 has label fatal only in a non-legacy app" do
       assert LogLevel.to_label(5, false) == :fatal
       assert LogLevel.to_label(5, true) == :unknown
     end
 
-    @tag :pending
     test "level 6 has label unknown" do
       assert LogLevel.to_label(6, false) == :unknown
       assert LogLevel.to_label(6, true) == :unknown
     end
 
-    @tag :pending
     test "level -1 has label unknown" do
       assert LogLevel.to_label(-1, false) == :unknown
       assert LogLevel.to_label(-1, true) == :unknown
@@ -52,47 +44,39 @@ defmodule LogLevelTest do
   end
 
   describe "LogLevel.alert_recipient/2" do
-    @tag :pending
     test "fatal code sends alert to ops" do
       assert LogLevel.alert_recipient(5, false) == :ops
     end
 
-    @tag :pending
     test "error code sends alert to ops" do
       assert LogLevel.alert_recipient(4, false) == :ops
       assert LogLevel.alert_recipient(4, true) == :ops
     end
 
-    @tag :pending
     test "unknown code sends alert to dev team 1 for a legacy app" do
       assert LogLevel.alert_recipient(6, true) == :dev1
       assert LogLevel.alert_recipient(0, true) == :dev1
       assert LogLevel.alert_recipient(5, true) == :dev1
     end
 
-    @tag :pending
     test "unknown code sends alert to dev team 2" do
       assert LogLevel.alert_recipient(6, false) == :dev2
     end
 
-    @tag :pending
     test "trace code does not send alert" do
       refute LogLevel.alert_recipient(0, false)
     end
 
-    @tag :pending
     test "debug code does not send alert" do
       refute LogLevel.alert_recipient(1, false)
       refute LogLevel.alert_recipient(1, true)
     end
 
-    @tag :pending
     test "info code does not send alert" do
       refute LogLevel.alert_recipient(2, false)
       refute LogLevel.alert_recipient(2, true)
     end
 
-    @tag :pending
     test "warning code does not send alert" do
       refute LogLevel.alert_recipient(3, false)
       refute LogLevel.alert_recipient(3, true)

--- a/exercises/concept/lucas-numbers/test/lucas_numbers_test.exs
+++ b/exercises/concept/lucas-numbers/test/lucas_numbers_test.exs
@@ -5,64 +5,54 @@ defmodule LucasNumbersTest do
     assert LucasNumbers.generate(1) == [2]
   end
 
-  @tag :pending
   test "generates a sequence of length 2" do
     assert LucasNumbers.generate(2) == [2, 1]
   end
 
-  @tag :pending
   test "generates a sequence of length 3" do
     assert LucasNumbers.generate(3) == [2, 1, 3]
   end
 
-  @tag :pending
   test "generates a sequence of length 4" do
     assert LucasNumbers.generate(4) == [2, 1, 3, 4]
   end
 
-  @tag :pending
   test "generates a sequence of length 5" do
     sequence = [2, 1, 3, 4, 7]
 
     assert LucasNumbers.generate(5) == sequence
   end
 
-  @tag :pending
   test "generates a sequence of length 6" do
     sequence = [2, 1, 3, 4, 7, 11]
 
     assert LucasNumbers.generate(6) == sequence
   end
 
-  @tag :pending
   test "generates a sequence of length 7" do
     sequence = [2, 1, 3, 4, 7, 11, 18]
 
     assert LucasNumbers.generate(7) == sequence
   end
 
-  @tag :pending
   test "generates a sequence of length 8" do
     sequence = [2, 1, 3, 4, 7, 11, 18, 29]
 
     assert LucasNumbers.generate(8) == sequence
   end
 
-  @tag :pending
   test "generates a sequence of length 9" do
     sequence = [2, 1, 3, 4, 7, 11, 18, 29, 47]
 
     assert LucasNumbers.generate(9) == sequence
   end
 
-  @tag :pending
   test "generates a sequence of length 10" do
     sequence = [2, 1, 3, 4, 7, 11, 18, 29, 47, 76]
 
     assert LucasNumbers.generate(10) == sequence
   end
 
-  @tag :pending
   test "generates a sequence of length 25" do
     sequence = [
       2,
@@ -95,14 +85,12 @@ defmodule LucasNumbersTest do
     assert LucasNumbers.generate(25) == sequence
   end
 
-  @tag :pending
   test "catch incorrect non-integer arguments" do
     assert_raise ArgumentError, "count must be specified as an integer >= 1", fn ->
       LucasNumbers.generate("Hello world!")
     end
   end
 
-  @tag :pending
   test "catch incorrect integer arguments" do
     assert_raise ArgumentError, "count must be specified as an integer >= 1", fn ->
       LucasNumbers.generate(-1)

--- a/exercises/concept/mensch-aergere-dich-nicht/test/mensch_aergere_dich_nicht_test.exs
+++ b/exercises/concept/mensch-aergere-dich-nicht/test/mensch_aergere_dich_nicht_test.exs
@@ -2,7 +2,6 @@ defmodule MenschAergereDichNichtTest do
   use ExUnit.Case
 
   describe "d6/0" do
-    # @tag :pending
     test "returns an integer from 1 to 6" do
       assert 1..100
              |> Enum.map(fn _ -> MenschAergereDichNicht.d6() end)
@@ -11,24 +10,20 @@ defmodule MenschAergereDichNichtTest do
   end
 
   describe "roll/0" do
-    @tag :pending
     test "returns a stream" do
       assert is_function(MenschAergereDichNicht.roll())
       assert is_list(Enum.to_list(MenschAergereDichNicht.roll()))
     end
 
-    @tag :pending
     test "returns a list of integers" do
       assert [roll | _] = Enum.to_list(MenschAergereDichNicht.roll())
       assert roll in 1..6
     end
 
-    @tag :pending
     test "allows using a rigged die" do
       assert Enum.to_list(MenschAergereDichNicht.roll(fn -> 4 end)) == [4]
     end
 
-    @tag :pending
     test "continues rolling when rolled a 6" do
       {:ok, agent} = Agent.start_link(fn -> [6, 6, 6, 3, 1] end)
 

--- a/exercises/concept/name-badge/test/name_badge_test.exs
+++ b/exercises/concept/name-badge/test/name_badge_test.exs
@@ -3,29 +3,24 @@ defmodule NameBadgeTest do
   doctest NameBadge
 
   describe "print/3" do
-    # @tag :pending
     test "prints the employee badge with full data" do
       assert NameBadge.print(455, "Mary M. Brown", "MARKETING") ==
                "[455] - Mary M. Brown - MARKETING"
     end
 
-    @tag :pending
     test "uppercases the department" do
       assert NameBadge.print(89, "Jack McGregor", "Procurement") ==
                "[89] - Jack McGregor - PROCUREMENT"
     end
 
-    @tag :pending
     test "prints the employee badge without id" do
       assert NameBadge.print(nil, "Barbara White", "Security") == "Barbara White - SECURITY"
     end
 
-    @tag :pending
     test "prints the owner badge" do
       assert NameBadge.print(1, "Anna Johnson", nil) == "[1] - Anna Johnson - OWNER"
     end
 
-    @tag :pending
     test "prints the owner badge without id" do
       assert NameBadge.print(nil, "Stephen Dann", nil) == "Stephen Dann - OWNER"
     end

--- a/exercises/concept/pacman-rules/test/rules_test.exs
+++ b/exercises/concept/pacman-rules/test/rules_test.exs
@@ -2,68 +2,56 @@ defmodule RulesTest do
   use ExUnit.Case
 
   describe "eat_ghost?/2" do
-    # @tag :pending
     test "ghost gets eaten" do
       assert Rules.eat_ghost?(true, true)
     end
 
-    @tag :pending
     test "ghost does not get eaten because no power pellet active" do
       refute Rules.eat_ghost?(false, true)
     end
 
-    @tag :pending
     test "ghost does not get eaten because not touching ghost" do
       refute Rules.eat_ghost?(true, false)
     end
   end
 
   describe "score?/2" do
-    @tag :pending
     test "score when eating dot" do
       assert Rules.score?(false, true)
     end
 
-    @tag :pending
     test "score when eating power pellet" do
       assert Rules.score?(true, false)
     end
 
-    @tag :pending
     test "no score when nothing eaten" do
       refute Rules.score?(false, false)
     end
   end
 
   describe "lose?/2" do
-    @tag :pending
     test "lose if touching a ghost without a power pellet active" do
       assert Rules.lose?(false, true)
     end
 
-    @tag :pending
     test "don't lose if touching a ghost with a power pellet active" do
       refute Rules.lose?(true, true)
     end
 
-    @tag :pending
     test "don't lose if not touching a ghost" do
       refute Rules.lose?(true, false)
     end
   end
 
   describe "win?/3" do
-    @tag :pending
     test "win if all dots eaten" do
       assert Rules.win?(true, false, false)
     end
 
-    @tag :pending
     test "don't win if all dots eaten, but touching a ghost" do
       refute Rules.win?(true, false, true)
     end
 
-    @tag :pending
     test "win if all dots eaten and touching a ghost with a power pellet active" do
       assert Rules.win?(true, true, true)
     end

--- a/exercises/concept/remote-control-car/test/remote_control_car_test.exs
+++ b/exercises/concept/remote-control-car/test/remote_control_car_test.exs
@@ -1,7 +1,6 @@
 defmodule RemoteControlCarTest do
   use ExUnit.Case
 
-  # @tag :pending
   test "required key 'nickname' should not have a default value" do
     assert_raise ArgumentError, fn ->
       quote do
@@ -11,7 +10,6 @@ defmodule RemoteControlCarTest do
     end
   end
 
-  @tag :pending
   test "new" do
     car = RemoteControlCar.new()
 
@@ -21,7 +19,6 @@ defmodule RemoteControlCarTest do
     assert car.nickname == "none"
   end
 
-  @tag :pending
   test "new with nickname" do
     nickname = "Red"
     car = RemoteControlCar.new(nickname)
@@ -32,7 +29,6 @@ defmodule RemoteControlCarTest do
     assert car.nickname == nickname
   end
 
-  @tag :pending
   test "display distance raises error when not given struct" do
     fake_car = %{
       battery_percentage: 100,
@@ -45,14 +41,12 @@ defmodule RemoteControlCarTest do
     end)
   end
 
-  @tag :pending
   test "display distance of new" do
     car = RemoteControlCar.new()
 
     assert RemoteControlCar.display_distance(car) == "0 meters"
   end
 
-  @tag :pending
   test "display distance of driven" do
     car = RemoteControlCar.new()
     car = %{car | distance_driven_in_meters: 20}
@@ -60,7 +54,6 @@ defmodule RemoteControlCarTest do
     assert RemoteControlCar.display_distance(car) == "20 meters"
   end
 
-  @tag :pending
   test "display battery raises error when not given struct" do
     fake_car = %{
       battery_percentage: 100,
@@ -73,14 +66,12 @@ defmodule RemoteControlCarTest do
     end)
   end
 
-  @tag :pending
   test "display battery of new" do
     car = RemoteControlCar.new()
 
     assert RemoteControlCar.display_battery(car) == "Battery at 100%"
   end
 
-  @tag :pending
   test "display battery of dead battery" do
     car = RemoteControlCar.new()
     car = %{car | battery_percentage: 0}
@@ -88,7 +79,6 @@ defmodule RemoteControlCarTest do
     assert RemoteControlCar.display_battery(car) == "Battery empty"
   end
 
-  @tag :pending
   test "drive raises error when not given struct" do
     fake_car = %{
       battery_percentage: 100,
@@ -101,7 +91,6 @@ defmodule RemoteControlCarTest do
     end)
   end
 
-  @tag :pending
   test "drive with battery" do
     car = RemoteControlCar.new() |> RemoteControlCar.drive()
 
@@ -110,7 +99,6 @@ defmodule RemoteControlCarTest do
     assert car.distance_driven_in_meters == 20
   end
 
-  @tag :pending
   test "drive with dead battery" do
     car =
       RemoteControlCar.new()

--- a/exercises/concept/rpg-character-sheet/test/rpg/character_sheet_test.exs
+++ b/exercises/concept/rpg-character-sheet/test/rpg/character_sheet_test.exs
@@ -3,7 +3,6 @@ defmodule RPG.CharacterSheetTest do
   import ExUnit.CaptureIO
 
   describe "welcome/0" do
-    # @tag :pending
     test "it prints a welcome message" do
       io =
         capture_io(fn ->
@@ -15,7 +14,6 @@ defmodule RPG.CharacterSheetTest do
   end
 
   describe "ask_name/0" do
-    @tag :pending
     test "it prints a prompt" do
       io =
         capture_io("\n", fn ->
@@ -25,7 +23,6 @@ defmodule RPG.CharacterSheetTest do
       assert io == "What is your character's name?\n"
     end
 
-    @tag :pending
     test "returns the trimmed input" do
       capture_io("Maxwell The Great\n", fn ->
         assert RPG.CharacterSheet.ask_name() == "Maxwell The Great"
@@ -34,7 +31,6 @@ defmodule RPG.CharacterSheetTest do
   end
 
   describe "ask_class/0" do
-    @tag :pending
     test "it prints a prompt" do
       io =
         capture_io("\n", fn ->
@@ -44,7 +40,6 @@ defmodule RPG.CharacterSheetTest do
       assert io == "What is your character's class?\n"
     end
 
-    @tag :pending
     test "returns the trimmed input" do
       capture_io("rogue\n", fn ->
         assert RPG.CharacterSheet.ask_class() == "rogue"
@@ -53,7 +48,6 @@ defmodule RPG.CharacterSheetTest do
   end
 
   describe "ask_level/0" do
-    @tag :pending
     test "it prints a prompt" do
       io =
         capture_io("1\n", fn ->
@@ -63,7 +57,6 @@ defmodule RPG.CharacterSheetTest do
       assert io == "What is your character's level?\n"
     end
 
-    @tag :pending
     test "returns the trimmed input as an integer" do
       capture_io("3\n", fn ->
         assert RPG.CharacterSheet.ask_level() == 3
@@ -72,7 +65,6 @@ defmodule RPG.CharacterSheetTest do
   end
 
   describe "run/0" do
-    @tag :pending
     test "it asks for name, class, and level" do
       io =
         capture_io("Susan The Fearless\nfighter\n6\n", fn ->
@@ -87,7 +79,6 @@ defmodule RPG.CharacterSheetTest do
              """
     end
 
-    @tag :pending
     test "it returns a character map" do
       capture_io("The Stranger\nrogue\n2\n", fn ->
         assert RPG.CharacterSheet.run() == %{
@@ -98,7 +89,6 @@ defmodule RPG.CharacterSheetTest do
       end)
     end
 
-    @tag :pending
     test "it inspects the character map" do
       io =
         capture_io("Anne\nhealer\n4\n", fn ->

--- a/exercises/concept/rpn-calculator-inspection/test/rpn_calculator_inspection_test.exs
+++ b/exercises/concept/rpn-calculator-inspection/test/rpn_calculator_inspection_test.exs
@@ -31,7 +31,6 @@ defmodule RPNCalculatorInspectionTest do
   end
 
   describe "start_reliability_check" do
-    # @tag :pending
     test "returns a map with test data" do
       calculator = fn _ -> 0 end
       input = "1 2 +"
@@ -41,7 +40,6 @@ defmodule RPNCalculatorInspectionTest do
       assert result.input == input
     end
 
-    @tag :pending
     test "starts a linked process" do
       old_value = Process.flag(:trap_exit, true)
 
@@ -56,7 +54,6 @@ defmodule RPNCalculatorInspectionTest do
       Process.flag(:trap_exit, old_value)
     end
 
-    @tag :pending
     test "the process runs the calculator function with the given input" do
       caller_process_pid = self()
 
@@ -70,7 +67,6 @@ defmodule RPNCalculatorInspectionTest do
   end
 
   describe "await_reliability_check_result" do
-    @tag :pending
     test "adds `input` => :ok to the results after a normal exit" do
       caller_process_pid = self()
       test_data = %{pid: caller_process_pid, input: "2 3 +"}
@@ -86,7 +82,6 @@ defmodule RPNCalculatorInspectionTest do
                expected_result
     end
 
-    @tag :pending
     test "adds `input` => :error to the results after an abnormal exit" do
       caller_process_pid = self()
       test_data = %{pid: caller_process_pid, input: "3 0 /"}
@@ -102,7 +97,6 @@ defmodule RPNCalculatorInspectionTest do
                expected_result
     end
 
-    @tag :pending
     test "adds `input` => :timeout to the results if no message arrives in 100ms" do
       caller_process_pid = self()
       test_data = %{pid: caller_process_pid, input: "24 12 /"}
@@ -125,7 +119,6 @@ defmodule RPNCalculatorInspectionTest do
       Task.await(task)
     end
 
-    @tag :pending
     test "normal exit messages from processes whose pids don't match stay in the inbox" do
       caller_process_pid = self()
       other_process_pid = spawn(fn -> nil end)
@@ -145,7 +138,6 @@ defmodule RPNCalculatorInspectionTest do
       assert Keyword.get(Process.info(self()), :message_queue_len) == 1
     end
 
-    @tag :pending
     test "abnormal exit messages from processes whose pids don't match stay in the inbox" do
       caller_process_pid = self()
       other_process_pid = spawn(fn -> nil end)
@@ -165,7 +157,6 @@ defmodule RPNCalculatorInspectionTest do
       assert Keyword.get(Process.info(self()), :message_queue_len) == 1
     end
 
-    @tag :pending
     test "any other messages stay in the inbox" do
       caller_process_pid = self()
       test_data = %{pid: caller_process_pid, input: "4 2 /"}
@@ -186,7 +177,6 @@ defmodule RPNCalculatorInspectionTest do
       assert Keyword.get(Process.info(self()), :message_queue_len) == 3
     end
 
-    @tag :pending
     test "doesn't change the trap_exit flag of the caller process" do
       caller_process_pid = self()
       Process.flag(:trap_exit, false)
@@ -219,7 +209,6 @@ defmodule RPNCalculatorInspectionTest do
   end
 
   describe "reliability_check" do
-    @tag :pending
     test "returns an empty map when input list empty" do
       inputs = []
       calculator = &RPNCalculator.unsafe_division/1
@@ -227,7 +216,6 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.reliability_check(calculator, inputs) == outputs
     end
 
-    @tag :pending
     test "returns a map with inputs as keys and :ok as values" do
       inputs = ["4 2 /", "8 2 /", "6 3 /"]
       calculator = &RPNCalculator.unsafe_division/1
@@ -241,7 +229,6 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.reliability_check(calculator, inputs) == outputs
     end
 
-    @tag :pending
     test "returns a map when input list has 1000 elements" do
       inputs = Enum.map(1..1000, &"#{2 * &1} #{&1} /")
       calculator = &RPNCalculator.unsafe_division/1
@@ -250,7 +237,6 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.reliability_check(calculator, inputs) == outputs
     end
 
-    @tag :pending
     test "returns a map when input list has 1000 elements and the calculator takes 50ms for each calculation" do
       inputs = Enum.map(1..1000, &"#{2 * &1} #{&1} /")
       calculator = fn input -> :timer.sleep(50) && RPNCalculator.unsafe_division(input) end
@@ -259,7 +245,6 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.reliability_check(calculator, inputs) == outputs
     end
 
-    @tag :pending
     test "returns :error values for inputs that cause the calculator to crash" do
       inputs = ["3 0 /", "22 11 /", "4 0 /"]
       calculator = &RPNCalculator.unsafe_division/1
@@ -273,7 +258,6 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.reliability_check(calculator, inputs) == outputs
     end
 
-    @tag :pending
     test "returns a map when input list has 1000 elements and all of them crash" do
       inputs = Enum.map(1..1000, &"#{2 * &1} 0 /")
       calculator = &RPNCalculator.unsafe_division/1
@@ -282,7 +266,6 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.reliability_check(calculator, inputs) == outputs
     end
 
-    @tag :pending
     test "restores the original value of the trap_exit flag" do
       inputs = ["3 0 /", "22 11 /", "4 0 /"]
       calculator = &RPNCalculator.unsafe_division/1
@@ -304,7 +287,6 @@ defmodule RPNCalculatorInspectionTest do
   end
 
   describe "correctness_check" do
-    @tag :pending
     test "returns an empty list when input list empty" do
       inputs = []
       calculator = &RPNCalculator.unsafe_division/1
@@ -312,7 +294,6 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.correctness_check(calculator, inputs) == outputs
     end
 
-    @tag :pending
     test "returns a list of results" do
       inputs = ["3 2 /", "4 2 /", "5 2 /"]
       calculator = &RPNCalculator.unsafe_division/1
@@ -320,7 +301,6 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.correctness_check(calculator, inputs) == outputs
     end
 
-    @tag :pending
     test "returns a list of results when input list has 1000 elements" do
       inputs = Enum.map(1..1000, &"100 #{&1} /")
       calculator = &RPNCalculator.unsafe_division/1
@@ -328,7 +308,6 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.correctness_check(calculator, inputs) == outputs
     end
 
-    @tag :pending
     test "returns a list of results when input list has 1000 elements and the calculator takes 50ms for each calculation" do
       inputs = Enum.map(1..1000, &"100 #{&1} /")
       calculator = fn input -> :timer.sleep(50) && RPNCalculator.unsafe_division(input) end
@@ -336,7 +315,6 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.correctness_check(calculator, inputs) == outputs
     end
 
-    @tag :pending
     test "awaits a single task for 100ms" do
       inputs = ["1 1 /1"]
       calculator = fn _ -> :timer.sleep(500) end

--- a/exercises/concept/rpn-calculator-output/test/rpn_calculator/output_test.exs
+++ b/exercises/concept/rpn-calculator-output/test/rpn_calculator/output_test.exs
@@ -18,7 +18,6 @@ defmodule RPNCalculator.OutputTest do
   end
 
   describe "write/3" do
-    # @tag :pending
     test "returns ok tuple if function succeeds" do
       resource = __MODULE__
       filename = "filename"
@@ -27,7 +26,6 @@ defmodule RPNCalculator.OutputTest do
       assert {:ok, equation} == RPNCalculator.Output.write(resource, filename, equation)
     end
 
-    @tag :pending
     @use_open_error_message """
     Use the open/1 function from the `resource` specified in the arguments to open `filename`.
 
@@ -42,7 +40,6 @@ defmodule RPNCalculator.OutputTest do
       assert_received {:open, ^filename}, @use_open_error_message
     end
 
-    @tag :pending
     @use_write_error_message """
     Use IO.write/2 to write to the opened `filename`.
     """
@@ -56,7 +53,6 @@ defmodule RPNCalculator.OutputTest do
              @use_write_error_message
     end
 
-    @tag :pending
     @use_close_error_message """
     Use the close/1 function from the `resource` specified in the arguments to close the opened file handle.
 
@@ -71,7 +67,6 @@ defmodule RPNCalculator.OutputTest do
       assert_received :close, @use_close_error_message
     end
 
-    @tag :pending
     test "rescues and returns error tuple from raised error" do
       resource = __MODULE__
       bad_filename = "bad_filename"
@@ -81,7 +76,6 @@ defmodule RPNCalculator.OutputTest do
                RPNCalculator.Output.write(resource, bad_filename, equation)
     end
 
-    @tag :pending
     test "closes resource even when rescuing from raised error" do
       resource = __MODULE__
       bad_filename = "bad_filename"

--- a/exercises/concept/rpn-calculator/test/rpn_calculator_test.exs
+++ b/exercises/concept/rpn-calculator/test/rpn_calculator_test.exs
@@ -1,19 +1,16 @@
 defmodule RPNCalculatorTest do
   use ExUnit.Case
 
-  # @tag :pending
   test "let it crash" do
     assert_raise(RuntimeError, fn ->
       RPNCalculator.calculate!([], fn _ -> raise "test error" end)
     end)
   end
 
-  @tag :pending
   test "rescue the crash, no message" do
     assert RPNCalculator.calculate([], fn _ -> raise "test error" end) == :error
   end
 
-  @tag :pending
   test "rescue the crash, get error tuple with message" do
     assert RPNCalculator.calculate_verbose([], fn _ -> raise "test error" end) ==
              {:error, "test error"}

--- a/exercises/concept/secrets/test/secrets_test.exs
+++ b/exercises/concept/secrets/test/secrets_test.exs
@@ -2,13 +2,11 @@ defmodule SecretsTest do
   use ExUnit.Case
 
   describe "secret_add" do
-    # @tag :pending
     test "add 3" do
       add = Secrets.secret_add(3)
       assert add.(3) === 6
     end
 
-    @tag :pending
     test "add 6" do
       add = Secrets.secret_add(6)
       assert add.(9) === 15
@@ -16,13 +14,11 @@ defmodule SecretsTest do
   end
 
   describe "secret_subtract" do
-    @tag :pending
     test "subtract 3" do
       subtract = Secrets.secret_subtract(3)
       assert subtract.(6) === 3
     end
 
-    @tag :pending
     test "subtract 6" do
       subtract = Secrets.secret_subtract(6)
       assert subtract.(3) === -3
@@ -30,13 +26,11 @@ defmodule SecretsTest do
   end
 
   describe "secret_multiply" do
-    @tag :pending
     test "multiply by 3" do
       multiply = Secrets.secret_multiply(3)
       assert multiply.(6) === 18
     end
 
-    @tag :pending
     test "multiply by 6" do
       multiply = Secrets.secret_multiply(6)
       assert multiply.(7) === 42
@@ -44,13 +38,11 @@ defmodule SecretsTest do
   end
 
   describe "secret_divide" do
-    @tag :pending
     test "divide by 3" do
       divide = Secrets.secret_divide(3)
       assert divide.(6) === 2
     end
 
-    @tag :pending
     test "divide by 6" do
       divide = Secrets.secret_divide(6)
       assert divide.(7) === 1
@@ -58,13 +50,11 @@ defmodule SecretsTest do
   end
 
   describe "secret_and" do
-    @tag :pending
     test "2 and 1" do
       ander = Secrets.secret_and(1)
       assert ander.(2) === 0
     end
 
-    @tag :pending
     test "7 and 7" do
       ander = Secrets.secret_and(7)
       assert ander.(7) === 7
@@ -72,13 +62,11 @@ defmodule SecretsTest do
   end
 
   describe "secret_xor" do
-    @tag :pending
     test "2 xor 1" do
       xorer = Secrets.secret_xor(1)
       assert xorer.(2) === 3
     end
 
-    @tag :pending
     test "7 xor 7" do
       xorer = Secrets.secret_xor(7)
       assert xorer.(7) === 0
@@ -86,7 +74,6 @@ defmodule SecretsTest do
   end
 
   describe "secret_combine" do
-    @tag :pending
     test "5 add 10 then subtract 5" do
       f = Secrets.secret_add(10)
       g = Secrets.secret_subtract(5)
@@ -95,7 +82,6 @@ defmodule SecretsTest do
       assert h.(5) === 10
     end
 
-    @tag :pending
     test "100 multiply by 2 then subtract 20" do
       f = Secrets.secret_multiply(2)
       g = Secrets.secret_subtract(20)
@@ -104,7 +90,6 @@ defmodule SecretsTest do
       assert h.(100) === 180
     end
 
-    @tag :pending
     test "100 divide by 10 then add 20" do
       f = Secrets.secret_divide(10)
       g = Secrets.secret_add(10)
@@ -113,7 +98,6 @@ defmodule SecretsTest do
       assert h.(100) === 20
     end
 
-    @tag :pending
     test "32 divide by 3 then multiply 5" do
       f = Secrets.secret_divide(3)
       g = Secrets.secret_add(5)
@@ -122,7 +106,6 @@ defmodule SecretsTest do
       assert h.(32) === 15
     end
 
-    @tag :pending
     test "7 and 3 then and 5" do
       f = Secrets.secret_and(3)
       g = Secrets.secret_and(5)
@@ -131,7 +114,6 @@ defmodule SecretsTest do
       assert h.(7) === 1
     end
 
-    @tag :pending
     test "7 and 7 then and 7" do
       f = Secrets.secret_and(7)
       g = Secrets.secret_and(7)
@@ -140,7 +122,6 @@ defmodule SecretsTest do
       assert h.(7) === 7
     end
 
-    @tag :pending
     test "4 xor 1 then xor 2" do
       f = Secrets.secret_xor(1)
       g = Secrets.secret_xor(2)
@@ -149,7 +130,6 @@ defmodule SecretsTest do
       assert h.(4) === 7
     end
 
-    @tag :pending
     test "7 xor 7 then xor 7" do
       f = Secrets.secret_xor(7)
       g = Secrets.secret_xor(7)
@@ -158,7 +138,6 @@ defmodule SecretsTest do
       assert h.(7) === 7
     end
 
-    @tag :pending
     test "4 add 3 then xor 7" do
       f = Secrets.secret_add(3)
       g = Secrets.secret_xor(7)
@@ -167,7 +146,6 @@ defmodule SecretsTest do
       assert h.(4) === 0
     end
 
-    @tag :pending
     test "81 divide by 9 then and 7" do
       f = Secrets.secret_divide(9)
       g = Secrets.secret_and(7)

--- a/exercises/concept/stack-underflow/test/rpn_calculator/exception_test.exs
+++ b/exercises/concept/stack-underflow/test/rpn_calculator/exception_test.exs
@@ -8,19 +8,16 @@ defmodule RPNCalculator.ExceptionTest do
   # allows for meaningful error messages.
   cond do
     config[:undefined_division_by_zero_error_module] ->
-      # @tag :pending
       test "DivisionByZeroError defined" do
         flunk("Implement the DivisionByZeroError inside of the `RPNCalculator.Exception` module")
       end
 
     config[:undefined_division_by_zero_error_exception] ->
-      # @tag :pending
       test "DivisionByZeroError defined" do
         flunk("define DivisionByZeroError exception using `defexception`")
       end
 
     true ->
-      # @tag :pending
       test "DivisionByZeroError fields defined by `defexception`" do
         assert %RPNCalculator.Exception.DivisionByZeroError{}.__exception__ == true
 
@@ -31,7 +28,6 @@ defmodule RPNCalculator.ExceptionTest do
                  "division by zero occurred"
       end
 
-      @tag :pending
       test "DivisionByZeroError message when raised with raise/1" do
         assert_raise(
           RPNCalculator.Exception.DivisionByZeroError,
@@ -45,19 +41,16 @@ defmodule RPNCalculator.ExceptionTest do
 
   cond do
     config[:undefined_stack_underflow_error_module] ->
-      # @tag :pending
       test "StackUnderflowError defined" do
         flunk("Implement the StackUnderflowError inside of the `RPNCalculator.Exception` module")
       end
 
     config[:undefined_stack_underflow_error_exception] ->
-      # @tag :pending
       test "StackUnderflowError defined" do
         flunk("define StackUnderflowError exception using `defexception`")
       end
 
     true ->
-      # @tag :pending
       test "StackUnderflowError fields defined by `defexception`" do
         assert %RPNCalculator.Exception.StackUnderflowError{}.__exception__ == true
 
@@ -68,7 +61,6 @@ defmodule RPNCalculator.ExceptionTest do
                  "stack underflow occurred"
       end
 
-      @tag :pending
       test "StackUnderflowError message when raised with raise/1" do
         assert_raise(
           RPNCalculator.Exception.StackUnderflowError,
@@ -79,7 +71,6 @@ defmodule RPNCalculator.ExceptionTest do
         )
       end
 
-      @tag :pending
       test "StackUnderflowError message when raised with raise/2" do
         assert_raise(
           RPNCalculator.Exception.StackUnderflowError,
@@ -92,7 +83,6 @@ defmodule RPNCalculator.ExceptionTest do
   end
 
   describe "divide/2" do
-    @tag :pending
     test "when stack doesn't contain any numbers, raise StackUnderflowError" do
       assert_raise(
         RPNCalculator.Exception.StackUnderflowError,
@@ -103,7 +93,6 @@ defmodule RPNCalculator.ExceptionTest do
       )
     end
 
-    @tag :pending
     test "when stack contains only one number, raise StackUnderflowError" do
       assert_raise(
         RPNCalculator.Exception.StackUnderflowError,
@@ -114,7 +103,6 @@ defmodule RPNCalculator.ExceptionTest do
       )
     end
 
-    @tag :pending
     test "when stack contains only one number, raise StackUnderflowError, even when it's a zero" do
       assert_raise(
         RPNCalculator.Exception.StackUnderflowError,
@@ -125,14 +113,12 @@ defmodule RPNCalculator.ExceptionTest do
       )
     end
 
-    @tag :pending
     test "when divisor is 0, raise DivisionByZeroError" do
       assert_raise(RPNCalculator.Exception.DivisionByZeroError, "division by zero occurred", fn ->
         RPNCalculator.Exception.divide([0, 2])
       end)
     end
 
-    @tag :pending
     test "divisor is not 0, don't raise" do
       RPNCalculator.Exception.divide([2, 4]) == 2
     end

--- a/exercises/concept/take-a-number/test/take_a_number_test.exs
+++ b/exercises/concept/take-a-number/test/take_a_number_test.exs
@@ -1,7 +1,6 @@
 defmodule TakeANumberTest do
   use ExUnit.Case
 
-  # @tag :pending
   test "starts a new process" do
     pid = TakeANumber.start()
     assert is_pid(pid)
@@ -9,14 +8,12 @@ defmodule TakeANumberTest do
     assert pid != TakeANumber.start()
   end
 
-  @tag :pending
   test "reports its own state" do
     pid = TakeANumber.start()
     send(pid, {:report_state, self()})
     assert_receive 0
   end
 
-  @tag :pending
   test "does not shut down after reporting its own state" do
     pid = TakeANumber.start()
     send(pid, {:report_state, self()})
@@ -26,14 +23,12 @@ defmodule TakeANumberTest do
     assert_receive 0
   end
 
-  @tag :pending
   test "gives out a number" do
     pid = TakeANumber.start()
     send(pid, {:take_a_number, self()})
     assert_receive 1
   end
 
-  @tag :pending
   test "gives out many consecutive numbers" do
     pid = TakeANumber.start()
     send(pid, {:take_a_number, self()})
@@ -58,7 +53,6 @@ defmodule TakeANumberTest do
     assert_receive 5
   end
 
-  @tag :pending
   test "stops" do
     pid = TakeANumber.start()
     assert Process.alive?(pid)
@@ -71,7 +65,6 @@ defmodule TakeANumberTest do
     refute Process.alive?(pid)
   end
 
-  @tag :pending
   test "ignores unexpected messages and keeps working" do
     pid = TakeANumber.start()
 

--- a/exercises/concept/wine-cellar/test/wine_cellar_test.exs
+++ b/exercises/concept/wine-cellar/test/wine_cellar_test.exs
@@ -2,7 +2,6 @@ defmodule WineCellarTest do
   use ExUnit.Case
 
   describe "explain_colors/0" do
-    # @tag :pending
     test "returns a keyword list" do
       assert WineCellar.explain_colors() == [
                white: "Fermented without skin contact.",
@@ -13,12 +12,10 @@ defmodule WineCellarTest do
   end
 
   describe "filter/3" do
-    @tag :pending
     test "works for empty cellar" do
       assert WineCellar.filter([], :rose) == []
     end
 
-    @tag :pending
     test "returns all wines of a chosen color" do
       cellar = [
         white: {"Chardonnay", 2015, "Italy"},
@@ -41,7 +38,6 @@ defmodule WineCellarTest do
       assert WineCellar.filter(cellar, :rose) == [{"Dornfelder", 2018, "Germany"}]
     end
 
-    @tag :pending
     test "filters wines of chosen color by year" do
       cellar = [
         white: {"Chardonnay", 2015, "Italy"},
@@ -60,7 +56,6 @@ defmodule WineCellarTest do
              ]
     end
 
-    @tag :pending
     test "filters wines of chosen color by country" do
       cellar = [
         white: {"Chardonnay", 2015, "Italy"},
@@ -79,7 +74,6 @@ defmodule WineCellarTest do
              ]
     end
 
-    @tag :pending
     test "filters wines of chosen color by year and country" do
       cellar = [
         white: {"Chardonnay", 2015, "Italy"},
@@ -97,7 +91,6 @@ defmodule WineCellarTest do
              ]
     end
 
-    @tag :pending
     test "filters wines of chosen color by country and year" do
       cellar = [
         white: {"Chardonnay", 2015, "Italy"},


### PR DESCRIPTION
It's not yet documented in the docs repo, but concept exercise tests should not be skipped at all (https://exercism-team.slack.com/archives/CR91YFNG3/p1617566538207100). This matters for students solving the exercises on their own machines, not via the website.