### PR TITLE
Make headings consistent in introductions

### DIFF
--- a/exercises/concept/basketball-website/.docs/introduction.md
+++ b/exercises/concept/basketball-website/.docs/introduction.md
@@ -1,4 +1,6 @@
-# Access Behaviour
+# Introduction
+
+## Access Behaviour
 
 Elixir uses code _Behaviours_ to provide common generic interfaces while facilitating specific implementations for each module which implements it. One such common example is the _Access Behaviour_.
 

--- a/exercises/concept/bird-count/.docs/introduction.md
+++ b/exercises/concept/bird-count/.docs/introduction.md
@@ -1,4 +1,6 @@
-# Recursion
+# Introduction
+
+## Recursion
 
 Recursive functions are functions that call themselves.
 

--- a/exercises/concept/boutique-inventory/.docs/introduction.md
+++ b/exercises/concept/boutique-inventory/.docs/introduction.md
@@ -1,4 +1,6 @@
-# Enum
+# Introduction
+
+## Enum
 
 `Enum` is a very useful module that provides a set of algorithms for working with enumerables. It offers sorting, filtering, grouping, counting, searching, finding min/max values, and much more.
 

--- a/exercises/concept/boutique-suggestions/.docs/introduction.md
+++ b/exercises/concept/boutique-suggestions/.docs/introduction.md
@@ -1,4 +1,6 @@
-# List Comprehensions
+# Introduction
+
+## List Comprehensions
 
 Comprehensions provide a facility for transforming _Enumerables_ easily and declaratively.
 

--- a/exercises/concept/bread-and-potions/.docs/introduction.md
+++ b/exercises/concept/bread-and-potions/.docs/introduction.md
@@ -1,4 +1,6 @@
-# Protocols
+# Introduction
+
+## Protocols
 
 Protocols are a mechanism to achieve polymorphism in Elixir when you want behavior to vary depending on the data type.
 

--- a/exercises/concept/chessboard/.docs/introduction.md
+++ b/exercises/concept/chessboard/.docs/introduction.md
@@ -1,4 +1,6 @@
-# Ranges
+# Introduction
+
+## Ranges
 
 Ranges represent a sequence of one or many consecutive integers. They are created by connecting two integers with `..`.
 

--- a/exercises/concept/city-office/.docs/introduction.md
+++ b/exercises/concept/city-office/.docs/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-## docs
+## Docs
 
 Documentation in Elixir is a first-class citizen.
 
@@ -29,7 +29,7 @@ defmodule String do
 end
 ```
 
-## typespecs
+## Typespecs
 
 Elixir is a dynamically typed language, which means it doesn't provide compile-time type checks. Still, type specifications can be used as a form of documentation.
 

--- a/exercises/concept/community-garden/.docs/introduction.md
+++ b/exercises/concept/community-garden/.docs/introduction.md
@@ -1,4 +1,6 @@
-# Agent
+# Introduction
+
+## Agent
 
 The `Agent` module facilitates an abstraction for spawning processes and the _receive-send_ loop. From here, we will call processes started using the `Agent` module _'agent processes'_. An _agent process_ might be chosen to represent a central shared state.
 

--- a/exercises/concept/date-parser/.docs/introduction.md
+++ b/exercises/concept/date-parser/.docs/introduction.md
@@ -1,4 +1,6 @@
-# Regular Expressions
+# Introduction
+
+## Regular Expressions
 
 Regular expressions (regex) are a powerful tool for working with strings in Elixir. Regular expressions in Elixir follow the **PCRE** specification (**P**erl **C**ompatible **R**egular **E**xpressions). String patterns representing the regular expression's meaning are first compiled then used for matching all or part of a string.
 

--- a/exercises/concept/file-sniffer/.docs/introduction.md
+++ b/exercises/concept/file-sniffer/.docs/introduction.md
@@ -1,4 +1,6 @@
-# Binaries
+# Introduction
+
+## Binaries
 
 Elixir provides an elegant syntax for working with binary data as we have seen with the `<<>>` special form provided for working with _bitstrings_.
 
@@ -14,7 +16,7 @@ Binary literals are defined using the bitstring special form `<<>>`. When defini
 
 A _null-byte_ is another name for `<<0>>`.
 
-## Pattern matching on binary data
+### Pattern matching on binary data
 
 Pattern matching is even extended to binaries, and we can pattern match on a portion of binary data much like we could for a list.
 

--- a/exercises/concept/high-school-sweetheart/.docs/introduction.md
+++ b/exercises/concept/high-school-sweetheart/.docs/introduction.md
@@ -1,4 +1,6 @@
-# Strings
+# Introduction
+
+## Strings
 
 Strings in Elixir are delimited by double quotes, and they are encoded in UTF-8:
 

--- a/exercises/concept/language-list/.docs/introduction.md
+++ b/exercises/concept/language-list/.docs/introduction.md
@@ -1,4 +1,6 @@
-# Lists
+# Introduction
+
+## Lists
 
 Lists are built-in to the Elixir language. They are considered a basic type, denoted by square brackets. Lists may be empty or hold any number of items of any type. For example:
 

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -2,6 +2,8 @@
 
 ## Basics
 
+### Variables
+
 Elixir is a dynamically-typed language, meaning that the type of a variable is only checked at runtime. Using the match `=` operator, we can bind a value of any type to a variable name:
 
 ```elixir

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -1,4 +1,6 @@
-# Basics
+# Introduction
+
+## Basics
 
 Elixir is a dynamically-typed language, meaning that the type of a variable is only checked at runtime. Using the match `=` operator, we can bind a value of any type to a variable name:
 
@@ -11,7 +13,7 @@ count = false # You may re-bind any type to a variable
 message = "Success!" # Strings can be created by enclosing characters within double quotes
 ```
 
-## Modules
+### Modules
 
 Elixir is an [functional-programming language][functional-programming] and requires all named functions to be defined in a _module_. The `defmodule` keyword is used to define a module. All modules are available to all other modules at runtime and do not require an _access modifier_ to make them visible to other parts of the program. A _module_ is analogous to a _class_ in other programming languages.
 
@@ -21,7 +23,7 @@ defmodule Calculator do
 end
 ```
 
-## Named functions
+### Named functions
 
 _Named Functions_ must be defined in a module. Each function can have zero or more arguments. All arguments are dynamically-typed, and the return type is not explicitly declared, it is the type of the value returned. An _access modifier_ can be specified for functions, making only desired functions available for use external to the module. In a function, the value of the last line is _implicitly returned_ to the calling function.
 
@@ -44,7 +46,7 @@ sum = Calculator.short_add(2, 2)
 # => 4
 ```
 
-## Arity of functions
+### Arity of functions
 
 It is common to refer to functions with their _arity_. The _arity_ of a function is the number of arguments it accepts.
 
@@ -55,7 +57,7 @@ def add(x, y, z) do
 end
 ```
 
-## Standard library
+### Standard library
 
 Elixir has a very rich and well-documented standard library. The documentation is available online at [hexdocs.pm/elixir][docs]. Save this link somewhere - you will use it a lot!
 
@@ -63,7 +65,7 @@ Most built-in data types have a corresponding module that offers functions for w
 
 A notable module is the `Kernel` module. It provides the basic capabilities on top of which the rest of the standard library is built, like arithmetic operators, control-flow macros, and much more. Functions for the `Kernel` module are automatically imported, so you can use them without the `Kernel.` prefix.
 
-## Code comments
+### Code comments
 
 Comments can be used to leave notes for other developers reading the source code. Single line comments in Elixir are preceded by `#`.
 

--- a/exercises/concept/newsletter/.docs/introduction.md
+++ b/exercises/concept/newsletter/.docs/introduction.md
@@ -1,4 +1,6 @@
-# File
+# Introduction
+
+## File
 
 Functions for working with files are provided by the `File` module.
 

--- a/exercises/concept/pacman-rules/.docs/introduction.md
+++ b/exercises/concept/pacman-rules/.docs/introduction.md
@@ -1,4 +1,6 @@
-# Booleans
+# Introduction
+
+## Booleans
 
 Elixir represents true and false values with the boolean type. There are only two values: _true_ and _false_. These values can be bound to a variable:
 

--- a/exercises/concept/remote-control-car/.docs/introduction.md
+++ b/exercises/concept/remote-control-car/.docs/introduction.md
@@ -1,4 +1,6 @@
-# Structs
+# Introduction
+
+## Structs
 
 Structs are an extension built on top of maps which provide compile-time checks and default values. A struct is named after the module it is defined in. To define a struct use the `defstruct` construct. The construct usually immediately follows after the module definition. `defstruct` accepts either a list of atoms (for `nil` default values) or key-value tuples (for specified default values). The fields without defaults must precede the fields with default values.
 
@@ -11,7 +13,7 @@ plane = %Plane{}
 # => %Plane{engine: nil, wings: 2}
 ```
 
-## Accessing fields and updating
+### Accessing fields and updating
 
 Since structs are built on maps, we can use most map functions to get and manipulate values. The _Access Behaviour_ is **not** implemented for structs. It is recommended to use the _static access operator_ `.` to access struct fields instead.
 
@@ -33,7 +35,7 @@ Since structs are built on maps, we can use most map functions to get and manipu
   # => %Plane{engine: nil, wings: 4}
   ```
 
-## Enforcing field value initialization
+### Enforcing field value initialization
 
 We can use the `@enforce_keys` module attribute with a list of the field keys to ensure that the values are initialized when the struct is created. If a key is not listed, its value will be `nil` as seen in the above example. If an enforced key is not initialized, an error is raised.
 

--- a/exercises/concept/rpg-character-sheet/.docs/introduction.md
+++ b/exercises/concept/rpg-character-sheet/.docs/introduction.md
@@ -1,8 +1,10 @@
-# IO
+# Introduction
+
+## IO
 
 Functions for handling input and output are provided by the `IO` module.
 
-## Output
+### Output
 
 To write a string to the standard output, use `IO.puts`. `IO.puts` always adds a new line at the end of the string. If you don't want that behavior, use `IO.write` instead. Both functions return the atom `:ok` if they succeed.
 
@@ -14,7 +16,7 @@ IO.puts("Hi!")
 
 `IO.puts` is useful for writing strings, but not much else. If you need a tool for debugging that will allow you to write any value to standard output, use `IO.inspect` instead. `IO.inspect` returns the value it was passed unchanged, so it can be inserted in any point in your code. It also accepts many options, for example `:label`, that will allow you to distinguish it form other `IO.inspect` calls.
 
-## Input
+### Input
 
 To read a line from the standard input, use `IO.gets`. `IO.gets` accepts one argument - a string that it will print as a prompt for the input. `IO.gets` doesn't add a new line after the prompt, you need it include it yourself if you need it.
 

--- a/exercises/concept/stack-underflow/.docs/introduction.md
+++ b/exercises/concept/stack-underflow/.docs/introduction.md
@@ -1,4 +1,6 @@
-# Exceptions
+# Introduction
+
+## Exceptions
 
 All errors in Elixir implement the _Exception Behaviour_. Just like the _Access Behaviour_, the _Exception Behaviour_ defines callback functions that a module must implement to fulfill the software contract of the behaviour. Once an error is defined, it has the following properties:
 
@@ -9,7 +11,7 @@ All errors in Elixir implement the _Exception Behaviour_. Just like the _Access 
 
 The _Exception Behaviour_ also specifies two callbacks: `message/1` and `exception/1`. If unimplemented, default implementations will be used. `message/1` transforms the error-struct to a readable message when called with `raise`. `exception/1` allows additional context to be added to the message when it is called with `raise/2`
 
-## Defining an exception
+### Defining an exception
 
 To define an exception from an error module, we use the `defexception` macro:
 
@@ -35,7 +37,7 @@ defmodule MyCustomizedError do
 end
 ```
 
-## Using exceptions
+### Using exceptions
 
 Defined errors may be used like a built in error using either `raise/1` or `raise/2`.
 

--- a/exercises/concept/wine-cellar/.docs/introduction.md
+++ b/exercises/concept/wine-cellar/.docs/introduction.md
@@ -1,4 +1,6 @@
-# Keyword Lists
+# Introduction
+
+## Keyword Lists
 
 Keyword lists are a key-value data structure.
 


### PR DESCRIPTION
Some of the existing `introduction.md` files didn't follow the heading pattern:
```
# Introduction

## Concept name

### Concept subheading
```

I'm fixing that in this PR.

It's important to note that all h1 are removed when the document is displayed on the website and replaced with "Introduction", thus following this pattern in all the files makes them more consistent with what you will see on the website.