### PR TITLE
🤖 Fix invalid UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -804,7 +804,7 @@
       {
         "slug": "resistor-color",
         "name": "Resistor Color",
-        "uuid": "12efd520-e3e5-437f-b93e-38af14aa605d",
+        "uuid": "c1532449-bf9e-446a-8e8f-97a6c19608e5",
         "prerequisites": [
           "lists",
           "enum"
@@ -817,7 +817,7 @@
       {
         "slug": "two-fer",
         "name": "Two Fer",
-        "uuid": "e7f3280e-0bef-4fac-8a69-cbfa2e5f818a",
+        "uuid": "6a130540-1b84-4147-8e6f-776dbf750489",
         "prerequisites": [
           "strings",
           "guards",
@@ -1419,7 +1419,7 @@
       {
         "slug": "leap",
         "name": "Leap",
-        "uuid": "3d0d82d7-fdff-4dd5-b720-7246317bb023",
+        "uuid": "f231c263-61fa-4139-a1c9-a69e6986a4cd",
         "prerequisites": [
           "integers",
           "booleans",


### PR DESCRIPTION
This PR regenerates each UUID on the track that was invalid.

To be valid, each value of a `uuid` key must:
- Be a well-formed version 4 UUID (compliant with RFC 4122) in the
  canonical textual representation [1]
- Not exist elsewhere on the track
- Not exist elsewhere on Exercism

A track can generate a suitable UUID by running `configlet uuid`.

In the future, `configlet lint` will produce an error for an invalid
UUID.

[1] That is, it must match this regular expression:
```
^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
```

## Tracking

https://github.com/exercism/v3-launch/issues/29
