### PR TITLE
Fix protein translation spec

### DIFF
--- a/exercises/practice/protein-translation/.meta/example.ex
+++ b/exercises/practice/protein-translation/.meta/example.ex
@@ -2,7 +2,7 @@ defmodule ProteinTranslation do
   @doc """
   Given an RNA string, return a list of proteins specified by codons, in order.
   """
-  @spec of_rna(String.t()) :: {atom, list(String.t())}
+  @spec of_rna(String.t()) :: {:ok, list(String.t())} | {:error, String.t()}
   def of_rna(rna) do
     translate_rna(rna, [])
   end
@@ -28,7 +28,7 @@ defmodule ProteinTranslation do
   UAG -> STOP
   UGA -> STOP
   """
-  @spec of_codon(String.t()) :: {atom, String.t()}
+  @spec of_codon(String.t()) :: {:ok, String.t()} | {:error, String.t()}
   def of_codon(codon) do
     translate_codon(codon)
   end

--- a/exercises/practice/protein-translation/lib/protein_translation.ex
+++ b/exercises/practice/protein-translation/lib/protein_translation.ex
@@ -2,7 +2,7 @@ defmodule ProteinTranslation do
   @doc """
   Given an RNA string, return a list of proteins specified by codons, in order.
   """
-  @spec of_rna(String.t()) :: {atom, list(String.t())} | {:error, String.t()}
+  @spec of_rna(String.t()) :: {:ok, list(String.t())} | {:error, String.t()}
   def of_rna(rna) do
   end
 

--- a/exercises/practice/protein-translation/lib/protein_translation.ex
+++ b/exercises/practice/protein-translation/lib/protein_translation.ex
@@ -2,7 +2,7 @@ defmodule ProteinTranslation do
   @doc """
   Given an RNA string, return a list of proteins specified by codons, in order.
   """
-  @spec of_rna(String.t()) :: {atom, list(String.t())}
+  @spec of_rna(String.t()) :: {atom, list(String.t())} | {:error, String.t()}
   def of_rna(rna) do
   end
 
@@ -27,7 +27,7 @@ defmodule ProteinTranslation do
   UAG -> STOP
   UGA -> STOP
   """
-  @spec of_codon(String.t()) :: {atom, String.t()}
+  @spec of_codon(String.t()) :: {:ok, String.t()} | {:error, String.t()}
   def of_codon(codon) do
   end
 end


### PR DESCRIPTION
The spec of `of_rna` was not correct (because in case of an error, a string is returned, not a list of strings), the spec of `of_codon` was just not specific enough IMO :) 