### PR TITLE
 Annotate every concept exercise test with @task_id

### DIFF
--- a/.github/pr-commenter.yml
+++ b/.github/pr-commenter.yml
@@ -59,6 +59,7 @@ comment:
       body: |
         - **Concept exercise tests changed**
             - ⚪️ Are all tests _un-skipped_?
+            - 🔢 Are all tests annotated with `@task_id`?
 
     - id: concept-changed
       files:

--- a/exercises/concept/basketball-website/test/basketball_website_test.exs
+++ b/exercises/concept/basketball-website/test/basketball_website_test.exs
@@ -2,6 +2,7 @@ defmodule BasketballWebsiteTest do
   use ExUnit.Case
 
   describe "extract_from_path retrieves from" do
+    @task_id 1
     test "first layer" do
       team_data = %{
         "coach" => %{},
@@ -12,6 +13,7 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.extract_from_path(team_data, "team_name") == "Hoop Masters"
     end
 
+    @task_id 1
     test "second layer" do
       team_data = %{
         "coach" => %{
@@ -25,6 +27,7 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.extract_from_path(team_data, "coach.first_name") == "Jane"
     end
 
+    @task_id 1
     test "third layer" do
       team_data = %{
         "coach" => %{},
@@ -48,6 +51,7 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.extract_from_path(team_data, "players.99.first_name") == "Amalee"
     end
 
+    @task_id 1
     test "fourth layer" do
       team_data = %{
         "coach" => %{},
@@ -84,6 +88,7 @@ defmodule BasketballWebsiteTest do
   end
 
   describe "extract_from_path returns nil from nonexistent last key in" do
+    @task_id 1
     test "first layer" do
       team_data = %{
         "coach" => %{},
@@ -94,6 +99,7 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.extract_from_path(team_data, "team_song") == nil
     end
 
+    @task_id 1
     test "second layer" do
       team_data = %{
         "coach" => %{
@@ -107,6 +113,7 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.extract_from_path(team_data, "coach.age") == nil
     end
 
+    @task_id 1
     test "third layer" do
       team_data = %{
         "coach" => %{},
@@ -124,6 +131,7 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.extract_from_path(team_data, "players.32.height") == nil
     end
 
+    @task_id 1
     test "fourth layer" do
       team_data = %{
         "coach" => %{},
@@ -147,6 +155,7 @@ defmodule BasketballWebsiteTest do
     end
   end
 
+  @task_id 1
   test "extract_from_path returns nil from nonexistent path" do
     team_data = %{
       "coach" => %{},
@@ -161,6 +170,7 @@ defmodule BasketballWebsiteTest do
   end
 
   describe "get_in_path retrieves from" do
+    @task_id 2
     test "first layer" do
       team_data = %{
         "coach" => %{},
@@ -171,6 +181,7 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.get_in_path(team_data, "team_name") == "Hoop Masters"
     end
 
+    @task_id 2
     test "second layer" do
       team_data = %{
         "coach" => %{
@@ -184,6 +195,7 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.get_in_path(team_data, "coach.first_name") == "Jane"
     end
 
+    @task_id 2
     test "third layer" do
       team_data = %{
         "coach" => %{},
@@ -207,6 +219,7 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.get_in_path(team_data, "players.99.first_name") == "Amalee"
     end
 
+    @task_id 2
     test "fourth layer" do
       team_data = %{
         "coach" => %{},
@@ -243,6 +256,7 @@ defmodule BasketballWebsiteTest do
   end
 
   describe "get_in_path returns nil from nonexistent last key in" do
+    @task_id 2
     test "first layer" do
       team_data = %{
         "coach" => %{},
@@ -253,6 +267,7 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.get_in_path(team_data, "team_song") == nil
     end
 
+    @task_id 2
     test "second layer" do
       team_data = %{
         "coach" => %{
@@ -266,6 +281,7 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.get_in_path(team_data, "coach.age") == nil
     end
 
+    @task_id 2
     test "third layer" do
       team_data = %{
         "coach" => %{},
@@ -283,6 +299,7 @@ defmodule BasketballWebsiteTest do
       assert BasketballWebsite.get_in_path(team_data, "players.32.height") == nil
     end
 
+    @task_id 2
     test "fourth layer" do
       team_data = %{
         "coach" => %{},
@@ -304,6 +321,7 @@ defmodule BasketballWebsiteTest do
     end
   end
 
+  @task_id 2
   test "get_in_path returns nil from nonexistent path" do
     team_data = %{
       "coach" => %{},

--- a/exercises/concept/bird-count/test/bird_count_test.exs
+++ b/exercises/concept/bird-count/test/bird_count_test.exs
@@ -2,10 +2,12 @@ defmodule BirdCountTest do
   use ExUnit.Case
 
   describe "today/1" do
+    @task_id 1
     test "returns nil if no bird watching data recorded" do
       assert BirdCount.today([]) == nil
     end
 
+    @task_id 1
     test "returns today's bird count" do
       assert BirdCount.today([7]) == 7
       assert BirdCount.today([2, 4, 11, 10, 6, 8]) == 2
@@ -13,10 +15,12 @@ defmodule BirdCountTest do
   end
 
   describe "increment_day_count/1" do
+    @task_id 2
     test "creates entry for today if no bird watching data recorded" do
       assert BirdCount.increment_day_count([]) == [1]
     end
 
+    @task_id 2
     test "adds 1 to today's bird count" do
       assert BirdCount.increment_day_count([7]) == [8]
       assert BirdCount.increment_day_count([4, 2, 1, 0, 10]) == [5, 2, 1, 0, 10]
@@ -24,15 +28,18 @@ defmodule BirdCountTest do
   end
 
   describe "has_day_without_birds?/1" do
+    @task_id 3
     test "false if no bird watching data recorded" do
       assert BirdCount.has_day_without_birds?([]) == false
     end
 
+    @task_id 3
     test "false if there are no zeros in bird watching data" do
       assert BirdCount.has_day_without_birds?([1]) == false
       assert BirdCount.has_day_without_birds?([6, 7, 10, 2, 5]) == false
     end
 
+    @task_id 3
     test "true if there are is at least one zero in bird watching data" do
       assert BirdCount.has_day_without_birds?([0]) == true
       assert BirdCount.has_day_without_birds?([4, 4, 0, 1]) == true
@@ -41,10 +48,12 @@ defmodule BirdCountTest do
   end
 
   describe "total/1" do
+    @task_id 4
     test "zero if no bird watching data recorded" do
       assert BirdCount.total([]) == 0
     end
 
+    @task_id 4
     test "sums up bird counts" do
       assert BirdCount.total([4]) == 4
       assert BirdCount.total([3, 0, 0, 4, 4, 0, 0, 10]) == 21
@@ -52,10 +61,12 @@ defmodule BirdCountTest do
   end
 
   describe "busy_days/1" do
+    @task_id 5
     test "zero if no bird watching data recorded" do
       assert BirdCount.busy_days([]) == 0
     end
 
+    @task_id 5
     test "counts days with bird count of 5 or more" do
       assert BirdCount.busy_days([1]) == 0
       assert BirdCount.busy_days([0, 5]) == 1

--- a/exercises/concept/boutique-inventory/test/boutique_inventory_test.exs
+++ b/exercises/concept/boutique-inventory/test/boutique_inventory_test.exs
@@ -61,8 +61,8 @@ defmodule BoutiqueInventoryTest do
              }
     end
 
+    @task_id 3
     test "sorts items by price" do
-      @task_id 3
       assert BoutiqueInventory.increase_quantity(
                %{
                  name: "Green Swimming Shorts",

--- a/exercises/concept/boutique-inventory/test/boutique_inventory_test.exs
+++ b/exercises/concept/boutique-inventory/test/boutique_inventory_test.exs
@@ -2,10 +2,12 @@ defmodule BoutiqueInventoryTest do
   use ExUnit.Case
 
   describe "sort_by_price/1" do
+    @task_id 1
     test "works for an empty inventory" do
       assert BoutiqueInventory.sort_by_price([]) == []
     end
 
+    @task_id 1
     test "sorts items by price" do
       assert BoutiqueInventory.sort_by_price([
                %{price: 65, name: "Maxi Yellow Summer Dress", quantity_by_size: %{}},
@@ -22,10 +24,12 @@ defmodule BoutiqueInventoryTest do
   end
 
   describe "with_missing_price/1" do
+    @task_id 2
     test "works for an empty inventory" do
       assert BoutiqueInventory.with_missing_price([]) == []
     end
 
+    @task_id 2
     test "filters out items that do have a price" do
       assert BoutiqueInventory.with_missing_price([
                %{name: "Red Flowery Top", price: 50, quantity_per_size: %{}},
@@ -41,6 +45,7 @@ defmodule BoutiqueInventoryTest do
   end
 
   describe "increase_quantity/2" do
+    @task_id 3
     test "works for an empty quantity map" do
       assert BoutiqueInventory.increase_quantity(
                %{
@@ -57,6 +62,7 @@ defmodule BoutiqueInventoryTest do
     end
 
     test "sorts items by price" do
+      @task_id 3
       assert BoutiqueInventory.increase_quantity(
                %{
                  name: "Green Swimming Shorts",
@@ -73,6 +79,7 @@ defmodule BoutiqueInventoryTest do
   end
 
   describe "total_quantity/1" do
+    @task_id 4
     test "works for an empty quantity map" do
       assert BoutiqueInventory.total_quantity(%{
                name: "Red Denim Pants",
@@ -81,6 +88,7 @@ defmodule BoutiqueInventoryTest do
              }) == 0
     end
 
+    @task_id 4
     test "sums up total quantity" do
       assert BoutiqueInventory.total_quantity(%{
                name: "Black Denim Skirt",

--- a/exercises/concept/boutique-suggestions/test/boutique_suggestions_test.exs
+++ b/exercises/concept/boutique-suggestions/test/boutique_suggestions_test.exs
@@ -1,6 +1,7 @@
 defmodule BoutiqueSuggestionsTest do
   use ExUnit.Case
 
+  @task_id 1
   test "generates one pair from one top and one bottom" do
     top = %{
       item_name: "Long Sleeve T-shirt",
@@ -21,6 +22,7 @@ defmodule BoutiqueSuggestionsTest do
     assert BoutiqueSuggestions.get_combinations([top], [bottom]) == [{top, bottom}]
   end
 
+  @task_id 1
   test "generates all pairs from two top and two bottom" do
     top1 = %{
       item_name: "Long Sleeve T-shirt",
@@ -60,6 +62,7 @@ defmodule BoutiqueSuggestionsTest do
     assert BoutiqueSuggestions.get_combinations(tops, bottoms) == expected
   end
 
+  @task_id 2
   test "does not create suggestions that 'clash'" do
     top = %{
       item_name: "Long Sleeve T-shirt",
@@ -80,10 +83,12 @@ defmodule BoutiqueSuggestionsTest do
     assert BoutiqueSuggestions.get_combinations([top], [bottom]) == []
   end
 
+  @task_id 3
   test "accepts keyword list for third argument for options" do
     assert BoutiqueSuggestions.get_combinations([], [], maximum_price: 200.00)
   end
 
+  @task_id 3
   test "filter rejects combinations based on combined maximum price" do
     top = %{
       item_name: "Sano Long Sleeve Shirt",
@@ -104,6 +109,7 @@ defmodule BoutiqueSuggestionsTest do
     assert BoutiqueSuggestions.get_combinations([top], [bottom], maximum_price: 100.00) == []
   end
 
+  @task_id 3
   test "filter accepts combinations based on combined maximum price" do
     top = %{
       item_name: "Sano Long Sleeve Shirt",
@@ -126,6 +132,7 @@ defmodule BoutiqueSuggestionsTest do
            ]
   end
 
+  @task_id 3
   test "provides default when maximum_price option not specified" do
     top = %{
       item_name: "Sano Long Sleeve Shirt",
@@ -146,6 +153,7 @@ defmodule BoutiqueSuggestionsTest do
     assert BoutiqueSuggestions.get_combinations([top], [bottom], other_option: "test") == []
   end
 
+  @task_id 3
   test "putting it all together" do
     top1 = %{
       item_name: "Long Sleeve T-shirt",

--- a/exercises/concept/bread-and-potions/test/rpg_test.exs
+++ b/exercises/concept/bread-and-potions/test/rpg_test.exs
@@ -8,10 +8,12 @@ defmodule RPGTest do
   end
 
   describe "Edible" do
+    @task_id 1
     test "is a protocol" do
       assert Edible.__protocol__(:functions) == [eat: 2]
     end
 
+    @task_id 1
     test "cannot eat a completely new item" do
       assert_raise Protocol.UndefinedError, fn ->
         Edible.eat(%NewItem{}, %Character{})
@@ -20,17 +22,20 @@ defmodule RPGTest do
   end
 
   describe "LoafOfBread" do
+    @task_id 2
     test "implements the Edible protocol" do
       {:consolidated, modules} = Edible.__protocol__(:impls)
       assert LoafOfBread in modules
     end
 
+    @task_id 2
     test "eating it increases health" do
       character = %Character{health: 50}
       {byproduct, %Character{} = character} = Edible.eat(%LoafOfBread{}, character)
       assert character.health == 55
     end
 
+    @task_id 2
     test "eating it has no byproduct" do
       character = %Character{}
       {byproduct, %Character{}} = Edible.eat(%LoafOfBread{}, character)
@@ -39,17 +44,20 @@ defmodule RPGTest do
   end
 
   describe "ManaPotion" do
+    @task_id 3
     test "implements the Edible protocol" do
       {:consolidated, modules} = Edible.__protocol__(:impls)
       assert ManaPotion in modules
     end
 
+    @task_id 3
     test "eating it increases mana" do
       character = %Character{mana: 10}
       {byproduct, %Character{} = character} = Edible.eat(%ManaPotion{strength: 6}, character)
       assert character.mana == 16
     end
 
+    @task_id 3
     test "eating it produces an empty bottle" do
       character = %Character{}
       {byproduct, %Character{}} = Edible.eat(%ManaPotion{}, character)
@@ -58,17 +66,20 @@ defmodule RPGTest do
   end
 
   describe "Poison" do
+    @task_id 4
     test "implements the Edible protocol" do
       {:consolidated, modules} = Edible.__protocol__(:impls)
       assert Poison in modules
     end
 
+    @task_id 4
     test "eating it brings health down to 0" do
       character = %Character{health: 120}
       {byproduct, %Character{} = character} = Edible.eat(%Poison{}, character)
       assert character.health == 0
     end
 
+    @task_id 4
     test "eating it produces an empty bottle" do
       character = %Character{}
       {byproduct, %Character{}} = Edible.eat(%Poison{}, character)
@@ -76,6 +87,7 @@ defmodule RPGTest do
     end
   end
 
+  @task_id 4
   test "eating many things one after another" do
     items = [
       %LoafOfBread{},

--- a/exercises/concept/captains-log/test/captains_log_test.exs
+++ b/exercises/concept/captains-log/test/captains_log_test.exs
@@ -2,6 +2,7 @@ defmodule CaptainsLogTest do
   use ExUnit.Case
 
   describe "random_planet_class" do
+    @task_id 1
     test "it always returns one of the letters: D, H, J, K, L, M, N, R, T, Y" do
       planetary_classes = ["D", "H", "J", "K", "L", "M", "N", "R", "T", "Y"]
 
@@ -10,6 +11,7 @@ defmodule CaptainsLogTest do
       end)
     end
 
+    @task_id 1
     test "it will eventually return each of the letters at least once" do
       planetary_classes = ["D", "H", "J", "K", "L", "M", "N", "R", "T", "Y"]
 
@@ -27,10 +29,12 @@ defmodule CaptainsLogTest do
   end
 
   describe "random_ship_registry_number" do
+    @task_id 2
     test "start with \"NCC-\"" do
       assert String.starts_with?(CaptainsLog.random_ship_registry_number(), "NCC-")
     end
 
+    @task_id 2
     test "ends with a random integer between 1000 and 9999" do
       Enum.each(0..100, fn _ ->
         random_ship_registry_number = CaptainsLog.random_ship_registry_number()
@@ -49,22 +53,26 @@ defmodule CaptainsLogTest do
   end
 
   describe "random_stardate" do
+    @task_id 3
     test "is a float" do
       assert is_float(CaptainsLog.random_stardate())
     end
 
+    @task_id 3
     test "is equal to or greater than 41_000.0" do
       Enum.each(0..100, fn _ ->
         assert CaptainsLog.random_stardate() >= 41_000.0
       end)
     end
 
+    @task_id 3
     test "is less than 42_000.0" do
       Enum.each(0..100, fn _ ->
         assert CaptainsLog.random_stardate() < 42_000.0
       end)
     end
 
+    @task_id 3
     test "consecutive calls return floats with different fractional parts" do
       decimal_parts =
         Enum.map(0..10, fn _ ->
@@ -75,6 +83,7 @@ defmodule CaptainsLogTest do
       assert Enum.count(Enum.uniq(decimal_parts)) > 3
     end
 
+    @task_id 3
     test "returns floats with fractional parts with more than one decimal place" do
       decimal_parts =
         Enum.map(0..10, fn _ ->
@@ -87,18 +96,22 @@ defmodule CaptainsLogTest do
   end
 
   describe "format_stardate" do
+    @task_id 4
     test "returns a string" do
       assert is_bitstring(CaptainsLog.format_stardate(41010.7))
     end
 
+    @task_id 4
     test "formats floats" do
       assert CaptainsLog.format_stardate(41543.3) == "41543.3"
     end
 
+    @task_id 4
     test "rounds floats to one decimal place" do
       assert CaptainsLog.format_stardate(41032.4512) == "41032.5"
     end
 
+    @task_id 4
     test "does not accept integers" do
       assert_raise ArgumentError, fn -> CaptainsLog.format_stardate(41411) end
     end

--- a/exercises/concept/chessboard/test/chessboard_test.exs
+++ b/exercises/concept/chessboard/test/chessboard_test.exs
@@ -1,18 +1,22 @@
 defmodule ChessboardTest do
   use ExUnit.Case
 
+  @task_id 1
   test "rank_range is a range from 1 to 8" do
     assert Chessboard.rank_range() == 1..8
   end
 
+  @task_id 2
   test "file_range is a range from ?A to ?H" do
     assert Chessboard.file_range() == ?A..?H
   end
 
+  @task_id 3
   test "ranks is a list of integers from 1 to 8" do
     assert Chessboard.ranks() == [1, 2, 3, 4, 5, 6, 7, 8]
   end
 
+  @task_id 4
   test "files is a list of letters (strings) from A to H" do
     assert Chessboard.files() == ["A", "B", "C", "D", "E", "F", "G", "H"]
   end

--- a/exercises/concept/city-office/test/form_test.exs
+++ b/exercises/concept/city-office/test/form_test.exs
@@ -96,6 +96,7 @@ defmodule FormTest do
   end
 
   describe "the Form module" do
+    @task_id 1
     test "has documentation" do
       expected_moduledoc = """
       A collection of loosely related functions helpful for filling out various forms at the city office.
@@ -106,14 +107,17 @@ defmodule FormTest do
   end
 
   describe "blanks/1" do
+    @task_id 2
     test "returns a string with Xs of a given length" do
       assert Form.blanks(5) == "XXXXX"
     end
 
+    @task_id 2
     test "returns an empty string when given length is 0" do
       assert Form.blanks(0) == ""
     end
 
+    @task_id 2
     test "has documentation" do
       expected_doc = """
       Generates a string of a given length.
@@ -125,20 +129,24 @@ defmodule FormTest do
       assert_doc({:blanks, 1}, expected_doc)
     end
 
+    @task_id 2
     test "has a correct spec" do
       assert_spec({:blanks, 1}, "non_neg_integer()", "String.t()")
     end
   end
 
   describe "letters/1" do
+    @task_id 3
     test "returns a list of upcase letters" do
       assert Form.letters("Sao Paulo") == ["S", "A", "O", " ", "P", "A", "U", "L", "O"]
     end
 
+    @task_id 3
     test "returns an empty list when given an empty string" do
       assert Form.letters("") == []
     end
 
+    @task_id 3
     test "has documentation" do
       expected_doc = """
       Splits the string into a list of uppercase letters.
@@ -150,24 +158,29 @@ defmodule FormTest do
       assert_doc({:letters, 1}, expected_doc)
     end
 
+    @task_id 3
     test "has a typespec" do
       assert_spec({:letters, 1}, "String.t()", "[String.t()]")
     end
   end
 
   describe "check_length/2" do
+    @task_id 4
     test "returns :ok is value is below max length" do
       assert Form.check_length("Ruiz", 6) == :ok
     end
 
+    @task_id 4
     test "returns :ok is value is of exactly max length" do
       assert Form.check_length("Martinez-Cooper", 15) == :ok
     end
 
+    @task_id 4
     test "returns an error tuple with the difference between max length and actual length" do
       assert Form.check_length("Martinez-Campbell", 10) == {:error, 7}
     end
 
+    @task_id 4
     test "has documentation" do
       expected_doc = """
       Checks if the value has no more than the maximum allowed number of letters.
@@ -179,6 +192,7 @@ defmodule FormTest do
       assert_doc({:check_length, 2}, expected_doc)
     end
 
+    @task_id 4
     test "has a typespec" do
       assert_spec(
         {:check_length, 2},
@@ -189,6 +203,7 @@ defmodule FormTest do
   end
 
   describe "custom types in the Form module" do
+    @task_id 5
     test "has a custom 'address_map' type" do
       expected_type_definition =
         "%{street: String.t(), postal_code: String.t(), city: String.t()}"
@@ -196,6 +211,7 @@ defmodule FormTest do
       assert_type({Form, :address_map}, expected_type_definition)
     end
 
+    @task_id 5
     test "has a custom 'address_tuple' type with named arguments" do
       expected_type_definition =
         "{street :: String.t(), postal_code :: String.t(), city :: String.t()}"
@@ -203,6 +219,7 @@ defmodule FormTest do
       assert_type({Form, :address_tuple}, expected_type_definition)
     end
 
+    @task_id 5
     test "has a custom 'address' type that is a union of 'address_map' and 'address_tuple'" do
       expected_type_definition = "address_map() | address_tuple()"
 
@@ -211,6 +228,7 @@ defmodule FormTest do
   end
 
   describe "format_address/1" do
+    @task_id 6
     test "accepts a map" do
       input = %{
         street: "Wiejska 4/6/8",
@@ -226,6 +244,7 @@ defmodule FormTest do
       assert Form.format_address(input) == result
     end
 
+    @task_id 6
     test "accepts a 3 string tuple" do
       result = """
       PLATZ DER REPUBLIK 1
@@ -235,6 +254,7 @@ defmodule FormTest do
       assert Form.format_address({"Platz der Republik 1", "11011", "Berlin"}) == result
     end
 
+    @task_id 6
     test "has documentation" do
       expected_doc = """
       Formats the address as an uppercase multiline string.
@@ -243,6 +263,7 @@ defmodule FormTest do
       assert_doc({:format_address, 1}, expected_doc)
     end
 
+    @task_id 6
     test "has a typespec" do
       assert_spec({:format_address, 1}, "address()", "String.t()")
     end

--- a/exercises/concept/community-garden/test/community_garden_test.exs
+++ b/exercises/concept/community-garden/test/community_garden_test.exs
@@ -1,27 +1,32 @@
 defmodule CommunityGardenTest do
   use ExUnit.Case
 
+  @task_id 1
   test "start returns an alive pid" do
     assert {:ok, pid} = CommunityGarden.start()
     assert Process.alive?(pid)
   end
 
+  @task_id 2
   test "when started, the registry is empty" do
     assert {:ok, pid} = CommunityGarden.start()
     assert [] == CommunityGarden.list_registrations(pid)
   end
 
+  @task_id 3
   test "can register a new plot" do
     assert {:ok, pid} = CommunityGarden.start()
     assert %Plot{} = CommunityGarden.register(pid, "Johnny Appleseed")
   end
 
+  @task_id 3
   test "maintains a registry of plots" do
     assert {:ok, pid} = CommunityGarden.start()
     assert %Plot{} = plot = CommunityGarden.register(pid, "Johnny Appleseed")
     assert [plot] == CommunityGarden.list_registrations(pid)
   end
 
+  @task_id 4
   test "can release a plot" do
     assert {:ok, pid} = CommunityGarden.start()
     assert %Plot{} = plot = CommunityGarden.register(pid, "Johnny Appleseed")
@@ -29,12 +34,7 @@ defmodule CommunityGardenTest do
     assert [] == CommunityGarden.list_registrations(pid)
   end
 
-  test "can get a specific registration by id" do
-    assert {:ok, pid} = CommunityGarden.start()
-    assert %Plot{} = plot = CommunityGarden.register(pid, "Johnny Appleseed")
-    assert "Johnny Appleseed" = CommunityGarden.get_registration(pid, plot.plot_id).registered_to
-  end
-
+  @task_id 5
   test "can get registration of a registered plot" do
     assert {:ok, pid} = CommunityGarden.start()
     assert %Plot{} = plot = CommunityGarden.register(pid, "Johnny Appleseed")
@@ -43,6 +43,7 @@ defmodule CommunityGardenTest do
     assert registered_plot.registered_to == "Johnny Appleseed"
   end
 
+  @task_id 5
   test "return not_found when attempt to get registration of an unregistered plot" do
     assert {:ok, pid} = CommunityGarden.start()
     assert {:not_found, "plot is unregistered"} = CommunityGarden.get_registration(pid, 1)

--- a/exercises/concept/date-parser/test/date_parser_test.exs
+++ b/exercises/concept/date-parser/test/date_parser_test.exs
@@ -2,185 +2,308 @@ defmodule DateParserTest do
   use ExUnit.Case
 
   describe "numeric pattern for day matches" do
+    @task_id 1
     test "un-padded 1", do: assert("1" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 2", do: assert("2" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 3", do: assert("3" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 4", do: assert("4" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 5", do: assert("5" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 6", do: assert("6" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 7", do: assert("7" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 8", do: assert("8" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 9", do: assert("9" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 10", do: assert("10" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 11", do: assert("11" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 12", do: assert("12" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 13", do: assert("13" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 14", do: assert("14" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 15", do: assert("15" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 16", do: assert("16" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 17", do: assert("17" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 18", do: assert("18" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 19", do: assert("19" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 20", do: assert("20" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 21", do: assert("21" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 22", do: assert("22" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 23", do: assert("23" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 24", do: assert("24" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 25", do: assert("25" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 26", do: assert("26" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 27", do: assert("27" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 28", do: assert("28" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 29", do: assert("29" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 30", do: assert("30" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "un-padded 31", do: assert("31" =~ Regex.compile!(DateParser.day()))
 
+    @task_id 1
     test "padded 01", do: assert("01" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "padded 02", do: assert("02" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "padded 03", do: assert("03" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "padded 04", do: assert("04" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "padded 05", do: assert("05" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "padded 06", do: assert("06" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "padded 07", do: assert("07" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "padded 08", do: assert("08" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "padded 09", do: assert("09" =~ Regex.compile!(DateParser.day()))
   end
 
   describe "numeric pattern for day doesn't match" do
+    @task_id 1
     test "too few digits", do: refute("" =~ Regex.compile!("^#{DateParser.day()}$"))
+    @task_id 1
     test "too many digits", do: refute("111" =~ Regex.compile!("^#{DateParser.day()}$"))
+    @task_id 1
     test "one letter", do: refute("a" =~ Regex.compile!(DateParser.day()))
+    @task_id 1
     test "two letters", do: refute("bb" =~ Regex.compile!(DateParser.day()))
   end
 
   describe "numeric pattern for month matches" do
+    @task_id 1
     test "un-padded 1", do: assert("1" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "un-padded 2", do: assert("2" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "un-padded 3", do: assert("3" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "un-padded 4", do: assert("4" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "un-padded 5", do: assert("5" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "un-padded 6", do: assert("6" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "un-padded 7", do: assert("7" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "un-padded 8", do: assert("8" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "un-padded 9", do: assert("9" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "un-padded 10", do: assert("10" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "un-padded 11", do: assert("11" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "un-padded 12", do: assert("11" =~ Regex.compile!(DateParser.month()))
 
+    @task_id 1
     test "padded 01", do: assert("01" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "padded 02", do: assert("02" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "padded 03", do: assert("03" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "padded 04", do: assert("04" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "padded 05", do: assert("05" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "padded 06", do: assert("06" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "padded 07", do: assert("07" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "padded 08", do: assert("08" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "padded 09", do: assert("09" =~ Regex.compile!(DateParser.month()))
   end
 
   describe "numeric pattern for month doesn't match" do
+    @task_id 1
     test "too few digits", do: refute("" =~ Regex.compile!("^#{DateParser.month()}$"))
+    @task_id 1
     test "too many digits", do: refute("111" =~ Regex.compile!("^#{DateParser.month()}$"))
+    @task_id 1
     test "one letter", do: refute("a" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "two letters", do: refute("bb" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "short month name", do: refute("Jan" =~ Regex.compile!(DateParser.month()))
+    @task_id 1
     test "long month name", do: refute("January" =~ Regex.compile!(DateParser.month()))
   end
 
   describe "numeric pattern for year" do
+    @task_id 1
     test "matches 4 digits", do: assert("1970" =~ Regex.compile!("^#{DateParser.year()}$"))
+    @task_id 1
     test "doesn't match short year", do: refute("84" =~ Regex.compile!("^#{DateParser.year()}$"))
+    @task_id 1
     test "doesn't match letters", do: refute("198A" =~ Regex.compile!("^#{DateParser.year()}$"))
+    @task_id 1
     test "doesn't match too few", do: refute("198" =~ Regex.compile!("^#{DateParser.year()}$"))
+    @task_id 1
     test "doesn't match too many", do: refute("19701" =~ Regex.compile!("^#{DateParser.year()}$"))
   end
 
   describe "day names match" do
+    @task_id 2
     test "Sunday", do: assert("Sunday" =~ Regex.compile!(DateParser.day_names()))
+    @task_id 2
     test "Monday", do: assert("Monday" =~ Regex.compile!(DateParser.day_names()))
+    @task_id 2
     test "Tuesday", do: assert("Tuesday" =~ Regex.compile!(DateParser.day_names()))
+    @task_id 2
     test "Wednesday", do: assert("Wednesday" =~ Regex.compile!(DateParser.day_names()))
+    @task_id 2
     test "Thursday", do: assert("Thursday" =~ Regex.compile!(DateParser.day_names()))
+    @task_id 2
     test "Friday", do: assert("Friday" =~ Regex.compile!(DateParser.day_names()))
+    @task_id 2
     test "Saturday", do: assert("Saturday" =~ Regex.compile!(DateParser.day_names()))
   end
 
   describe "day names don't match with trailing or leading whitespace" do
+    @task_id 2
     test "Sunday", do: refute(" Sunday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
+    @task_id 2
     test "Monday", do: refute(" Monday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
+    @task_id 2
     test "Tuesday", do: refute(" Tuesday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
+    @task_id 2
     test "Wednesday", do: refute(" Wednesday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
+    @task_id 2
     test "Thursday", do: refute(" Thursday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
+    @task_id 2
     test "Friday", do: refute(" Friday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
+    @task_id 2
     test "Saturday", do: refute(" Saturday " =~ Regex.compile!("^#{DateParser.day_names()}$"))
   end
 
   describe "day names don't match" do
+    @task_id 2
     test "combined" do
       refute "TuesdayWednesday" =~ Regex.compile!("^#{DateParser.day_names()}$")
     end
 
+    @task_id 2
     test "short name" do
       refute "Sun" =~ Regex.compile!("^#{DateParser.day_names()}$")
     end
 
+    @task_id 2
     test "numeric day of the week (0-indexed)" do
       refute "0" =~ Regex.compile!("^#{DateParser.day_names()}$")
     end
 
+    @task_id 2
     test "numeric day of the week (1-indexed)" do
       refute "1" =~ Regex.compile!("^#{DateParser.day_names()}$")
     end
   end
 
   describe "month names match" do
+    @task_id 2
     test "January", do: assert("January" =~ Regex.compile!(DateParser.month_names()))
+    @task_id 2
     test "February", do: assert("February" =~ Regex.compile!(DateParser.month_names()))
+    @task_id 2
     test "March", do: assert("March" =~ Regex.compile!(DateParser.month_names()))
+    @task_id 2
     test "April", do: assert("April" =~ Regex.compile!(DateParser.month_names()))
+    @task_id 2
     test "May", do: assert("May" =~ Regex.compile!(DateParser.month_names()))
+    @task_id 2
     test "June", do: assert("June" =~ Regex.compile!(DateParser.month_names()))
+    @task_id 2
     test "July", do: assert("July" =~ Regex.compile!(DateParser.month_names()))
+    @task_id 2
     test "August", do: assert("August" =~ Regex.compile!(DateParser.month_names()))
+    @task_id 2
     test "September", do: assert("September" =~ Regex.compile!(DateParser.month_names()))
+    @task_id 2
     test "October", do: assert("October" =~ Regex.compile!(DateParser.month_names()))
+    @task_id 2
     test "November", do: assert("November" =~ Regex.compile!(DateParser.month_names()))
+    @task_id 2
     test "December", do: assert("December" =~ Regex.compile!(DateParser.month_names()))
   end
 
   describe "month names don't match with trailing or leading whitespace" do
+    @task_id 2
     test "January", do: refute(" January " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @task_id 2
     test "February", do: refute(" February " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @task_id 2
     test "March", do: refute(" March " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @task_id 2
     test "April", do: refute(" April " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @task_id 2
     test "May", do: refute(" May " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @task_id 2
     test "June", do: refute(" June " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @task_id 2
     test "July", do: refute(" July " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @task_id 2
     test "August", do: refute(" August " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @task_id 2
     test "September", do: refute(" September " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @task_id 2
     test "October", do: refute(" October " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @task_id 2
     test "November", do: refute(" November " =~ Regex.compile!("^#{DateParser.month_names()}$"))
+    @task_id 2
     test "December", do: refute(" December " =~ Regex.compile!("^#{DateParser.month_names()}$"))
   end
 
   describe "month names don't match" do
+    @task_id 2
     test "combined" do
       refute "JanuaryFebruary" =~ Regex.compile!("^#{DateParser.month_names()}$")
     end
 
+    @task_id 2
     test "short name" do
       refute "Jan" =~ Regex.compile!("^#{DateParser.month_names()}$")
     end
 
+    @task_id 2
     test "numeric month of the year (0-indexed)" do
       refute "0" =~ Regex.compile!("^#{DateParser.month_names()}$")
     end
 
+    @task_id 2
     test "numeric month of the year (1-indexed)" do
       refute "1" =~ Regex.compile!("^#{DateParser.month_names()}$")
     end
   end
 
   describe "capture" do
+    @task_id 3
     test "numeric month" do
       assert %{"month" => "01"} =
                DateParser.capture_month()
@@ -188,6 +311,7 @@ defmodule DateParserTest do
                |> Regex.named_captures("01")
     end
 
+    @task_id 3
     test "numeric day" do
       assert %{"day" => "01"} =
                DateParser.capture_day()
@@ -195,6 +319,7 @@ defmodule DateParserTest do
                |> Regex.named_captures("01")
     end
 
+    @task_id 3
     test "numeric year" do
       assert %{"year" => "1970"} =
                DateParser.capture_year()
@@ -202,6 +327,7 @@ defmodule DateParserTest do
                |> Regex.named_captures("1970")
     end
 
+    @task_id 3
     test "capture day name" do
       assert %{"day_name" => "Monday"} =
                DateParser.capture_day_name()
@@ -209,6 +335,7 @@ defmodule DateParserTest do
                |> Regex.named_captures("Monday")
     end
 
+    @task_id 3
     test "capture month name" do
       assert %{"month_name" => "February"} =
                DateParser.capture_month_name()
@@ -216,6 +343,7 @@ defmodule DateParserTest do
                |> Regex.named_captures("February")
     end
 
+    @task_id 4
     test "numeric date" do
       assert %{"year" => "1970", "month" => "02", "day" => "01"} =
                DateParser.capture_numeric_date()
@@ -223,6 +351,7 @@ defmodule DateParserTest do
                |> Regex.named_captures("01/02/1970")
     end
 
+    @task_id 4
     test "month named date" do
       assert %{"year" => "1970", "month_name" => "January", "day" => "1"} =
                DateParser.capture_month_name_date()
@@ -230,6 +359,7 @@ defmodule DateParserTest do
                |> Regex.named_captures("January 1, 1970")
     end
 
+    @task_id 4
     test "day and month named date" do
       assert %{
                "year" => "1970",
@@ -244,46 +374,56 @@ defmodule DateParserTest do
   end
 
   describe "regex match" do
+    @task_id 5
     test "numeric date matches" do
       assert DateParser.match_numeric_date() |> Regex.match?("01/02/1970")
     end
 
+    @task_id 5
     test "numeric date has named captures" do
       assert %{"year" => "1970", "month" => "02", "day" => "01"} =
                DateParser.match_numeric_date()
                |> Regex.named_captures("01/02/1970")
     end
 
+    @task_id 5
     test "numeric date with a prefix doesn't match" do
       refute DateParser.match_numeric_date() |> Regex.match?("The day was 01/02/1970")
     end
 
+    @task_id 5
     test "numeric date with a suffix doesn't match" do
       refute DateParser.match_numeric_date() |> Regex.match?("01/02/1970 was the day")
     end
 
+    @task_id 5
     test "month named date matches" do
       assert DateParser.match_month_name_date() |> Regex.match?("January 1, 1970")
     end
 
+    @task_id 5
     test "month named date has named captures" do
       assert %{"year" => "1970", "month_name" => "January", "day" => "1"} =
                DateParser.match_month_name_date()
                |> Regex.named_captures("January 1, 1970")
     end
 
+    @task_id 5
     test "month named date with a prefix doesn't match" do
       refute DateParser.match_month_name_date() |> Regex.match?("The day was January 1, 1970")
     end
 
+    @task_id 5
     test "month named date with a suffix doesn't match" do
       refute DateParser.match_month_name_date() |> Regex.match?("January 1, 1970 was the day")
     end
 
+    @task_id 5
     test "day and month names date matches" do
       assert DateParser.match_day_month_name_date() |> Regex.match?("Thursday, January 1, 1970")
     end
 
+    @task_id 5
     test "day and month names date has named captures" do
       assert %{
                "year" => "1970",
@@ -295,11 +435,13 @@ defmodule DateParserTest do
                |> Regex.named_captures("Thursday, January 1, 1970")
     end
 
+    @task_id 5
     test "day and month names date with a prefix doesn't match" do
       refute DateParser.match_day_month_name_date()
              |> Regex.match?("The day way Thursday, January 1, 1970")
     end
 
+    @task_id 5
     test "day and month names date with a suffix doesn't match" do
       refute DateParser.match_day_month_name_date()
              |> Regex.match?("Thursday, January 1, 1970 was the day")

--- a/exercises/concept/dna-encoding/test/dna_test.exs
+++ b/exercises/concept/dna-encoding/test/dna_test.exs
@@ -2,45 +2,69 @@ defmodule DNATest do
   use ExUnit.Case
 
   describe "encode to 4-bit encoding" do
+    @task_id 1
     test "?\\s to 0b0000", do: assert(DNA.encode_nucleotide(?\s) == 0b0000)
+    @task_id 1
     test "?A to 0b0001", do: assert(DNA.encode_nucleotide(?A) == 0b0001)
+    @task_id 1
     test "?C to 0b0010", do: assert(DNA.encode_nucleotide(?C) == 0b0010)
+    @task_id 1
     test "?G to 0b0100", do: assert(DNA.encode_nucleotide(?G) == 0b0100)
+    @task_id 1
     test "?T to 0b1000", do: assert(DNA.encode_nucleotide(?T) == 0b1000)
   end
 
   describe "decode to code point" do
+    @task_id 2
     test "0b0000 to ?\\s", do: assert(DNA.decode_nucleotide(0b0000) == ?\s)
+    @task_id 2
     test "0b0001 to ?A", do: assert(DNA.decode_nucleotide(0b0001) == ?A)
+    @task_id 2
     test "0b0010 to ?C", do: assert(DNA.decode_nucleotide(0b0010) == ?C)
+    @task_id 2
     test "0b0100 to ?G", do: assert(DNA.decode_nucleotide(0b0100) == ?G)
+    @task_id 2
     test "0b1000 to ?T", do: assert(DNA.decode_nucleotide(0b1000) == ?T)
   end
 
   describe "encoding" do
+    @task_id 3
     test "' '", do: assert(DNA.encode(' ') == <<0b0000::4>>)
+    @task_id 3
     test "'A'", do: assert(DNA.encode('A') == <<0b0001::4>>)
+    @task_id 3
     test "'C'", do: assert(DNA.encode('C') == <<0b0010::4>>)
+    @task_id 3
     test "'G'", do: assert(DNA.encode('G') == <<0b0100::4>>)
+    @task_id 3
     test "'T'", do: assert(DNA.encode('T') == <<0b1000::4>>)
 
+    @task_id 3
     test "' ACGT'",
       do: assert(DNA.encode(' ACGT') == <<0b0000::4, 0b0001::4, 0b0010::4, 0b0100::4, 0b1000::4>>)
 
+    @task_id 3
     test "'TGCA '",
       do: assert(DNA.encode('TGCA ') == <<0b1000::4, 0b0100::4, 0b0010::4, 0b0001::4, 0b0000::4>>)
   end
 
   describe "decoding" do
+    @task_id 4
     test "' '", do: assert(DNA.decode(<<0b0000::4>>) == ' ')
+    @task_id 4
     test "'A'", do: assert(DNA.decode(<<0b0001::4>>) == 'A')
+    @task_id 4
     test "'C'", do: assert(DNA.decode(<<0b0010::4>>) == 'C')
+    @task_id 4
     test "'G'", do: assert(DNA.decode(<<0b0100::4>>) == 'G')
+    @task_id 4
     test "'T'", do: assert(DNA.decode(<<0b1000::4>>) == 'T')
 
+    @task_id 4
     test "' ACGT'",
       do: assert(DNA.decode(<<0b0000::4, 0b0001::4, 0b0010::4, 0b0100::4, 0b1000::4>>) == ' ACGT')
 
+    @task_id 4
     test "'TGCA '",
       do: assert(DNA.decode(<<0b1000::4, 0b0100::4, 0b0010::4, 0b0001::4, 0b0000::4>>) == 'TGCA ')
   end

--- a/exercises/concept/file-sniffer/test/file_sniffer_test.exs
+++ b/exercises/concept/file-sniffer/test/file_sniffer_test.exs
@@ -8,92 +8,112 @@ defmodule FileSnifferTest do
   @exe_file File.read!(Path.join("assets", "elf.o"))
 
   describe "get type from extension:" do
+    @task_id 1
     test "bmp" do
       assert FileSniffer.type_from_extension("bmp") == "image/bmp"
     end
 
+    @task_id 1
     test "gif" do
       assert FileSniffer.type_from_extension("gif") == "image/gif"
     end
 
+    @task_id 1
     test "jpg" do
       assert FileSniffer.type_from_extension("jpg") == "image/jpg"
     end
 
+    @task_id 1
     test "png" do
       assert FileSniffer.type_from_extension("png") == "image/png"
     end
 
+    @task_id 1
     test "exe" do
       assert FileSniffer.type_from_extension("exe") == "application/octet-stream"
     end
   end
 
   describe "get type from binary:" do
+    @task_id 2
     test "bmp" do
       assert FileSniffer.type_from_binary(@bmp_file) == "image/bmp"
     end
 
+    @task_id 2
     test "gif" do
       assert FileSniffer.type_from_binary(@gif_file) == "image/gif"
     end
 
+    @task_id 2
     test "jpg" do
       assert FileSniffer.type_from_binary(@jpg_file) == "image/jpg"
     end
 
+    @task_id 2
     test "png" do
       assert FileSniffer.type_from_binary(@png_file) == "image/png"
     end
 
+    @task_id 2
     test "exe" do
       assert FileSniffer.type_from_binary(@exe_file) == "application/octet-stream"
     end
   end
 
   describe "verify valid files" do
+    @task_id 3
     test "bmp" do
       assert FileSniffer.verify(@bmp_file, "bmp") == {:ok, "image/bmp"}
     end
 
+    @task_id 3
     test "gif" do
       assert FileSniffer.verify(@gif_file, "gif") == {:ok, "image/gif"}
     end
 
+    @task_id 3
     test "jpg" do
       assert FileSniffer.verify(@jpg_file, "jpg") == {:ok, "image/jpg"}
     end
 
+    @task_id 3
     test "png" do
       assert FileSniffer.verify(@png_file, "png") == {:ok, "image/png"}
     end
 
+    @task_id 3
     test "exe" do
       assert FileSniffer.verify(@exe_file, "exe") == {:ok, "application/octet-stream"}
     end
   end
 
   describe "reject invalid files" do
+    @task_id 3
     test "bmp" do
       assert FileSniffer.verify(@exe_file, "bmp") ==
                {:error, "Warning, file format and file extension do not match."}
     end
 
+    @task_id 3
     test "gif" do
       assert FileSniffer.verify(@exe_file, "gif") ==
                {:error, "Warning, file format and file extension do not match."}
     end
 
+    @task_id 3
     test "jpg" do
       assert FileSniffer.verify(@exe_file, "jpg") ==
                {:error, "Warning, file format and file extension do not match."}
     end
 
+    @task_id 3
     test "png" do
       assert FileSniffer.verify(@exe_file, "png") ==
                {:error, "Warning, file format and file extension do not match."}
     end
 
+    @task_id 3
     test "exe" do
       assert FileSniffer.verify(@png_file, "exe") ==
                {:error, "Warning, file format and file extension do not match."}

--- a/exercises/concept/german-sysadmin/test/username_test.exs
+++ b/exercises/concept/german-sysadmin/test/username_test.exs
@@ -2,19 +2,23 @@ defmodule UsernameTest do
   use ExUnit.Case
 
   describe "sanitize/1" do
+    @task_id 1
     test "works for an empty charlist" do
       assert Username.sanitize('') == ''
     end
 
+    @task_id 1
     test "it keeps lowercase latin letters" do
       input = Enum.to_list(0..0x10FFFF) -- [?_, ?ß, ?ä, ?ö, ?ü]
       assert Username.sanitize(input) == 'abcdefghijklmnopqrstuvwxyz'
     end
 
+    @task_id 2
     test "it keeps underscores" do
       assert Username.sanitize('marcel_huber') == 'marcel_huber'
     end
 
+    @task_id 3
     test "it substitutes german letters" do
       assert Username.sanitize('krüger') == 'krueger'
       assert Username.sanitize('köhler') == 'koehler'

--- a/exercises/concept/guessing-game/test/guessing_game_test.exs
+++ b/exercises/concept/guessing-game/test/guessing_game_test.exs
@@ -1,30 +1,37 @@
 defmodule GuessingGameTest do
   use ExUnit.Case
 
+  @task_id 1
   test "correct when the guessed number equals secret" do
     assert GuessingGame.compare(7, 7) == "Correct"
   end
 
+  @task_id 2
   test "too high when guessed number is greater than the secret" do
     assert GuessingGame.compare(9, 18) == "Too High"
   end
 
+  @task_id 3
   test "too low when guessed number is less than the secret" do
     assert GuessingGame.compare(42, 30) == "Too Low"
   end
 
+  @task_id 4
   test "so close when guess differs from 7 secret by -1" do
     assert GuessingGame.compare(64, 63) == "So close"
   end
 
+  @task_id 4
   test "so close when guess differs from 7 secret by +1" do
     assert GuessingGame.compare(52, 53) == "So close"
   end
 
+  @task_id 5
   test "when no guess is supplied, ask the player to make a guess" do
     assert GuessingGame.compare(15) == "Make a guess"
   end
 
+  @task_id 5
   test "when the atom :no_guess is supplied, ask the player to make a guess" do
     assert GuessingGame.compare(16, :no_guess) == "Make a guess"
   end

--- a/exercises/concept/high-school-sweetheart/test/high_school_sweetheart_test.exs
+++ b/exercises/concept/high-school-sweetheart/test/high_school_sweetheart_test.exs
@@ -2,36 +2,43 @@ defmodule HighSchoolSweetheartTest do
   use ExUnit.Case
 
   describe "first_letter/1" do
+    @task_id 1
     test "it gets the first letter" do
       assert HighSchoolSweetheart.first_letter("Mary") == "M"
     end
 
+    @task_id 1
     test "it doesn't change the letter's case" do
       assert HighSchoolSweetheart.first_letter("john") == "j"
     end
 
+    @task_id 1
     test "it strips extra whitespace" do
       assert HighSchoolSweetheart.first_letter("\n\t   Sarah   ") == "S"
     end
   end
 
   describe "initial/1" do
+    @task_id 2
     test "it gets the first letter and appends a dot" do
       assert HighSchoolSweetheart.initial("Betty") == "B."
     end
 
+    @task_id 2
     test "it uppercases the first letter" do
       assert HighSchoolSweetheart.initial("james") == "J."
     end
   end
 
   describe "initials/1" do
+    @task_id 3
     test "returns the initials for the first name and the last name" do
       assert HighSchoolSweetheart.initials("Linda Miller") == "L. M."
     end
   end
 
   describe "pair/2" do
+    @task_id 4
     test "prints the pair's initials inside a heart" do
       assert HighSchoolSweetheart.pair("Avery Bryant", "Charlie Dixon") ==
                """

--- a/exercises/concept/high-score/test/high_score_test.exs
+++ b/exercises/concept/high-score/test/high_score_test.exs
@@ -5,16 +5,19 @@ defmodule HighScoreTest do
   # added to the elixir-lang/elixir github repository as of Apr 27, 2020.
 
   test "new/1 result in empty score map" do
+    @task_id 1
     assert HighScore.new() == %{}
   end
 
   describe "add_player/2" do
+    @task_id 2
     test "add player without score to empty score map" do
       scores = HighScore.new()
 
       assert HighScore.add_player(scores, "José Valim") == %{"José Valim" => 0}
     end
 
+    @task_id 2
     test "add two players without score to empty map" do
       scores =
         HighScore.new()
@@ -24,6 +27,7 @@ defmodule HighScoreTest do
       assert scores == %{"Chris McCord" => 0, "José Valim" => 0}
     end
 
+    @task_id 2
     test "add player with score to empty score map" do
       scores =
         HighScore.new()
@@ -32,6 +36,7 @@ defmodule HighScoreTest do
       assert scores == %{"José Valim" => 486_373}
     end
 
+    @task_id 2
     test "add players with scores to empty score map" do
       scores =
         HighScore.new()
@@ -43,6 +48,7 @@ defmodule HighScoreTest do
   end
 
   describe "remove_player/2" do
+    @task_id 3
     test "remove from empty score map results in empty score map" do
       scores =
         HighScore.new()
@@ -51,6 +57,7 @@ defmodule HighScoreTest do
       assert scores == %{}
     end
 
+    @task_id 3
     test "remove player after adding results in empty score map" do
       map =
         HighScore.new()
@@ -60,6 +67,7 @@ defmodule HighScoreTest do
       assert map == %{}
     end
 
+    @task_id 3
     test "remove first player after adding two results in map with remaining player" do
       scores =
         HighScore.new()
@@ -70,6 +78,7 @@ defmodule HighScoreTest do
       assert scores == %{"Chris McCord" => 0}
     end
 
+    @task_id 3
     test "remove second player after adding two results in map with remaining player" do
       scores =
         HighScore.new()
@@ -82,6 +91,7 @@ defmodule HighScoreTest do
   end
 
   describe "reset_score/2" do
+    @task_id 4
     test "resetting score for non-existent player sets player score to 0" do
       scores =
         HighScore.new()
@@ -90,6 +100,7 @@ defmodule HighScoreTest do
       assert scores == %{"José Valim" => 0}
     end
 
+    @task_id 4
     test "resetting score for existing player sets previous player score to 0" do
       scores =
         HighScore.new()
@@ -102,6 +113,7 @@ defmodule HighScoreTest do
   end
 
   describe "update_score/3" do
+    @task_id 5
     test "update score for non existent player initializes value" do
       scores =
         HighScore.new()
@@ -110,6 +122,7 @@ defmodule HighScoreTest do
       assert scores == %{"José Valim" => 486_373}
     end
 
+    @task_id 5
     test "update score for existing player adds score to previous" do
       scores =
         HighScore.new()
@@ -119,6 +132,7 @@ defmodule HighScoreTest do
       assert scores == %{"José Valim" => 486_373}
     end
 
+    @task_id 5
     test "update score for existing player with non-zero score adds score to previous" do
       scores =
         HighScore.new()
@@ -131,6 +145,7 @@ defmodule HighScoreTest do
   end
 
   describe "get_players/1" do
+    @task_id 6
     test "empty score map gives empty list" do
       scores_by_player =
         HighScore.new()
@@ -139,6 +154,7 @@ defmodule HighScoreTest do
       assert scores_by_player == []
     end
 
+    @task_id 6
     test "score map with one entry gives one result" do
       players =
         HighScore.new()
@@ -149,6 +165,7 @@ defmodule HighScoreTest do
       assert players == ["José Valim"]
     end
 
+    @task_id 6
     test "score map with multiple entries gives results in unknown order" do
       players =
         HighScore.new()

--- a/exercises/concept/high-score/test/high_score_test.exs
+++ b/exercises/concept/high-score/test/high_score_test.exs
@@ -4,8 +4,8 @@ defmodule HighScoreTest do
   # Trivia: Scores used in this test suite are based on lines of code
   # added to the elixir-lang/elixir github repository as of Apr 27, 2020.
 
+  @task_id 1
   test "new/1 result in empty score map" do
-    @task_id 1
     assert HighScore.new() == %{}
   end
 

--- a/exercises/concept/kitchen-calculator/test/kitchen_calculator_test.exs
+++ b/exercises/concept/kitchen-calculator/test/kitchen_calculator_test.exs
@@ -2,68 +2,83 @@ defmodule KitchenCalculatorTest do
   use ExUnit.Case
 
   describe "get volume from tuple pair" do
+    @task_id 1
     test "get cups" do
       assert KitchenCalculator.get_volume({:cup, 1}) == 1
     end
 
+    @task_id 1
     test "get fluid ounces" do
       assert KitchenCalculator.get_volume({:fluid_ounce, 2}) == 2
     end
 
+    @task_id 1
     test "get teaspoons" do
       assert KitchenCalculator.get_volume({:teaspoons, 3}) == 3
     end
 
+    @task_id 1
     test "get tablespoons" do
       assert KitchenCalculator.get_volume({:tablespoons, 4}) == 4
     end
 
+    @task_id 1
     test "get milliliters" do
       assert KitchenCalculator.get_volume({:milliliter, 5}) == 5
     end
   end
 
   describe "convert to milliliters from" do
+    @task_id 2
     test "milliliters" do
       assert KitchenCalculator.to_milliliter({:milliliter, 3}) == {:milliliter, 3}
     end
 
+    @task_id 2
     test "cups" do
       assert KitchenCalculator.to_milliliter({:cup, 3}) == {:milliliter, 720}
     end
 
+    @task_id 2
     test "fluid ounces" do
       assert KitchenCalculator.to_milliliter({:fluid_ounce, 100}) == {:milliliter, 3000}
     end
 
+    @task_id 2
     test "teaspoon" do
       assert KitchenCalculator.to_milliliter({:teaspoon, 3}) == {:milliliter, 15}
     end
 
+    @task_id 2
     test "tablespoon" do
       assert KitchenCalculator.to_milliliter({:tablespoon, 3}) == {:milliliter, 45}
     end
   end
 
   describe "convert from milliliters to" do
+    @task_id 3
     test "milliliters" do
       assert KitchenCalculator.from_milliliter({:milliliter, 4}, :milliliter) == {:milliliter, 4}
     end
 
+    @task_id 3
     test "cups" do
       assert KitchenCalculator.from_milliliter({:milliliter, 840}, :cup) == {:cup, 3.5}
     end
 
+    @task_id 3
     test "fluid ounces" do
       assert KitchenCalculator.from_milliliter({:milliliter, 4522.5}, :fluid_ounce) ==
                {:fluid_ounce, 150.75}
     end
 
+    @task_id 3
     test "teaspoon" do
       assert KitchenCalculator.from_milliliter({:milliliter, 61.25}, :teaspoon) ==
                {:teaspoon, 12.25}
     end
 
+    @task_id 3
     test "tablespoon" do
       assert KitchenCalculator.from_milliliter({:milliliter, 71.25}, :tablespoon) ==
                {:tablespoon, 4.75}
@@ -71,18 +86,22 @@ defmodule KitchenCalculatorTest do
   end
 
   describe "convert from x to y:" do
+    @task_id 4
     test "teaspoon to tablespoon" do
       assert KitchenCalculator.convert({:teaspoon, 15}, :tablespoon) == {:tablespoon, 5}
     end
 
+    @task_id 4
     test "cups to fluid ounces" do
       assert KitchenCalculator.convert({:cup, 4}, :fluid_ounce) == {:fluid_ounce, 32}
     end
 
+    @task_id 4
     test "fluid ounces to teaspoons" do
       assert KitchenCalculator.convert({:fluid_ounce, 4}, :teaspoon) == {:teaspoon, 24}
     end
 
+    @task_id 4
     test "tablespoons to cups" do
       assert KitchenCalculator.convert({:tablespoon, 320}, :cup) == {:cup, 20}
     end

--- a/exercises/concept/language-list/test/language_list_test.exs
+++ b/exercises/concept/language-list/test/language_list_test.exs
@@ -1,104 +1,126 @@
 defmodule LanguageListTest do
   use ExUnit.Case
 
-  test "new list" do
-    assert LanguageList.new() == []
+  describe "new/0" do
+    @task_id 1
+    test "new list" do
+      assert LanguageList.new() == []
+    end
   end
 
-  test "count an empty list" do
-    assert LanguageList.new() |> LanguageList.count() == 0
+  describe "add/1" do
+    @task_id 2
+    test "add a language to a list" do
+      language = "Elixir"
+      list = [language]
+
+      assert LanguageList.new() |> LanguageList.add(language) == list
+    end
+
+    @task_id 2
+    test "add several languages to a list" do
+      list =
+        LanguageList.new()
+        |> LanguageList.add("Clojure")
+        |> LanguageList.add("Haskell")
+        |> LanguageList.add("Erlang")
+        |> LanguageList.add("F#")
+        |> LanguageList.add("Elixir")
+
+      assert list == ["Elixir", "F#", "Erlang", "Haskell", "Clojure"]
+    end
   end
 
-  test "add a language to a list" do
-    language = "Elixir"
-    list = [language]
+  describe "remove/0" do
+    @task_id 3
+    test "remove on an empty list results in error" do
+      assert_raise ArgumentError, fn -> LanguageList.new() |> LanguageList.remove() end
+    end
 
-    assert LanguageList.new() |> LanguageList.add(language) == list
+    @task_id 3
+    test "add then remove results in empty list" do
+      list =
+        LanguageList.new()
+        |> LanguageList.add("Elixir")
+        |> LanguageList.remove()
+
+      assert list == []
+    end
+
+    @task_id 3
+    test "adding two languages, when removed, removes first item" do
+      list =
+        LanguageList.new()
+        |> LanguageList.add("F#")
+        |> LanguageList.add("Elixir")
+        |> LanguageList.remove()
+
+      assert list == ["F#"]
+    end
   end
 
-  test "add several languages to a list" do
-    list =
-      LanguageList.new()
-      |> LanguageList.add("Clojure")
-      |> LanguageList.add("Haskell")
-      |> LanguageList.add("Erlang")
-      |> LanguageList.add("F#")
-      |> LanguageList.add("Elixir")
+  describe "first/0" do
+    @task_id 4
+    test "first on an empty list raises an error" do
+      assert_raise ArgumentError, fn -> LanguageList.new() |> LanguageList.first() end
+    end
 
-    assert list == ["Elixir", "F#", "Erlang", "Haskell", "Clojure"]
+    @task_id 4
+    test "add one language, then get the first" do
+      assert LanguageList.new() |> LanguageList.add("Elixir") |> LanguageList.first() == "Elixir"
+    end
+
+    @task_id 4
+    test "add a few languages, then get the first" do
+      first =
+        LanguageList.new()
+        |> LanguageList.add("Elixir")
+        |> LanguageList.add("Prolog")
+        |> LanguageList.add("F#")
+        |> LanguageList.first()
+
+      assert first == "F#"
+    end
   end
 
-  test "remove on an empty list results in error" do
-    assert_raise ArgumentError, fn -> LanguageList.new() |> LanguageList.remove() end
+  describe "count/0" do
+    @task_id 5
+    test "the count of a new list is 0" do
+      assert LanguageList.new() |> LanguageList.count() == 0
+    end
+
+    @task_id 5
+    test "the count of a one-language list is 1" do
+      count =
+        LanguageList.new()
+        |> LanguageList.add("Elixir")
+        |> LanguageList.count()
+
+      assert count == 1
+    end
+
+    @task_id 5
+    test "the count of a multiple-item list is equal to its length" do
+      count =
+        LanguageList.new()
+        |> LanguageList.add("Elixir")
+        |> LanguageList.add("Prolog")
+        |> LanguageList.add("F#")
+        |> LanguageList.count()
+
+      assert count == 3
+    end
   end
 
-  test "add then remove results in empty list" do
-    list =
-      LanguageList.new()
-      |> LanguageList.add("Elixir")
-      |> LanguageList.remove()
+  describe "exciting_list?/1" do
+    @task_id 6
+    test "an exciting language list" do
+      assert LanguageList.exciting_list?(["Clojure", "Haskell", "Erlang", "F#", "Elixir"])
+    end
 
-    assert list == []
-  end
-
-  test "adding two languages, when removed, removes first item" do
-    list =
-      LanguageList.new()
-      |> LanguageList.add("F#")
-      |> LanguageList.add("Elixir")
-      |> LanguageList.remove()
-
-    assert list == ["F#"]
-  end
-
-  test "first on an empty list raises an error" do
-    assert_raise ArgumentError, fn -> LanguageList.new() |> LanguageList.first() end
-  end
-
-  test "add one language, then get the first" do
-    assert LanguageList.new() |> LanguageList.add("Elixir") |> LanguageList.first() == "Elixir"
-  end
-
-  test "add a few languages, then get the first" do
-    first =
-      LanguageList.new()
-      |> LanguageList.add("Elixir")
-      |> LanguageList.add("Prolog")
-      |> LanguageList.add("F#")
-      |> LanguageList.first()
-
-    assert first == "F#"
-  end
-
-  test "the count of a new list is 0" do
-    assert LanguageList.new() |> LanguageList.count() == 0
-  end
-
-  test "the count of a one-language list is 1" do
-    count =
-      LanguageList.new()
-      |> LanguageList.add("Elixir")
-      |> LanguageList.count()
-
-    assert count == 1
-  end
-
-  test "the count of a multiple-item list is equal to its length" do
-    count =
-      LanguageList.new()
-      |> LanguageList.add("Elixir")
-      |> LanguageList.add("Prolog")
-      |> LanguageList.add("F#")
-      |> LanguageList.count()
-
-    assert count == 3
-  end
-
-  test "an exciting language list" do
-    assert LanguageList.exciting_list?(["Clojure", "Haskell", "Erlang", "F#", "Elixir"])
-  end
-
-  test "not an exciting language list" do
-    refute LanguageList.exciting_list?(["Java", "C", "JavaScript"])
+    @task_id 6
+    test "not an exciting language list" do
+      refute LanguageList.exciting_list?(["Java", "C", "JavaScript"])
+    end
   end
 end

--- a/exercises/concept/lasagna/test/lasagna_test.exs
+++ b/exercises/concept/lasagna/test/lasagna_test.exs
@@ -2,30 +2,37 @@ defmodule LasagnaTest do
   use ExUnit.Case
   doctest Lasagna
 
+  @task_id 1
   test "expected minutes in oven" do
     assert Lasagna.expected_minutes_in_oven() === 40
   end
 
+  @task_id 2
   test "remaining minutes in oven" do
     assert Lasagna.remaining_minutes_in_oven(25) === 15
   end
 
+  @task_id 3
   test "preparation time in minutes for one layer" do
     assert Lasagna.preparation_time_in_minutes(1) === 2
   end
 
+  @task_id 3
   test "preparation time in minutes for multiple layers" do
     assert Lasagna.preparation_time_in_minutes(4) === 8
   end
 
+  @task_id 4
   test "total time in minutes for one layer" do
     assert Lasagna.total_time_in_minutes(1, 30) === 32
   end
 
+  @task_id 4
   test "total time in minutes for multiple layers" do
     assert Lasagna.total_time_in_minutes(4, 8) === 16
   end
 
+  @task_id 5
   test "notification message" do
     assert Lasagna.alarm() === "Ding!"
   end

--- a/exercises/concept/library-fees/test/library_fees_test.exs
+++ b/exercises/concept/library-fees/test/library_fees_test.exs
@@ -2,11 +2,13 @@ defmodule LibraryFeesTest do
   use ExUnit.Case
 
   describe "datetime_from_string/1" do
+    @task_id 1
     test "returns NaiveDateTime" do
       result = LibraryFees.datetime_from_string("2021-01-01T12:00:00Z")
       assert result.__struct__ == NaiveDateTime
     end
 
+    @task_id 1
     test "parses an ISO8601 string" do
       result = LibraryFees.datetime_from_string("2019-12-24T13:15:45Z")
       assert result == ~N[2019-12-24 13:15:45Z]
@@ -14,30 +16,36 @@ defmodule LibraryFeesTest do
   end
 
   describe "before_noon?/1" do
+    @task_id 2
     test "returns true if the given NaiveDateTime is before 12:00" do
       assert LibraryFees.before_noon?(~N[2020-06-06 11:59:59Z]) == true
     end
 
+    @task_id 2
     test "returns false if the given NaiveDateTime is after 12:00" do
       assert LibraryFees.before_noon?(~N[2021-01-03 12:01:01Z]) == false
     end
 
+    @task_id 2
     test "returns false if the given NaiveDateTime is exactly at 12:00" do
       assert LibraryFees.before_noon?(~N[2018-11-17 12:00:00Z]) == false
     end
   end
 
   describe "return_datetime/1" do
+    @task_id 3
     test "adds 28 days if the given NaiveDateTime is before 12:00" do
       result = LibraryFees.return_datetime(~N[2020-02-14 11:59:59Z])
       assert result == ~N[2020-03-13 11:59:59Z]
     end
 
+    @task_id 3
     test "adds 29 days if the given NaiveDateTime is after 12:00" do
       result = LibraryFees.return_datetime(~N[2021-01-03 12:01:01Z])
       assert result == ~N[2021-02-01 12:01:01Z]
     end
 
+    @task_id 3
     test "adds 29 days if the given NaiveDateTime is exactly at 12:00" do
       result = LibraryFees.return_datetime(~N[2018-12-01 12:00:00Z])
       assert result == ~N[2018-12-30 12:00:00Z]
@@ -45,21 +53,25 @@ defmodule LibraryFeesTest do
   end
 
   describe "days_late/2" do
+    @task_id 4
     test "returns 0 when identical datetimes" do
       result = LibraryFees.days_late(~N[2021-02-01 12:00:00Z], ~N[2021-02-01 12:00:00Z])
       assert result == 0
     end
 
+    @task_id 4
     test "returns 0 when identical dates, but different times" do
       result = LibraryFees.days_late(~N[2019-03-11 13:50:00Z], ~N[2019-03-11 12:00:00Z])
       assert result == 0
     end
 
+    @task_id 4
     test "returns 0 when planned return date is later than actual return date" do
       result = LibraryFees.days_late(~N[2020-12-03 09:50:00Z], ~N[2020-11-29 16:00:00Z])
       assert result == 0
     end
 
+    @task_id 4
     test "returns date difference in numbers of days when planned return date is earlier than actual return date" do
       result = LibraryFees.days_late(~N[2020-06-12 09:50:00Z], ~N[2020-06-21 16:00:00Z])
       assert result == 9
@@ -67,67 +79,81 @@ defmodule LibraryFeesTest do
   end
 
   describe "monday?" do
+    @task_id 5
     test "2021-02-01 was a Monday" do
       assert LibraryFees.monday?(~N[2021-02-01 14:01:00Z]) == true
     end
 
+    @task_id 5
     test "2020-03-16 was a Monday" do
       assert LibraryFees.monday?(~N[2020-03-16 09:23:52Z]) == true
     end
 
+    @task_id 5
     test "2020-04-22 was a Monday" do
       assert LibraryFees.monday?(~N[2019-04-22 15:44:03Z]) == true
     end
 
+    @task_id 5
     test "2021-02-02 was a Tuesday" do
       assert LibraryFees.monday?(~N[2021-02-02 15:07:00Z]) == false
     end
 
+    @task_id 5
     test "2020-03-14 was a Friday" do
       assert LibraryFees.monday?(~N[2020-03-14 08:54:51Z]) == false
     end
 
+    @task_id 5
     test "2019-04-28 was a Sunday" do
       assert LibraryFees.monday?(~N[2019-04-28 11:37:12Z]) == false
     end
   end
 
   describe "calculate_late_fee/2" do
+    @task_id 6
     test "returns 0 if the book was returned less than 28 days after a morning checkout" do
       result = LibraryFees.calculate_late_fee("2018-11-01T09:00:00Z", "2018-11-13T14:12:00Z", 123)
       assert result == 0
     end
 
+    @task_id 6
     test "returns 0 if the book was returned exactly 28 days after a morning checkout" do
       result = LibraryFees.calculate_late_fee("2018-11-01T09:00:00Z", "2018-11-29T14:12:00Z", 123)
       assert result == 0
     end
 
+    @task_id 6
     test "returns the rate for one day if the book was returned exactly 29 days after a morning checkout" do
       result = LibraryFees.calculate_late_fee("2018-11-01T09:00:00Z", "2018-11-30T14:12:00Z", 320)
       assert result == 320
     end
 
+    @task_id 6
     test "returns 0 if the book was returned less than 29 days after an afternoon checkout" do
       result = LibraryFees.calculate_late_fee("2019-05-01T16:12:00Z", "2019-05-17T14:32:45Z", 400)
       assert result == 0
     end
 
+    @task_id 6
     test "returns 0 if the book was returned exactly 29 days after an afternoon checkout" do
       result = LibraryFees.calculate_late_fee("2019-05-01T16:12:00Z", "2019-05-30T14:32:45Z", 313)
       assert result == 0
     end
 
+    @task_id 6
     test "returns the rate for one day if the book was returned exactly 30 days after an afternoon checkout" do
       result = LibraryFees.calculate_late_fee("2019-05-01T16:12:00Z", "2019-05-31T14:32:45Z", 234)
       assert result == 234
     end
 
+    @task_id 6
     test "multiplies the number of days late by the rate for one day" do
       result = LibraryFees.calculate_late_fee("2021-01-01T08:00:00Z", "2021-02-13T08:00:00Z", 111)
       assert result == 111 * 15
     end
 
+    @task_id 6
     test "late fees are 50% off (rounded down) when the book is returned on a Monday" do
       result = LibraryFees.calculate_late_fee("2021-01-01T08:00:00Z", "2021-02-15T08:00:00Z", 111)
       assert result == trunc(111 * 17 * 0.5)

--- a/exercises/concept/log-level/test/log_level_test.exs
+++ b/exercises/concept/log-level/test/log_level_test.exs
@@ -2,41 +2,49 @@ defmodule LogLevelTest do
   use ExUnit.Case
 
   describe "LogLevel.to_label/1" do
+    @task_id 1
     test "level 0 has label trace only in a non-legacy app" do
       assert LogLevel.to_label(0, false) == :trace
       assert LogLevel.to_label(0, true) == :unknown
     end
 
+    @task_id 1
     test "level 1 has label debug" do
       assert LogLevel.to_label(1, false) == :debug
       assert LogLevel.to_label(1, true) == :debug
     end
 
+    @task_id 1
     test "level 2 has label info" do
       assert LogLevel.to_label(2, false) == :info
       assert LogLevel.to_label(2, true) == :info
     end
 
+    @task_id 1
     test "level 3 has label warning" do
       assert LogLevel.to_label(3, false) == :warning
       assert LogLevel.to_label(3, true) == :warning
     end
 
+    @task_id 1
     test "level 4 has label error" do
       assert LogLevel.to_label(4, false) == :error
       assert LogLevel.to_label(4, true) == :error
     end
 
+    @task_id 1
     test "level 5 has label fatal only in a non-legacy app" do
       assert LogLevel.to_label(5, false) == :fatal
       assert LogLevel.to_label(5, true) == :unknown
     end
 
+    @task_id 1
     test "level 6 has label unknown" do
       assert LogLevel.to_label(6, false) == :unknown
       assert LogLevel.to_label(6, true) == :unknown
     end
 
+    @task_id 1
     test "level -1 has label unknown" do
       assert LogLevel.to_label(-1, false) == :unknown
       assert LogLevel.to_label(-1, true) == :unknown
@@ -44,39 +52,47 @@ defmodule LogLevelTest do
   end
 
   describe "LogLevel.alert_recipient/2" do
+    @task_id 2
     test "fatal code sends alert to ops" do
       assert LogLevel.alert_recipient(5, false) == :ops
     end
 
+    @task_id 2
     test "error code sends alert to ops" do
       assert LogLevel.alert_recipient(4, false) == :ops
       assert LogLevel.alert_recipient(4, true) == :ops
     end
 
+    @task_id 2
     test "unknown code sends alert to dev team 1 for a legacy app" do
       assert LogLevel.alert_recipient(6, true) == :dev1
       assert LogLevel.alert_recipient(0, true) == :dev1
       assert LogLevel.alert_recipient(5, true) == :dev1
     end
 
+    @task_id 2
     test "unknown code sends alert to dev team 2" do
       assert LogLevel.alert_recipient(6, false) == :dev2
     end
 
+    @task_id 2
     test "trace code does not send alert" do
       refute LogLevel.alert_recipient(0, false)
     end
 
+    @task_id 2
     test "debug code does not send alert" do
       refute LogLevel.alert_recipient(1, false)
       refute LogLevel.alert_recipient(1, true)
     end
 
+    @task_id 2
     test "info code does not send alert" do
       refute LogLevel.alert_recipient(2, false)
       refute LogLevel.alert_recipient(2, true)
     end
 
+    @task_id 2
     test "warning code does not send alert" do
       refute LogLevel.alert_recipient(3, false)
       refute LogLevel.alert_recipient(3, true)

--- a/exercises/concept/lucas-numbers/test/lucas_numbers_test.exs
+++ b/exercises/concept/lucas-numbers/test/lucas_numbers_test.exs
@@ -1,58 +1,69 @@
 defmodule LucasNumbersTest do
   use ExUnit.Case
 
+  @task_id 1
   test "generates a sequence of length 1" do
     assert LucasNumbers.generate(1) == [2]
   end
 
+  @task_id 1
   test "generates a sequence of length 2" do
     assert LucasNumbers.generate(2) == [2, 1]
   end
 
+  @task_id 2
   test "generates a sequence of length 3" do
     assert LucasNumbers.generate(3) == [2, 1, 3]
   end
 
+  @task_id 2
   test "generates a sequence of length 4" do
     assert LucasNumbers.generate(4) == [2, 1, 3, 4]
   end
 
+  @task_id 2
   test "generates a sequence of length 5" do
     sequence = [2, 1, 3, 4, 7]
 
     assert LucasNumbers.generate(5) == sequence
   end
 
+  @task_id 2
   test "generates a sequence of length 6" do
     sequence = [2, 1, 3, 4, 7, 11]
 
     assert LucasNumbers.generate(6) == sequence
   end
 
+  @task_id 2
   test "generates a sequence of length 7" do
     sequence = [2, 1, 3, 4, 7, 11, 18]
 
     assert LucasNumbers.generate(7) == sequence
   end
 
+  @task_id 2
   test "generates a sequence of length 8" do
     sequence = [2, 1, 3, 4, 7, 11, 18, 29]
 
     assert LucasNumbers.generate(8) == sequence
   end
 
+  @task_id 2
   test "generates a sequence of length 9" do
     sequence = [2, 1, 3, 4, 7, 11, 18, 29, 47]
 
     assert LucasNumbers.generate(9) == sequence
   end
 
+  @task_id 2
   test "generates a sequence of length 10" do
     sequence = [2, 1, 3, 4, 7, 11, 18, 29, 47, 76]
 
     assert LucasNumbers.generate(10) == sequence
   end
 
+  @task_id 2
   test "generates a sequence of length 25" do
     sequence = [
       2,
@@ -85,12 +96,14 @@ defmodule LucasNumbersTest do
     assert LucasNumbers.generate(25) == sequence
   end
 
+  @task_id 3
   test "catch incorrect non-integer arguments" do
     assert_raise ArgumentError, "count must be specified as an integer >= 1", fn ->
       LucasNumbers.generate("Hello world!")
     end
   end
 
+  @task_id 3
   test "catch incorrect integer arguments" do
     assert_raise ArgumentError, "count must be specified as an integer >= 1", fn ->
       LucasNumbers.generate(-1)

--- a/exercises/concept/name-badge/test/name_badge_test.exs
+++ b/exercises/concept/name-badge/test/name_badge_test.exs
@@ -3,24 +3,29 @@ defmodule NameBadgeTest do
   doctest NameBadge
 
   describe "print/3" do
+    @task_id 1
     test "prints the employee badge with full data" do
       assert NameBadge.print(455, "Mary M. Brown", "MARKETING") ==
                "[455] - Mary M. Brown - MARKETING"
     end
 
+    @task_id 1
     test "uppercases the department" do
       assert NameBadge.print(89, "Jack McGregor", "Procurement") ==
                "[89] - Jack McGregor - PROCUREMENT"
     end
 
+    @task_id 2
     test "prints the employee badge without id" do
       assert NameBadge.print(nil, "Barbara White", "Security") == "Barbara White - SECURITY"
     end
 
+    @task_id 3
     test "prints the owner badge" do
       assert NameBadge.print(1, "Anna Johnson", nil) == "[1] - Anna Johnson - OWNER"
     end
 
+    @task_id 3
     test "prints the owner badge without id" do
       assert NameBadge.print(nil, "Stephen Dann", nil) == "Stephen Dann - OWNER"
     end

--- a/exercises/concept/newsletter/test/newsletter_test.exs
+++ b/exercises/concept/newsletter/test/newsletter_test.exs
@@ -10,6 +10,7 @@ defmodule NewsletterTest do
   end
 
   describe "read_emails" do
+    @task_id 1
     test "returns a list of all lines in a file" do
       emails_file_path = Path.join(["assets", "emails.txt"])
 
@@ -21,6 +22,7 @@ defmodule NewsletterTest do
              ]
     end
 
+    @task_id 1
     test "returns an empty list if the file if empty" do
       empty_file_path = Path.join(["assets", "empty.txt"])
       assert Newsletter.read_emails(empty_file_path) == []
@@ -28,12 +30,14 @@ defmodule NewsletterTest do
   end
 
   describe "open_log" do
+    @task_id 2
     test "returns a pid" do
       file = Newsletter.open_log(@temp_file_path)
       assert is_pid(file)
       File.close(file)
     end
 
+    @task_id 2
     test "opens the file for writing" do
       file = Newsletter.open_log(@temp_file_path)
       assert IO.write(file, "hello") == :ok
@@ -43,12 +47,14 @@ defmodule NewsletterTest do
   end
 
   describe "log_sent_email" do
+    @task_id 3
     test "returns ok" do
       file = File.open!(@temp_file_path, [:write])
       assert Newsletter.log_sent_email(file, "janice@example.com") == :ok
       File.close(file)
     end
 
+    @task_id 3
     test "writes the email address to the given file" do
       file = File.open!(@temp_file_path, [:write])
       Newsletter.log_sent_email(file, "joe@example.com")
@@ -56,6 +62,7 @@ defmodule NewsletterTest do
       File.close(file)
     end
 
+    @task_id 3
     test "writes many email addresses to the given file" do
       file = File.open!(@temp_file_path, [:write])
       Newsletter.log_sent_email(file, "joe@example.com")
@@ -70,11 +77,13 @@ defmodule NewsletterTest do
   end
 
   describe "close_log" do
+    @task_id 4
     test "returns ok" do
       file = File.open!(@temp_file_path, [:write])
       assert Newsletter.close_log(file) == :ok
     end
 
+    @task_id 4
     test "closes the file" do
       file = File.open!(@temp_file_path, [:read])
       assert Newsletter.close_log(file) == :ok
@@ -83,6 +92,7 @@ defmodule NewsletterTest do
   end
 
   describe "send_newsletter" do
+    @task_id 5
     test "returns ok" do
       send_fun = fn _ -> :ok end
 
@@ -93,6 +103,7 @@ defmodule NewsletterTest do
              ) == :ok
     end
 
+    @task_id 5
     test "calls send function for every email from the emails file" do
       send_fun = fn email -> send(self(), {:send, email}) && :ok end
 
@@ -104,6 +115,7 @@ defmodule NewsletterTest do
       assert_received {:send, "dave@example.com"}
     end
 
+    @task_id 5
     test "logs emails that were sent" do
       send_fun = fn _ -> :ok end
 
@@ -118,6 +130,7 @@ defmodule NewsletterTest do
                """
     end
 
+    @task_id 5
     test "does not log emails that could not be sent" do
       send_fun = fn
         "bob@example.com" -> :error
@@ -133,6 +146,7 @@ defmodule NewsletterTest do
              """
     end
 
+    @task_id 5
     test "logs the email immediately after it was sent" do
       send_fun = fn email ->
         case email do

--- a/exercises/concept/pacman-rules/test/rules_test.exs
+++ b/exercises/concept/pacman-rules/test/rules_test.exs
@@ -2,56 +2,68 @@ defmodule RulesTest do
   use ExUnit.Case
 
   describe "eat_ghost?/2" do
+    @task_id 1
     test "ghost gets eaten" do
       assert Rules.eat_ghost?(true, true)
     end
 
+    @task_id 1
     test "ghost does not get eaten because no power pellet active" do
       refute Rules.eat_ghost?(false, true)
     end
 
+    @task_id 1
     test "ghost does not get eaten because not touching ghost" do
       refute Rules.eat_ghost?(true, false)
     end
   end
 
   describe "score?/2" do
+    @task_id 2
     test "score when eating dot" do
       assert Rules.score?(false, true)
     end
 
+    @task_id 2
     test "score when eating power pellet" do
       assert Rules.score?(true, false)
     end
 
+    @task_id 2
     test "no score when nothing eaten" do
       refute Rules.score?(false, false)
     end
   end
 
   describe "lose?/2" do
+    @task_id 3
     test "lose if touching a ghost without a power pellet active" do
       assert Rules.lose?(false, true)
     end
 
+    @task_id 3
     test "don't lose if touching a ghost with a power pellet active" do
       refute Rules.lose?(true, true)
     end
 
+    @task_id 3
     test "don't lose if not touching a ghost" do
       refute Rules.lose?(true, false)
     end
   end
 
   describe "win?/3" do
+    @task_id 4
     test "win if all dots eaten" do
       assert Rules.win?(true, false, false)
     end
 
+    @task_id 4
     test "don't win if all dots eaten, but touching a ghost" do
       refute Rules.win?(true, false, true)
     end
 
+    @task_id 4
     test "win if all dots eaten and touching a ghost with a power pellet active" do
       assert Rules.win?(true, true, true)
     end

--- a/exercises/concept/remote-control-car/test/remote_control_car_test.exs
+++ b/exercises/concept/remote-control-car/test/remote_control_car_test.exs
@@ -1,6 +1,7 @@
 defmodule RemoteControlCarTest do
   use ExUnit.Case
 
+  @task_id 1
   test "required key 'nickname' should not have a default value" do
     assert_raise ArgumentError, fn ->
       quote do
@@ -10,6 +11,7 @@ defmodule RemoteControlCarTest do
     end
   end
 
+  @task_id 1
   test "new" do
     car = RemoteControlCar.new()
 
@@ -19,6 +21,7 @@ defmodule RemoteControlCarTest do
     assert car.nickname == "none"
   end
 
+  @task_id 2
   test "new with nickname" do
     nickname = "Red"
     car = RemoteControlCar.new(nickname)
@@ -29,6 +32,7 @@ defmodule RemoteControlCarTest do
     assert car.nickname == nickname
   end
 
+  @task_id 3
   test "display distance raises error when not given struct" do
     fake_car = %{
       battery_percentage: 100,
@@ -41,12 +45,14 @@ defmodule RemoteControlCarTest do
     end)
   end
 
+  @task_id 3
   test "display distance of new" do
     car = RemoteControlCar.new()
 
     assert RemoteControlCar.display_distance(car) == "0 meters"
   end
 
+  @task_id 3
   test "display distance of driven" do
     car = RemoteControlCar.new()
     car = %{car | distance_driven_in_meters: 20}
@@ -54,6 +60,7 @@ defmodule RemoteControlCarTest do
     assert RemoteControlCar.display_distance(car) == "20 meters"
   end
 
+  @task_id 4
   test "display battery raises error when not given struct" do
     fake_car = %{
       battery_percentage: 100,
@@ -66,12 +73,14 @@ defmodule RemoteControlCarTest do
     end)
   end
 
+  @task_id 4
   test "display battery of new" do
     car = RemoteControlCar.new()
 
     assert RemoteControlCar.display_battery(car) == "Battery at 100%"
   end
 
+  @task_id 4
   test "display battery of dead battery" do
     car = RemoteControlCar.new()
     car = %{car | battery_percentage: 0}
@@ -79,6 +88,7 @@ defmodule RemoteControlCarTest do
     assert RemoteControlCar.display_battery(car) == "Battery empty"
   end
 
+  @task_id 5
   test "drive raises error when not given struct" do
     fake_car = %{
       battery_percentage: 100,
@@ -91,6 +101,7 @@ defmodule RemoteControlCarTest do
     end)
   end
 
+  @task_id 5
   test "drive with battery" do
     car = RemoteControlCar.new() |> RemoteControlCar.drive()
 
@@ -99,6 +110,7 @@ defmodule RemoteControlCarTest do
     assert car.distance_driven_in_meters == 20
   end
 
+  @task_id 6
   test "drive with dead battery" do
     car =
       RemoteControlCar.new()

--- a/exercises/concept/rpg-character-sheet/test/rpg/character_sheet_test.exs
+++ b/exercises/concept/rpg-character-sheet/test/rpg/character_sheet_test.exs
@@ -3,6 +3,7 @@ defmodule RPG.CharacterSheetTest do
   import ExUnit.CaptureIO
 
   describe "welcome/0" do
+    @task_id 1
     test "it prints a welcome message" do
       io =
         capture_io(fn ->
@@ -14,6 +15,7 @@ defmodule RPG.CharacterSheetTest do
   end
 
   describe "ask_name/0" do
+    @task_id 2
     test "it prints a prompt" do
       io =
         capture_io("\n", fn ->
@@ -23,6 +25,7 @@ defmodule RPG.CharacterSheetTest do
       assert io == "What is your character's name?\n"
     end
 
+    @task_id 2
     test "returns the trimmed input" do
       capture_io("Maxwell The Great\n", fn ->
         assert RPG.CharacterSheet.ask_name() == "Maxwell The Great"
@@ -31,6 +34,7 @@ defmodule RPG.CharacterSheetTest do
   end
 
   describe "ask_class/0" do
+    @task_id 3
     test "it prints a prompt" do
       io =
         capture_io("\n", fn ->
@@ -40,6 +44,7 @@ defmodule RPG.CharacterSheetTest do
       assert io == "What is your character's class?\n"
     end
 
+    @task_id 3
     test "returns the trimmed input" do
       capture_io("rogue\n", fn ->
         assert RPG.CharacterSheet.ask_class() == "rogue"
@@ -48,6 +53,7 @@ defmodule RPG.CharacterSheetTest do
   end
 
   describe "ask_level/0" do
+    @task_id 4
     test "it prints a prompt" do
       io =
         capture_io("1\n", fn ->
@@ -57,6 +63,7 @@ defmodule RPG.CharacterSheetTest do
       assert io == "What is your character's level?\n"
     end
 
+    @task_id 4
     test "returns the trimmed input as an integer" do
       capture_io("3\n", fn ->
         assert RPG.CharacterSheet.ask_level() == 3
@@ -65,6 +72,7 @@ defmodule RPG.CharacterSheetTest do
   end
 
   describe "run/0" do
+    @task_id 5
     test "it asks for name, class, and level" do
       io =
         capture_io("Susan The Fearless\nfighter\n6\n", fn ->
@@ -79,6 +87,7 @@ defmodule RPG.CharacterSheetTest do
              """
     end
 
+    @task_id 5
     test "it returns a character map" do
       capture_io("The Stranger\nrogue\n2\n", fn ->
         assert RPG.CharacterSheet.run() == %{
@@ -89,6 +98,7 @@ defmodule RPG.CharacterSheetTest do
       end)
     end
 
+    @task_id 5
     test "it inspects the character map" do
       io =
         capture_io("Anne\nhealer\n4\n", fn ->

--- a/exercises/concept/rpn-calculator-inspection/test/rpn_calculator_inspection_test.exs
+++ b/exercises/concept/rpn-calculator-inspection/test/rpn_calculator_inspection_test.exs
@@ -31,6 +31,7 @@ defmodule RPNCalculatorInspectionTest do
   end
 
   describe "start_reliability_check" do
+    @task_id 1
     test "returns a map with test data" do
       calculator = fn _ -> 0 end
       input = "1 2 +"
@@ -40,6 +41,7 @@ defmodule RPNCalculatorInspectionTest do
       assert result.input == input
     end
 
+    @task_id 1
     test "starts a linked process" do
       old_value = Process.flag(:trap_exit, true)
 
@@ -54,6 +56,7 @@ defmodule RPNCalculatorInspectionTest do
       Process.flag(:trap_exit, old_value)
     end
 
+    @task_id 1
     test "the process runs the calculator function with the given input" do
       caller_process_pid = self()
 
@@ -67,6 +70,7 @@ defmodule RPNCalculatorInspectionTest do
   end
 
   describe "await_reliability_check_result" do
+    @task_id 2
     test "adds `input` => :ok to the results after a normal exit" do
       caller_process_pid = self()
       test_data = %{pid: caller_process_pid, input: "2 3 +"}
@@ -82,6 +86,7 @@ defmodule RPNCalculatorInspectionTest do
                expected_result
     end
 
+    @task_id 2
     test "adds `input` => :error to the results after an abnormal exit" do
       caller_process_pid = self()
       test_data = %{pid: caller_process_pid, input: "3 0 /"}
@@ -97,6 +102,7 @@ defmodule RPNCalculatorInspectionTest do
                expected_result
     end
 
+    @task_id 2
     test "adds `input` => :timeout to the results if no message arrives in 100ms" do
       caller_process_pid = self()
       test_data = %{pid: caller_process_pid, input: "24 12 /"}
@@ -119,6 +125,7 @@ defmodule RPNCalculatorInspectionTest do
       Task.await(task)
     end
 
+    @task_id 2
     test "normal exit messages from processes whose pids don't match stay in the inbox" do
       caller_process_pid = self()
       other_process_pid = spawn(fn -> nil end)
@@ -138,6 +145,7 @@ defmodule RPNCalculatorInspectionTest do
       assert Keyword.get(Process.info(self()), :message_queue_len) == 1
     end
 
+    @task_id 2
     test "abnormal exit messages from processes whose pids don't match stay in the inbox" do
       caller_process_pid = self()
       other_process_pid = spawn(fn -> nil end)
@@ -157,6 +165,7 @@ defmodule RPNCalculatorInspectionTest do
       assert Keyword.get(Process.info(self()), :message_queue_len) == 1
     end
 
+    @task_id 2
     test "any other messages stay in the inbox" do
       caller_process_pid = self()
       test_data = %{pid: caller_process_pid, input: "4 2 /"}
@@ -177,6 +186,7 @@ defmodule RPNCalculatorInspectionTest do
       assert Keyword.get(Process.info(self()), :message_queue_len) == 3
     end
 
+    @task_id 2
     test "doesn't change the trap_exit flag of the caller process" do
       caller_process_pid = self()
       Process.flag(:trap_exit, false)
@@ -209,6 +219,7 @@ defmodule RPNCalculatorInspectionTest do
   end
 
   describe "reliability_check" do
+    @task_id 3
     test "returns an empty map when input list empty" do
       inputs = []
       calculator = &RPNCalculator.unsafe_division/1
@@ -216,6 +227,7 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.reliability_check(calculator, inputs) == outputs
     end
 
+    @task_id 3
     test "returns a map with inputs as keys and :ok as values" do
       inputs = ["4 2 /", "8 2 /", "6 3 /"]
       calculator = &RPNCalculator.unsafe_division/1
@@ -229,6 +241,7 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.reliability_check(calculator, inputs) == outputs
     end
 
+    @task_id 3
     test "returns a map when input list has 1000 elements" do
       inputs = Enum.map(1..1000, &"#{2 * &1} #{&1} /")
       calculator = &RPNCalculator.unsafe_division/1
@@ -237,6 +250,7 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.reliability_check(calculator, inputs) == outputs
     end
 
+    @task_id 3
     test "returns a map when input list has 1000 elements and the calculator takes 50ms for each calculation" do
       inputs = Enum.map(1..1000, &"#{2 * &1} #{&1} /")
       calculator = fn input -> :timer.sleep(50) && RPNCalculator.unsafe_division(input) end
@@ -245,6 +259,7 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.reliability_check(calculator, inputs) == outputs
     end
 
+    @task_id 3
     test "returns :error values for inputs that cause the calculator to crash" do
       inputs = ["3 0 /", "22 11 /", "4 0 /"]
       calculator = &RPNCalculator.unsafe_division/1
@@ -258,6 +273,7 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.reliability_check(calculator, inputs) == outputs
     end
 
+    @task_id 3
     test "returns a map when input list has 1000 elements and all of them crash" do
       inputs = Enum.map(1..1000, &"#{2 * &1} 0 /")
       calculator = &RPNCalculator.unsafe_division/1
@@ -266,6 +282,7 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.reliability_check(calculator, inputs) == outputs
     end
 
+    @task_id 3
     test "restores the original value of the trap_exit flag" do
       inputs = ["3 0 /", "22 11 /", "4 0 /"]
       calculator = &RPNCalculator.unsafe_division/1
@@ -287,6 +304,7 @@ defmodule RPNCalculatorInspectionTest do
   end
 
   describe "correctness_check" do
+    @task_id 4
     test "returns an empty list when input list empty" do
       inputs = []
       calculator = &RPNCalculator.unsafe_division/1
@@ -294,6 +312,7 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.correctness_check(calculator, inputs) == outputs
     end
 
+    @task_id 4
     test "returns a list of results" do
       inputs = ["3 2 /", "4 2 /", "5 2 /"]
       calculator = &RPNCalculator.unsafe_division/1
@@ -301,6 +320,7 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.correctness_check(calculator, inputs) == outputs
     end
 
+    @task_id 4
     test "returns a list of results when input list has 1000 elements" do
       inputs = Enum.map(1..1000, &"100 #{&1} /")
       calculator = &RPNCalculator.unsafe_division/1
@@ -308,6 +328,7 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.correctness_check(calculator, inputs) == outputs
     end
 
+    @task_id 4
     test "returns a list of results when input list has 1000 elements and the calculator takes 50ms for each calculation" do
       inputs = Enum.map(1..1000, &"100 #{&1} /")
       calculator = fn input -> :timer.sleep(50) && RPNCalculator.unsafe_division(input) end
@@ -315,6 +336,7 @@ defmodule RPNCalculatorInspectionTest do
       assert RPNCalculatorInspection.correctness_check(calculator, inputs) == outputs
     end
 
+    @task_id 4
     test "awaits a single task for 100ms" do
       inputs = ["1 1 /1"]
       calculator = fn _ -> :timer.sleep(500) end

--- a/exercises/concept/rpn-calculator-output/test/rpn_calculator/output_test.exs
+++ b/exercises/concept/rpn-calculator-output/test/rpn_calculator/output_test.exs
@@ -18,6 +18,7 @@ defmodule RPNCalculator.OutputTest do
   end
 
   describe "write/3" do
+    @task_id 1
     test "returns ok tuple if function succeeds" do
       resource = __MODULE__
       filename = "filename"
@@ -31,6 +32,7 @@ defmodule RPNCalculator.OutputTest do
 
     E.g.) resource.open(filename)
     """
+    @task_id 1
     test "opens resource" do
       resource = __MODULE__
       filename = "filename"
@@ -43,6 +45,7 @@ defmodule RPNCalculator.OutputTest do
     @use_write_error_message """
     Use IO.write/2 to write to the opened `filename`.
     """
+    @task_id 2
     test "writes to resource" do
       resource = __MODULE__
       filename = "filename"
@@ -53,20 +56,7 @@ defmodule RPNCalculator.OutputTest do
              @use_write_error_message
     end
 
-    @use_close_error_message """
-    Use the close/1 function from the `resource` specified in the arguments to close the opened file handle.
-
-    E.g.) resource.close(filename)
-    """
-    test "closes resource" do
-      resource = __MODULE__
-      filename = "filename"
-      equation = "1 1 +"
-
-      RPNCalculator.Output.write(resource, filename, equation)
-      assert_received :close, @use_close_error_message
-    end
-
+    @task_id 2
     test "rescues and returns error tuple from raised error" do
       resource = __MODULE__
       bad_filename = "bad_filename"
@@ -76,6 +66,22 @@ defmodule RPNCalculator.OutputTest do
                RPNCalculator.Output.write(resource, bad_filename, equation)
     end
 
+    @use_close_error_message """
+    Use the close/1 function from the `resource` specified in the arguments to close the opened file handle.
+
+    E.g.) resource.close(filename)
+    """
+    @task_id 3
+    test "closes resource" do
+      resource = __MODULE__
+      filename = "filename"
+      equation = "1 1 +"
+
+      RPNCalculator.Output.write(resource, filename, equation)
+      assert_received :close, @use_close_error_message
+    end
+
+    @task_id 3
     test "closes resource even when rescuing from raised error" do
       resource = __MODULE__
       bad_filename = "bad_filename"

--- a/exercises/concept/rpn-calculator/.docs/instructions.md
+++ b/exercises/concept/rpn-calculator/.docs/instructions.md
@@ -27,12 +27,12 @@ When doing more research you notice that many functions use atoms and tuples to 
 ```elixir
 stack = []
 operation = fn _ -> "operation completed" end
-RPNCalculator.calculate!(stack, operation)
+RPNCalculator.calculate(stack, operation)
 # => {:ok, "operation completed"}
 
 stack = []
 operation = fn _ -> raise ArgumentError, "An error occurred" end
-RPNCalculator.calculate!(stack, operation)
+RPNCalculator.calculate(stack, operation)
 # => :error
 ```
 
@@ -43,11 +43,11 @@ Some of the errors contain important information that your coworkers need to hav
 ```elixir
 stack = []
 operation = fn _ -> "operation completed" end
-RPNCalculator.calculate!(stack, operation)
+RPNCalculator.calculate_verbose(stack, operation)
 # => {:ok, "operation completed"}
 
 stack = []
 operation = fn _ -> raise ArgumentError, "An error occurred" end
-RPNCalculator.calculate!(stack, operation)
+RPNCalculator.calculate_verbose(stack, operation)
 # => {:error, "An error occurred"}
 ```

--- a/exercises/concept/rpn-calculator/test/rpn_calculator_test.exs
+++ b/exercises/concept/rpn-calculator/test/rpn_calculator_test.exs
@@ -1,16 +1,19 @@
 defmodule RPNCalculatorTest do
   use ExUnit.Case
 
+  @task_id 1
   test "let it crash" do
     assert_raise(RuntimeError, fn ->
       RPNCalculator.calculate!([], fn _ -> raise "test error" end)
     end)
   end
 
+  @task_id 2
   test "rescue the crash, no message" do
     assert RPNCalculator.calculate([], fn _ -> raise "test error" end) == :error
   end
 
+  @task_id 3
   test "rescue the crash, get error tuple with message" do
     assert RPNCalculator.calculate_verbose([], fn _ -> raise "test error" end) ==
              {:error, "test error"}

--- a/exercises/concept/secrets/test/secrets_test.exs
+++ b/exercises/concept/secrets/test/secrets_test.exs
@@ -2,11 +2,13 @@ defmodule SecretsTest do
   use ExUnit.Case
 
   describe "secret_add" do
+    @task_id 1
     test "add 3" do
       add = Secrets.secret_add(3)
       assert add.(3) === 6
     end
 
+    @task_id 1
     test "add 6" do
       add = Secrets.secret_add(6)
       assert add.(9) === 15
@@ -14,11 +16,13 @@ defmodule SecretsTest do
   end
 
   describe "secret_subtract" do
+    @task_id 2
     test "subtract 3" do
       subtract = Secrets.secret_subtract(3)
       assert subtract.(6) === 3
     end
 
+    @task_id 2
     test "subtract 6" do
       subtract = Secrets.secret_subtract(6)
       assert subtract.(3) === -3
@@ -26,11 +30,13 @@ defmodule SecretsTest do
   end
 
   describe "secret_multiply" do
+    @task_id 3
     test "multiply by 3" do
       multiply = Secrets.secret_multiply(3)
       assert multiply.(6) === 18
     end
 
+    @task_id 3
     test "multiply by 6" do
       multiply = Secrets.secret_multiply(6)
       assert multiply.(7) === 42
@@ -38,11 +44,13 @@ defmodule SecretsTest do
   end
 
   describe "secret_divide" do
+    @task_id 4
     test "divide by 3" do
       divide = Secrets.secret_divide(3)
       assert divide.(6) === 2
     end
 
+    @task_id 4
     test "divide by 6" do
       divide = Secrets.secret_divide(6)
       assert divide.(7) === 1
@@ -50,11 +58,13 @@ defmodule SecretsTest do
   end
 
   describe "secret_and" do
+    @task_id 5
     test "2 and 1" do
       ander = Secrets.secret_and(1)
       assert ander.(2) === 0
     end
 
+    @task_id 5
     test "7 and 7" do
       ander = Secrets.secret_and(7)
       assert ander.(7) === 7
@@ -62,11 +72,13 @@ defmodule SecretsTest do
   end
 
   describe "secret_xor" do
+    @task_id 6
     test "2 xor 1" do
       xorer = Secrets.secret_xor(1)
       assert xorer.(2) === 3
     end
 
+    @task_id 6
     test "7 xor 7" do
       xorer = Secrets.secret_xor(7)
       assert xorer.(7) === 0
@@ -74,6 +86,7 @@ defmodule SecretsTest do
   end
 
   describe "secret_combine" do
+    @task_id 7
     test "5 add 10 then subtract 5" do
       f = Secrets.secret_add(10)
       g = Secrets.secret_subtract(5)
@@ -82,6 +95,7 @@ defmodule SecretsTest do
       assert h.(5) === 10
     end
 
+    @task_id 7
     test "100 multiply by 2 then subtract 20" do
       f = Secrets.secret_multiply(2)
       g = Secrets.secret_subtract(20)
@@ -90,6 +104,7 @@ defmodule SecretsTest do
       assert h.(100) === 180
     end
 
+    @task_id 7
     test "100 divide by 10 then add 20" do
       f = Secrets.secret_divide(10)
       g = Secrets.secret_add(10)
@@ -98,6 +113,7 @@ defmodule SecretsTest do
       assert h.(100) === 20
     end
 
+    @task_id 7
     test "32 divide by 3 then multiply 5" do
       f = Secrets.secret_divide(3)
       g = Secrets.secret_add(5)
@@ -106,6 +122,7 @@ defmodule SecretsTest do
       assert h.(32) === 15
     end
 
+    @task_id 7
     test "7 and 3 then and 5" do
       f = Secrets.secret_and(3)
       g = Secrets.secret_and(5)
@@ -114,6 +131,7 @@ defmodule SecretsTest do
       assert h.(7) === 1
     end
 
+    @task_id 7
     test "7 and 7 then and 7" do
       f = Secrets.secret_and(7)
       g = Secrets.secret_and(7)
@@ -122,6 +140,7 @@ defmodule SecretsTest do
       assert h.(7) === 7
     end
 
+    @task_id 7
     test "4 xor 1 then xor 2" do
       f = Secrets.secret_xor(1)
       g = Secrets.secret_xor(2)
@@ -130,6 +149,7 @@ defmodule SecretsTest do
       assert h.(4) === 7
     end
 
+    @task_id 7
     test "7 xor 7 then xor 7" do
       f = Secrets.secret_xor(7)
       g = Secrets.secret_xor(7)
@@ -138,6 +158,7 @@ defmodule SecretsTest do
       assert h.(7) === 7
     end
 
+    @task_id 7
     test "4 add 3 then xor 7" do
       f = Secrets.secret_add(3)
       g = Secrets.secret_xor(7)
@@ -146,6 +167,7 @@ defmodule SecretsTest do
       assert h.(4) === 0
     end
 
+    @task_id 7
     test "81 divide by 9 then and 7" do
       f = Secrets.secret_divide(9)
       g = Secrets.secret_and(7)

--- a/exercises/concept/stack-underflow/test/rpn_calculator/exception_test.exs
+++ b/exercises/concept/stack-underflow/test/rpn_calculator/exception_test.exs
@@ -8,16 +8,19 @@ defmodule RPNCalculator.ExceptionTest do
   # allows for meaningful error messages.
   cond do
     config[:undefined_division_by_zero_error_module] ->
+      @task_id 1
       test "DivisionByZeroError defined" do
         flunk("Implement the DivisionByZeroError inside of the `RPNCalculator.Exception` module")
       end
 
     config[:undefined_division_by_zero_error_exception] ->
+      @task_id 1
       test "DivisionByZeroError defined" do
         flunk("define DivisionByZeroError exception using `defexception`")
       end
 
     true ->
+      @task_id 1
       test "DivisionByZeroError fields defined by `defexception`" do
         assert %RPNCalculator.Exception.DivisionByZeroError{}.__exception__ == true
 
@@ -28,6 +31,7 @@ defmodule RPNCalculator.ExceptionTest do
                  "division by zero occurred"
       end
 
+      @task_id 1
       test "DivisionByZeroError message when raised with raise/1" do
         assert_raise(
           RPNCalculator.Exception.DivisionByZeroError,
@@ -41,16 +45,19 @@ defmodule RPNCalculator.ExceptionTest do
 
   cond do
     config[:undefined_stack_underflow_error_module] ->
+      @task_id 2
       test "StackUnderflowError defined" do
         flunk("Implement the StackUnderflowError inside of the `RPNCalculator.Exception` module")
       end
 
     config[:undefined_stack_underflow_error_exception] ->
+      @task_id 2
       test "StackUnderflowError defined" do
         flunk("define StackUnderflowError exception using `defexception`")
       end
 
     true ->
+      @task_id 2
       test "StackUnderflowError fields defined by `defexception`" do
         assert %RPNCalculator.Exception.StackUnderflowError{}.__exception__ == true
 
@@ -61,6 +68,7 @@ defmodule RPNCalculator.ExceptionTest do
                  "stack underflow occurred"
       end
 
+      @task_id 2
       test "StackUnderflowError message when raised with raise/1" do
         assert_raise(
           RPNCalculator.Exception.StackUnderflowError,
@@ -71,6 +79,7 @@ defmodule RPNCalculator.ExceptionTest do
         )
       end
 
+      @task_id 2
       test "StackUnderflowError message when raised with raise/2" do
         assert_raise(
           RPNCalculator.Exception.StackUnderflowError,
@@ -83,6 +92,7 @@ defmodule RPNCalculator.ExceptionTest do
   end
 
   describe "divide/2" do
+    @task_id 3
     test "when stack doesn't contain any numbers, raise StackUnderflowError" do
       assert_raise(
         RPNCalculator.Exception.StackUnderflowError,
@@ -93,6 +103,7 @@ defmodule RPNCalculator.ExceptionTest do
       )
     end
 
+    @task_id 3
     test "when stack contains only one number, raise StackUnderflowError" do
       assert_raise(
         RPNCalculator.Exception.StackUnderflowError,
@@ -103,6 +114,7 @@ defmodule RPNCalculator.ExceptionTest do
       )
     end
 
+    @task_id 3
     test "when stack contains only one number, raise StackUnderflowError, even when it's a zero" do
       assert_raise(
         RPNCalculator.Exception.StackUnderflowError,
@@ -113,12 +125,14 @@ defmodule RPNCalculator.ExceptionTest do
       )
     end
 
+    @task_id 3
     test "when divisor is 0, raise DivisionByZeroError" do
       assert_raise(RPNCalculator.Exception.DivisionByZeroError, "division by zero occurred", fn ->
         RPNCalculator.Exception.divide([0, 2])
       end)
     end
 
+    @task_id 3
     test "divisor is not 0, don't raise" do
       RPNCalculator.Exception.divide([2, 4]) == 2
     end

--- a/exercises/concept/take-a-number/test/take_a_number_test.exs
+++ b/exercises/concept/take-a-number/test/take_a_number_test.exs
@@ -1,6 +1,7 @@
 defmodule TakeANumberTest do
   use ExUnit.Case
 
+  @task_id 1
   test "starts a new process" do
     pid = TakeANumber.start()
     assert is_pid(pid)
@@ -8,12 +9,14 @@ defmodule TakeANumberTest do
     assert pid != TakeANumber.start()
   end
 
+  @task_id 2
   test "reports its own state" do
     pid = TakeANumber.start()
     send(pid, {:report_state, self()})
     assert_receive 0
   end
 
+  @task_id 2
   test "does not shut down after reporting its own state" do
     pid = TakeANumber.start()
     send(pid, {:report_state, self()})
@@ -23,12 +26,14 @@ defmodule TakeANumberTest do
     assert_receive 0
   end
 
+  @task_id 3
   test "gives out a number" do
     pid = TakeANumber.start()
     send(pid, {:take_a_number, self()})
     assert_receive 1
   end
 
+  @task_id 3
   test "gives out many consecutive numbers" do
     pid = TakeANumber.start()
     send(pid, {:take_a_number, self()})
@@ -53,6 +58,7 @@ defmodule TakeANumberTest do
     assert_receive 5
   end
 
+  @task_id 4
   test "stops" do
     pid = TakeANumber.start()
     assert Process.alive?(pid)
@@ -65,6 +71,7 @@ defmodule TakeANumberTest do
     refute Process.alive?(pid)
   end
 
+  @task_id 5
   test "ignores unexpected messages and keeps working" do
     pid = TakeANumber.start()
 

--- a/exercises/concept/wine-cellar/test/wine_cellar_test.exs
+++ b/exercises/concept/wine-cellar/test/wine_cellar_test.exs
@@ -2,6 +2,7 @@ defmodule WineCellarTest do
   use ExUnit.Case
 
   describe "explain_colors/0" do
+    @task_id 1
     test "returns a keyword list" do
       assert WineCellar.explain_colors() == [
                white: "Fermented without skin contact.",
@@ -12,10 +13,12 @@ defmodule WineCellarTest do
   end
 
   describe "filter/3" do
+    @task_id 2
     test "works for empty cellar" do
       assert WineCellar.filter([], :rose) == []
     end
 
+    @task_id 2
     test "returns all wines of a chosen color" do
       cellar = [
         white: {"Chardonnay", 2015, "Italy"},
@@ -38,6 +41,7 @@ defmodule WineCellarTest do
       assert WineCellar.filter(cellar, :rose) == [{"Dornfelder", 2018, "Germany"}]
     end
 
+    @task_id 3
     test "filters wines of chosen color by year" do
       cellar = [
         white: {"Chardonnay", 2015, "Italy"},
@@ -56,6 +60,7 @@ defmodule WineCellarTest do
              ]
     end
 
+    @task_id 4
     test "filters wines of chosen color by country" do
       cellar = [
         white: {"Chardonnay", 2015, "Italy"},
@@ -74,6 +79,7 @@ defmodule WineCellarTest do
              ]
     end
 
+    @task_id 4
     test "filters wines of chosen color by year and country" do
       cellar = [
         white: {"Chardonnay", 2015, "Italy"},
@@ -91,6 +97,7 @@ defmodule WineCellarTest do
              ]
     end
 
+    @task_id 4
     test "filters wines of chosen color by country and year" do
       cellar = [
         white: {"Chardonnay", 2015, "Italy"},


### PR DESCRIPTION
Closes #729

Approach: if there is a test that tests "everything together", I'm putting it as part of the last task. I am assuming that tasks need to be done in order, which is technically true in many exercises.

I skipped freelancer-rates and did it in this PR instead https://github.com/exercism/elixir/pull/719 because it adds a new task. I also skipped mensch-aergere-dich-nicht because it's deprecated.