### PR TITLE
Run concept exercise tests in predictable order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,15 +33,22 @@ Please keep the following in mind:
 
 - For practice exercises, use typespecs in the example and template files as described [here](http://elixir-lang.org/getting-started/typespecs-and-behaviours.html).
 
-- Each test file should have a `test_helper.exs` with code like the following
-  at the top of the file. This allows the tests to be run on CI and configures
-  tests to be skipped with the `:pending` flag.
+- Each practice exercise test file should have a `test_helper.exs` with code like the following at the top of the file.
+  This allows the tests to be run on CI and configures tests to be skipped with the `:pending` flag.
 
     ```elixir
-    ExUnit.start
-    ExUnit.configure exclude: :pending, trace: true
+    ExUnit.start()
+    ExUnit.configure(exclude: :pending, trace: true)
     ```
 
+- Each concept exercise test file should have a `test_helper.exs` with code like the following at the top of the file.
+  This allows the tests to always run in the order in which they're defined in the test file, to encourage solving the exercises task by task.
+
+    ```elixir
+    ExUnit.start()
+    ExUnit.configure(exclude: :pending, trace: true, seed: 0)
+    ```
+  
 - All but the initial test for each practice exercise should be tagged `:pending`.
 
     ```elixir

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Please keep the following in mind:
     ExUnit.start()
     ExUnit.configure(exclude: :pending, trace: true, seed: 0)
     ```
-  
+
 - All but the initial test for each practice exercise should be tagged `:pending`.
 
     ```elixir

--- a/exercises/concept/basketball-website/test/test_helper.exs
+++ b/exercises/concept/basketball-website/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/bird-count/test/test_helper.exs
+++ b/exercises/concept/bird-count/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/boutique-inventory/test/test_helper.exs
+++ b/exercises/concept/boutique-inventory/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/boutique-suggestions/test/test_helper.exs
+++ b/exercises/concept/boutique-suggestions/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/bread-and-potions/test/test_helper.exs
+++ b/exercises/concept/bread-and-potions/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/captains-log/test/test_helper.exs
+++ b/exercises/concept/captains-log/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/chessboard/test/test_helper.exs
+++ b/exercises/concept/chessboard/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/city-office/test/test_helper.exs
+++ b/exercises/concept/city-office/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/community-garden/test/test_helper.exs
+++ b/exercises/concept/community-garden/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/date-parser/test/test_helper.exs
+++ b/exercises/concept/date-parser/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/dna-encoding/test/test_helper.exs
+++ b/exercises/concept/dna-encoding/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/file-sniffer/test/test_helper.exs
+++ b/exercises/concept/file-sniffer/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/freelancer-rates/test/test_helper.exs
+++ b/exercises/concept/freelancer-rates/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/german-sysadmin/test/test_helper.exs
+++ b/exercises/concept/german-sysadmin/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/guessing-game/test/test_helper.exs
+++ b/exercises/concept/guessing-game/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/high-school-sweetheart/test/test_helper.exs
+++ b/exercises/concept/high-school-sweetheart/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/high-score/test/test_helper.exs
+++ b/exercises/concept/high-score/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/kitchen-calculator/test/test_helper.exs
+++ b/exercises/concept/kitchen-calculator/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/language-list/test/test_helper.exs
+++ b/exercises/concept/language-list/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/lasagna/test/test_helper.exs
+++ b/exercises/concept/lasagna/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/library-fees/test/test_helper.exs
+++ b/exercises/concept/library-fees/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/log-level/test/test_helper.exs
+++ b/exercises/concept/log-level/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/lucas-numbers/test/test_helper.exs
+++ b/exercises/concept/lucas-numbers/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/mensch-aergere-dich-nicht/test/test_helper.exs
+++ b/exercises/concept/mensch-aergere-dich-nicht/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/name-badge/test/test_helper.exs
+++ b/exercises/concept/name-badge/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/newsletter/test/test_helper.exs
+++ b/exercises/concept/newsletter/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/pacman-rules/test/test_helper.exs
+++ b/exercises/concept/pacman-rules/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/remote-control-car/test/test_helper.exs
+++ b/exercises/concept/remote-control-car/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/rpg-character-sheet/test/test_helper.exs
+++ b/exercises/concept/rpg-character-sheet/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/rpn-calculator-inspection/test/test_helper.exs
+++ b/exercises/concept/rpn-calculator-inspection/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/rpn-calculator-output/test/test_helper.exs
+++ b/exercises/concept/rpn-calculator-output/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/rpn-calculator/test/test_helper.exs
+++ b/exercises/concept/rpn-calculator/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/secrets/test/test_helper.exs
+++ b/exercises/concept/secrets/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/stack-underflow/test/test_helper.exs
+++ b/exercises/concept/stack-underflow/test/test_helper.exs
@@ -10,4 +10,4 @@ options = [
 ]
 
 ExUnit.start(options)
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/take-a-number/test/test_helper.exs
+++ b/exercises/concept/take-a-number/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)

--- a/exercises/concept/wine-cellar/test/test_helper.exs
+++ b/exercises/concept/wine-cellar/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-ExUnit.configure(exclude: :pending, trace: true)
+ExUnit.configure(exclude: :pending, trace: true, seed: 0)


### PR DESCRIPTION
Concept exercises do not have skips, so for a student on their own machine all tests will run at once, in random order. For learning purposes, it would be better if the tests always run in the same order as they're defined in in the file.

I asked Jeremy and Erik about this on Slack (https://exercism-team.slack.com/archives/CR91YFNG3/p1621353127004100) and they both confirmed that would be best.

For practice Exercises, I think it makes sense to keep the random order because:
- the student themselves control unskipping
- it's the Elixir way to randomize test order :)
- there's no right way of approaching an exercise, whereas concept exercise clearly have tasks in order