### PR TITLE
Fix parameter names for Rules.score?/2

### DIFF
--- a/exercises/concept/pacman-rules/lib/rules.ex
+++ b/exercises/concept/pacman-rules/lib/rules.ex
@@ -3,7 +3,7 @@ defmodule Rules do
     raise "Please implement the eat_ghost?/2 function"
   end
 
-  def score?(touching_power_pellet, touching_power_pellet) do
+  def score?(touching_power_pellet, touching_dot) do
     raise "Please implement the score?/2 function"
   end
 


### PR DESCRIPTION
While I was going through this exercise, I noticed that the default definition for `Rules.score?/2` had incorrect parameter names used.