### PR TITLE
Update LEARNING.md

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -5,12 +5,13 @@ those learning Elixir for the first time. These resources can help you get
 started:
 
 * [Elixir Getting Started Guide](http://elixir-lang.org/getting-started/introduction.html)
-* [Elixir Documentation](http://elixir-lang.org/docs/stable/elixir/)
-* [Programming Elixir](https://pragprog.com/book/elixir13/programming-elixir-1-3), by Dave Thomas
+* [Elixir Documentation](https://hexdocs.pm/elixir/)
+* [Programming Elixir](https://pragprog.com/titles/elixir16/programming-elixir-1-6/), by Dave Thomas
+* [Elixir in Action](https://www.manning.com/books/elixir-in-action-second-edition), by Saša Jurić
 * [StackOverflow](http://stackoverflow.com/questions/tagged/elixir)
-* [Introducing Elixir](http://shop.oreilly.com/product/0636920030584.do), by Simon St. Laurent, J. David Eisenberg
-* [Etudes for Elixir](https://github.com/oreillymedia/etudes-for-elixir), by J. David Eisenberg (exercise companion for Introducing Elixir)
+* [Introducing Elixir](https://www.oreilly.com/library/view/introducing-elixir-2nd/9781491956847/), by Simon St. Laurent, J. David Eisenberg
 * [Elixir School](https://elixirschool.com)
+* [Joy of Elixir](https://joyofelixir.com/toc.html)
 * [Elixir Examples](https://elixir-examples.github.io/)
 * [Exercism's BEAM Gitter channel](https://gitter.im/exercism/xerlang)
 * [Elixir Forum](https://elixirforum.com/)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -2,7 +2,7 @@
 
 ## Elixir Documentation
 
-* [Elixir Docs](http://elixir-lang.org/docs.html)
+* [Elixir Docs](https://hexdocs.pm/elixir/)
 
 ## Hex - A package manager for the Erlang ecosystem.
 


### PR DESCRIPTION
- Elixir docs URL changed
- new "Programming Elixir" and "Introducing Elixir" edition
- Added "Elixir in Action" and "Joy of Elixir"
- Removed "Etudes for Elixir" because it seems only related to the first edition of "Introducing Elixir" (I couldn't find an updated version for the second edition)