### PR TITLE
Better documentation for contributing to the track (language versions, deps, configlet)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,17 @@ Please keep the following in mind:
 
 - No tests should be skipped for concept exercises.
 
+- `.meta/tests.toml` files are generated and updated by `configlet`.
+
+    ```shell
+    # check which exercises need updating
+    $ ./bin/configlet sync
+
+    # add all missing tests to tests.toml for a given exercise
+    $ ./bin/configlet sync --update --exercise zebra-puzzle
+
+    ```
+
 
 ## Language versions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,18 @@ We welcome pull requests that provide fixes and improvements to existing
 exercises. If you're unsure, then go ahead and open a GitHub issue, and we'll
 discuss the change.
 
+## General rules
+
 Please keep the following in mind:
 
-- Please start by reading the general Exercism [contributing guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data).
+- For Exercism-wide explanations of how a track is structured, [look in the `exercism/docs` repository](https://github.com/exercism/docs/tree/main/building/tracks).
 
 - Pull requests should be focused on a single exercise, issue, or change.
 
 - We welcome changes to code style, and wording. Please open a separate PR for
   these changes if possible.
+
+- Content (exercises, documentation etc.) should be written in American English.
 
 - Please open an issue before creating a PR that makes significant (breaking)
   changes to an existing exercise or makes changes across many exercises. It is
@@ -24,12 +28,17 @@ Please keep the following in mind:
 
 - Watch out for trailing spaces, extra blank lines, and spaces in blank lines.
 
+- The CI is going to run a lot of check on your PR. Pay attention to the failures, try to understand and fix them.
+
+
+## Exercises
+
 - Each exercise must stand on its own. Do not reference files outside the
   exercise directory. They will not be included when the user fetches the
   exercise.
 
 - Each problem should have a test suite, an example solution, and a template
-  file for the real implementation. Read about [the anatomy of practice exercises][https://github.com/exercism/docs/blob/main/anatomy/tracks/practice-exercises.md] or [the anatomy of concept exercises][https://github.com/exercism/docs/blob/main/anatomy/tracks/concept-exercises.md], depending on to which type of exercise you want to contribute.
+  file for the real implementation. Read about [the anatomy of practice exercises](https://github.com/exercism/docs/blob/main/building/tracks/practice-exercises.md) or [the anatomy of concept exercises](https://github.com/exercism/docs/blob/main/building/tracks/concept-exercises.md), depending on to which type of exercise you want to contribute.
 
 - For practice exercises, use typespecs in the example and template files as described [here](http://elixir-lang.org/getting-started/typespecs-and-behaviours.html).
 
@@ -60,6 +69,22 @@ Please keep the following in mind:
 
 - No tests should be skipped for concept exercises.
 
-All the tests for Exercism Elixir Track exercises can be run from the top level of the repo
-with `$ ./bin/test_exercises.sh`. Please run this command before submitting your PR. Watch out
-for and correct any compiler warnings you may have introduced.
+
+## Language versions
+
+- We try to keep all exercises compatible with older major Elixir and Erlang versions, at least 2 years into the past.
+
+- All test suites and example solutions must work in all Elixir and Erlang versions that we currently support. Please consult the GitHub workflows configuration (e.g. `.github/workflows/pr.ci.yml`) to check which versions those are.
+
+- As soon as a new major Elixir version is released, we want to start supporting it.
+
+- The test runner always runs on the newest major Elixir version.
+
+- The exercises' `mix.exs` files should have the Elixir version commented out.
+
+
+## External dependencies
+
+Exercises should not use any external dependencies. Each exercise should be solvable with the standard library only.
+
+This allows us more freedom with language version management and keeps the learning process easier for students.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ installation instructions can be found at
 
 ---
 
-### Test Assignments
+### Test Exercises
 
-To test all of the assignments against their example solution, you can run `bin/test_exercises.sh`:
+To test all of the exercises against their example solution, you can run `bin/test_exercises.sh`:
 
 ```shell
 $ ./bin/test_exercises.sh
@@ -52,6 +52,27 @@ To run dialyzer on all exercises, run `./bin/dialyzer_check.sh`. It might take a
 ### Code and document formatting
 
 To check formatting of all exercises and all documents, run `./bin/check_formatting.sh`. It will also be run for you by Github Actions as part of the PR check.
+
+### Track linting
+
+[`configlet`](https://github.com/exercism/configlet) is an Exercism-wide tool for working with tracks. You can download it by running:
+
+```shell
+$ ./bin/fetch_configlet.sh
+```
+
+R run its `lint` command to verify if all exercises have all the necessary files and if config files are correct:
+
+```shell
+$ ./bin/configlet lint
+
+The `exercises.practice.slug` value is `transpose 🙂`, but it must be a lowercase and kebab-case string:
+/Users/angelika/Documents/exercism/elixir/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
+```
 
 ## Contributing Guide
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To check formatting of all exercises and all documents, run `./bin/check_formatt
 $ ./bin/fetch_configlet.sh
 ```
 
-R run its `lint` command to verify if all exercises have all the necessary files and if config files are correct:
+Run its `lint` command to verify if all exercises have all the necessary files and if config files are correct:
 
 ```shell
 $ ./bin/configlet lint

--- a/README.md
+++ b/README.md
@@ -19,29 +19,30 @@ installation instructions can be found at
 
 ---
 
-### Test All Assignments
+### Test Assignments
 
 To test all of the assignments against their example solution, you can run `bin/test_exercises.sh`:
 
 ```shell
 $ ./bin/test_exercises.sh
-Testing: accumulate -- Pass
-Testing: acronym -- Pass
+Testing: accumulate Pass
+Testing: acronym Pass
 ...
-Testing: zipper -- Pass
+Testing: zipper Pass
 --------------------------------------------------------------------------------
 93/93 tests passed.
 ```
 
 This will take some time.
 
-### Test Specific Assignment
-
-Go in the the specific exercise directory, run `mix test` to test an individual assignment:
+To only test some exercises, run:
 
 ```shell
-cd exercises/$EXERCISE_NAME
-mix test
+$ ./bin/test_exercises.sh word-count zebra-puzzle
+Testing: word-count Pass
+Testing: zebra-puzzle Pass
+--------------------------------------------------------------------------------
+2/2 tests passed.
 ```
 
 ### Dialyzer

--- a/bin/test_exercises.sh
+++ b/bin/test_exercises.sh
@@ -13,6 +13,9 @@ set -euo pipefail
 #
 # An exit code of 0 indicates all tests successful, 1 indicates an error with at
 # least one exercise.
+#
+# Optionally, you can pass a list of exercise names
+# to only run tests for those exercises.
 # ###
 
 # helper subroutine
@@ -39,8 +42,15 @@ relative_root=$(pwd)
 rm -rf tmp-exercises
 cp -a exercises tmp-exercises
 
+exercises=`echo tmp-exercises/*/*`
+
+if [[ ! -z "$@" ]]; then
+  pattern=$(echo "$@" | sed 's/ /|/g')
+  exercises=$(find $exercises -maxdepth 0 | grep -E "$pattern")
+fi
+
 # test each exercise
-for exercise in tmp-exercises/*/*
+for exercise in $exercises
 do
   if [ -d ${exercise} ]
   then


### PR DESCRIPTION
Changes:
- Add an option to `bin/test_exercises.sh` to only test a few chosen exercises, mention it in `README.md`.
- Mention in `README.md` how to download configlet and how to use it to lint the track.
- Mention in `CONTRIBUTING.md` our choices about supporting Elixir versions and not using external dependencies.