### PR TITLE
Set a specific range of supported versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,13 +83,13 @@ Please keep the following in mind:
 
 ## Language versions
 
-- We try to keep all exercises compatible with older major Elixir and Erlang versions, at least 2 years into the past.
+- We try to keep all exercises compatible with older Elixir and Erlang versions. We aim to support the 6 latest minor Elixir versions.
 
 - All test suites and example solutions must work in all Elixir and Erlang versions that we currently support. Please consult the GitHub workflows configuration (e.g. `.github/workflows/pr.ci.yml`) to check which versions those are.
 
-- As soon as a new major Elixir version is released, we want to start supporting it.
+- As soon as a new minor Elixir version is released, we want to start supporting it, and we drop support of the oldest currently supported version.
 
-- The test runner always runs on the newest major Elixir version.
+- The test runner always runs on the newest minor Elixir version.
 
 - The exercises' `mix.exs` files should have the Elixir version commented out.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Exercism Elixir Track
 
-![build status](https://travis-ci.org/exercism/elixir.svg?branch=master)
+![GitHub branch checks state](https://img.shields.io/github/checks-status/exercism/elixir/main)
+![GitHub contributors](https://img.shields.io/github/contributors-anon/exercism/elixir)
+![GitHub commit activity](https://img.shields.io/github/commit-activity/m/exercism/elixir)
 
-Exercism Exercises in Elixir
+[Exercism Exercises in Elixir](https://exercism.io/my/tracks/elixir)
 
 ## Setup
 
-The exercises currently target Elixir >= 1.7 and Erlang/OTP >= 20. Detailed
-installation instructions can be found at
-[http://elixir-lang.org/install.html](http://elixir-lang.org/install.html).
+The exercises currently target Elixir versions from 1.7 to 1.12 and Erlang/OTP versions from 20 to 24. Detailed installation instructions can be found at
+[http://elixir-lang.org/install.html](http://elixir-lang.org/install.html). We recommend using the [asdf version manager](https://github.com/asdf-vm/asdf) to manage multiple Elixir versions.
 
 ## Testing
 


### PR DESCRIPTION
Let's say we support exactly 6 latest minor Elixir versions. That's more specific than "at least 2 years".

Also fixes a mistake from my last PR where I called them "major" Elixir versions 🙃.