### PR TITLE
Configlet sync

### DIFF
--- a/exercises/practice/accumulate/.meta/tests.toml
+++ b/exercises/practice/accumulate/.meta/tests.toml
@@ -1,0 +1,24 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+[64d97c14-36dd-44a8-9621-2cecebd6ed23]
+description = "accumulate empty"
+
+[00008ed2-4651-4929-8c08-8b4dbd70872e]
+description = "accumulate squares"
+
+[551016da-4396-4cae-b0ec-4c3a1a264125]
+description = "accumulate upcases"
+
+[cdf95597-b6ec-4eac-a838-3480d13d0d05]
+description = "accumulate reversed strings"
+
+[bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb]
+description = "accumulate recursively"

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -1,12 +1,23 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
-
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 [dd40c4d2-3c8b-44e5-992a-f42b393ec373]
 description = "no matches"
 
 [b3cca662-f50a-489e-ae10-ab8290a09bdc]
 description = "detects two anagrams"
+include = false
+
+[03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
+description = "detects two anagrams"
+reimplements = "b3cca662-f50a-489e-ae10-ab8290a09bdc"
 
 [a27558ee-9ba0-4552-96b1-ecf665b06556]
 description = "does not detect anagram subsets"

--- a/exercises/practice/anagram/test/anagram_test.exs
+++ b/exercises/practice/anagram/test/anagram_test.exs
@@ -9,8 +9,8 @@ defmodule AnagramTest do
 
   @tag :pending
   test "detects two anagrams" do
-    matches = Anagram.match("master", ~w(stream pigeon maters))
-    assert matches == ~w(stream maters)
+    matches = Anagram.match("solemn", ~w(lemons cherry melons))
+    assert matches == ~w(lemons melons)
   end
 
   @tag :pending

--- a/exercises/practice/forth/.meta/tests.toml
+++ b/exercises/practice/forth/.meta/tests.toml
@@ -1,141 +1,150 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
-
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 [9962203f-f00a-4a85-b404-8a8ecbcec09d]
-description = "numbers just get pushed onto the stack"
+description = "parsing and numbers -> numbers just get pushed onto the stack"
 
 [9e69588e-a3d8-41a3-a371-ea02206c1e6e]
-description = "can add two numbers"
+description = "addition -> can add two numbers"
 
 [52336dd3-30da-4e5c-8523-bdf9a3427657]
-description = "errors if there is nothing on the stack"
+description = "addition -> errors if there is nothing on the stack"
 
 [06efb9a4-817a-435e-b509-06166993c1b8]
-description = "errors if there is only one value on the stack"
+description = "addition -> errors if there is only one value on the stack"
 
 [09687c99-7bbc-44af-8526-e402f997ccbf]
-description = "can subtract two numbers"
+description = "subtraction -> can subtract two numbers"
 
 [5d63eee2-1f7d-4538-b475-e27682ab8032]
-description = "errors if there is nothing on the stack"
+description = "subtraction -> errors if there is nothing on the stack"
 
 [b3cee1b2-9159-418a-b00d-a1bb3765c23b]
-description = "errors if there is only one value on the stack"
+description = "subtraction -> errors if there is only one value on the stack"
 
 [5df0ceb5-922e-401f-974d-8287427dbf21]
-description = "can multiply two numbers"
+description = "multiplication -> can multiply two numbers"
 
 [9e004339-15ac-4063-8ec1-5720f4e75046]
-description = "errors if there is nothing on the stack"
+description = "multiplication -> errors if there is nothing on the stack"
 
 [8ba4b432-9f94-41e0-8fae-3b3712bd51b3]
-description = "errors if there is only one value on the stack"
+description = "multiplication -> errors if there is only one value on the stack"
 
 [e74c2204-b057-4cff-9aa9-31c7c97a93f5]
-description = "can divide two numbers"
+description = "division -> can divide two numbers"
 
 [54f6711c-4b14-4bb0-98ad-d974a22c4620]
-description = "performs integer division"
+description = "division -> performs integer division"
 
 [a5df3219-29b4-4d2f-b427-81f82f42a3f1]
-description = "errors if dividing by zero"
+description = "division -> errors if dividing by zero"
 
 [1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a]
-description = "errors if there is nothing on the stack"
+description = "division -> errors if there is nothing on the stack"
 
 [d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d]
-description = "errors if there is only one value on the stack"
+description = "division -> errors if there is only one value on the stack"
 
 [ee28d729-6692-4a30-b9be-0d830c52a68c]
-description = "addition and subtraction"
+description = "combined arithmetic -> addition and subtraction"
 
 [40b197da-fa4b-4aca-a50b-f000d19422c1]
-description = "multiplication and division"
+description = "combined arithmetic -> multiplication and division"
 
 [c5758235-6eef-4bf6-ab62-c878e50b9957]
-description = "copies a value on the stack"
+description = "dup -> copies a value on the stack"
 
 [f6889006-5a40-41e7-beb3-43b09e5a22f4]
-description = "copies the top value on the stack"
+description = "dup -> copies the top value on the stack"
 
 [40b7569c-8401-4bd4-a30d-9adf70d11bc4]
-description = "errors if there is nothing on the stack"
+description = "dup -> errors if there is nothing on the stack"
 
 [1971da68-1df2-4569-927a-72bf5bb7263c]
-description = "removes the top value on the stack if it is the only one"
+description = "drop -> removes the top value on the stack if it is the only one"
 
 [8929d9f2-4a78-4e0f-90ad-be1a0f313fd9]
-description = "removes the top value on the stack if it is not the only one"
+description = "drop -> removes the top value on the stack if it is not the only one"
 
 [6dd31873-6dd7-4cb8-9e90-7daa33ba045c]
-description = "errors if there is nothing on the stack"
+description = "drop -> errors if there is nothing on the stack"
 
 [3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3]
-description = "swaps the top two values on the stack if they are the only ones"
+description = "swap -> swaps the top two values on the stack if they are the only ones"
 
 [8ce869d5-a503-44e4-ab55-1da36816ff1c]
-description = "swaps the top two values on the stack if they are not the only ones"
+description = "swap -> swaps the top two values on the stack if they are not the only ones"
 
 [74ba5b2a-b028-4759-9176-c5c0e7b2b154]
-description = "errors if there is nothing on the stack"
+description = "swap -> errors if there is nothing on the stack"
 
 [dd52e154-5d0d-4a5c-9e5d-73eb36052bc8]
-description = "errors if there is only one value on the stack"
+description = "swap -> errors if there is only one value on the stack"
 
 [a2654074-ba68-4f93-b014-6b12693a8b50]
-description = "copies the second element if there are only two"
+description = "over -> copies the second element if there are only two"
 
 [c5b51097-741a-4da7-8736-5c93fa856339]
-description = "copies the second element if there are more than two"
+description = "over -> copies the second element if there are more than two"
 
 [6e1703a6-5963-4a03-abba-02e77e3181fd]
-description = "errors if there is nothing on the stack"
+description = "over -> errors if there is nothing on the stack"
 
 [ee574dc4-ef71-46f6-8c6a-b4af3a10c45f]
-description = "errors if there is only one value on the stack"
+description = "over -> errors if there is only one value on the stack"
 
 [ed45cbbf-4dbf-4901-825b-54b20dbee53b]
-description = "can consist of built-in words"
+description = "user-defined words -> can consist of built-in words"
 
 [2726ea44-73e4-436b-bc2b-5ff0c6aa014b]
-description = "execute in the right order"
+description = "user-defined words -> execute in the right order"
 
 [9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33]
-description = "can override other user-defined words"
+description = "user-defined words -> can override other user-defined words"
 
 [669db3f3-5bd6-4be0-83d1-618cd6e4984b]
-description = "can override built-in words"
+description = "user-defined words -> can override built-in words"
 
 [588de2f0-c56e-4c68-be0b-0bb1e603c500]
-description = "can override built-in operators"
+description = "user-defined words -> can override built-in operators"
 
 [ac12aaaf-26c6-4a10-8b3c-1c958fa2914c]
-description = "can use different words with the same name"
+description = "user-defined words -> can use different words with the same name"
 
 [53f82ef0-2750-4ccb-ac04-5d8c1aefabb1]
-description = "can define word that uses word with the same name"
+description = "user-defined words -> can define word that uses word with the same name"
 
 [35958cee-a976-4a0f-9378-f678518fa322]
-description = "cannot redefine numbers"
+description = "user-defined words -> cannot redefine non-negative numbers"
+
+[df5b2815-3843-4f55-b16c-c3ed507292a7]
+description = "user-defined words -> cannot redefine negative numbers"
 
 [5180f261-89dd-491e-b230-62737e09806f]
-description = "errors if executing a non-existent word"
+description = "user-defined words -> errors if executing a non-existent word"
 
 [7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6]
-description = "DUP is case-insensitive"
+description = "case-insensitivity -> DUP is case-insensitive"
 
 [339ed30b-f5b4-47ff-ab1c-67591a9cd336]
-description = "DROP is case-insensitive"
+description = "case-insensitivity -> DROP is case-insensitive"
 
 [ee1af31e-1355-4b1b-bb95-f9d0b2961b87]
-description = "SWAP is case-insensitive"
+description = "case-insensitivity -> SWAP is case-insensitive"
 
 [acdc3a49-14c8-4cc2-945d-11edee6408fa]
-description = "OVER is case-insensitive"
+description = "case-insensitivity -> OVER is case-insensitive"
 
 [5934454f-a24f-4efc-9fdd-5794e5f0c23c]
-description = "user-defined words are case-insensitive"
+description = "case-insensitivity -> user-defined words are case-insensitive"
 
 [037d4299-195f-4be7-a46d-f07ca6280a06]
-description = "definitions are case-insensitive"
+description = "case-insensitivity -> definitions are case-insensitive"

--- a/exercises/practice/forth/test/forth_test.exs
+++ b/exercises/practice/forth/test/forth_test.exs
@@ -403,6 +403,13 @@ defmodule ForthTest do
     end
 
     @tag :pending
+    test "cannot redefine negative numbers" do
+      assert_raise Forth.InvalidWord, fn ->
+        Forth.new() |> Forth.eval(": -1 2 ;")
+      end
+    end
+
+    @tag :pending
     test "raises if executing a non-existent word" do
       assert_raise Forth.UnknownWord, fn ->
         Forth.new() |> Forth.eval("foo")

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,7 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
-
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 [f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
 description = "empty strands"
 
@@ -17,14 +23,44 @@ description = "long identical strands"
 [cd2273a5-c576-46c8-a52b-dee251c3e6e5]
 description = "long different strands"
 
+[919f8ef0-b767-4d1b-8516-6379d07fcb28]
+description = "disallow first strand longer"
+include = false
+
 [b9228bb1-465f-4141-b40f-1f99812de5a8]
 description = "disallow first strand longer"
+reimplements = "919f8ef0-b767-4d1b-8516-6379d07fcb28"
+
+[8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
+description = "disallow second strand longer"
+include = false
 
 [dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
 description = "disallow second strand longer"
+reimplements = "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e"
+
+[5dce058b-28d4-4ca7-aa64-adfe4e17784c]
+description = "disallow left empty strand"
+include = false
+
+[db92e77e-7c72-499d-8fe6-9354d2bfd504]
+description = "disallow left empty strand"
+include = false
+reimplements = "5dce058b-28d4-4ca7-aa64-adfe4e17784c"
 
 [b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
 description = "disallow empty first strand"
+reimplements = "db92e77e-7c72-499d-8fe6-9354d2bfd504"
+
+[38826d4b-16fb-4639-ac3e-ba027dec8b5f]
+description = "disallow right empty strand"
+include = false
+
+[920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
+description = "disallow right empty strand"
+include = false
+reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
 
 [9ab9262f-3521-4191-81f5-0ed184a5aa89]
 description = "disallow empty second strand"
+reimplements = "920cd6e3-18f4-4143-b6b8-74270bb8f8a3"

--- a/exercises/practice/isogram/.meta/tests.toml
+++ b/exercises/practice/isogram/.meta/tests.toml
@@ -1,7 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
-
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 [a0e97d2d-669e-47c7-8134-518a1e2c4555]
 description = "empty string"
 
@@ -40,3 +46,6 @@ description = "duplicated character in the middle"
 
 [310ac53d-8932-47bc-bbb4-b2b94f25a83e]
 description = "same first and last characters"
+
+[0d0b8644-0a1e-4a31-a432-2b3ee270d847]
+description = "word with duplicated character and with two hyphens"

--- a/exercises/practice/isogram/test/isogram_test.exs
+++ b/exercises/practice/isogram/test/isogram_test.exs
@@ -65,4 +65,9 @@ defmodule IsogramTest do
   test "same first and last characters" do
     refute Isogram.isogram?("angola")
   end
+
+  @tag :pending
+  test "word with duplicated character and with two hyphens" do
+    refute Isogram.isogram?("up-to-date")
+  end
 end

--- a/exercises/practice/kindergarten-garden/.meta/tests.toml
+++ b/exercises/practice/kindergarten-garden/.meta/tests.toml
@@ -1,30 +1,60 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
-
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 [1fc316ed-17ab-4fba-88ef-3ae78296b692]
-description = "garden with single student"
+description = "partial garden -> garden with single student"
 
 [acd19dc1-2200-4317-bc2a-08f021276b40]
-description = "different garden with single student"
+description = "partial garden -> different garden with single student"
 
 [c376fcc8-349c-446c-94b0-903947315757]
-description = "garden with two students"
+description = "partial garden -> garden with two students"
 
 [2d620f45-9617-4924-9d27-751c80d17db9]
-description = "second student's garden"
+description = "partial garden -> multiple students for the same garden with three students -> second student's garden"
 
 [57712331-4896-4364-89f8-576421d69c44]
-description = "third student's garden"
+description = "partial garden -> multiple students for the same garden with three students -> third student's garden"
 
 [149b4290-58e1-40f2-8ae4-8b87c46e765b]
-description = "first student's garden"
+description = "full garden -> for Alice, first student's garden"
 
 [ba25dbbc-10bd-4a37-b18e-f89ecd098a5e]
-description = "second student's garden"
+description = "full garden -> for Bob, second student's garden"
+
+[566b621b-f18e-4c5f-873e-be30544b838c]
+description = "full garden -> for Charlie"
+
+[3ad3df57-dd98-46fc-9269-1877abf612aa]
+description = "full garden -> for David"
+
+[0f0a55d1-9710-46ed-a0eb-399ba8c72db2]
+description = "full garden -> for Eve"
+
+[a7e80c90-b140-4ea1-aee3-f4625365c9a4]
+description = "full garden -> for Fred"
+
+[9d94b273-2933-471b-86e8-dba68694c615]
+description = "full garden -> for Ginny"
+
+[f55bc6c2-ade8-4844-87c4-87196f1b7258]
+description = "full garden -> for Harriet"
+
+[759070a3-1bb1-4dd4-be2c-7cce1d7679ae]
+description = "full garden -> for Ileana"
+
+[78578123-2755-4d4a-9c7d-e985b8dda1c6]
+description = "full garden -> for Joseph"
 
 [6bb66df7-f433-41ab-aec2-3ead6e99f65b]
-description = "second to last student's garden"
+description = "full garden -> for Kincaid, second to last student's garden"
 
 [d7edec11-6488-418a-94e6-ed509e0fa7eb]
-description = "last student's garden"
+description = "full garden -> for Larry, last student's garden"

--- a/exercises/practice/list-ops/.meta/tests.toml
+++ b/exercises/practice/list-ops/.meta/tests.toml
@@ -1,66 +1,105 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
-
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 [485b9452-bf94-40f7-a3db-c3cf4850066a]
-description = "empty lists"
+description = "append entries to a list and return the new list -> empty lists"
 
 [2c894696-b609-4569-b149-8672134d340a]
-description = "list to empty list"
+description = "append entries to a list and return the new list -> list to empty list"
+
+[e842efed-3bf6-4295-b371-4d67a4fdf19c]
+description = "append entries to a list and return the new list -> empty list to list"
 
 [71dcf5eb-73ae-4a0e-b744-a52ee387922f]
-description = "non-empty lists"
+description = "append entries to a list and return the new list -> non-empty lists"
 
 [28444355-201b-4af2-a2f6-5550227bde21]
-description = "empty list"
+description = "concatenate a list of lists -> empty list"
 
 [331451c1-9573-42a1-9869-2d06e3b389a9]
-description = "list of lists"
+description = "concatenate a list of lists -> list of lists"
 
 [d6ecd72c-197f-40c3-89a4-aa1f45827e09]
-description = "list of nested lists"
+description = "concatenate a list of lists -> list of nested lists"
 
 [0524fba8-3e0f-4531-ad2b-f7a43da86a16]
-description = "empty list"
+description = "filter list returning only values that satisfy the filter function -> empty list"
 
 [88494bd5-f520-4edb-8631-88e415b62d24]
-description = "non-empty list"
+description = "filter list returning only values that satisfy the filter function -> non-empty list"
 
 [1cf0b92d-8d96-41d5-9c21-7b3c37cb6aad]
-description = "empty list"
+description = "returns the length of a list -> empty list"
 
 [d7b8d2d9-2d16-44c4-9a19-6e5f237cb71e]
-description = "non-empty list"
+description = "returns the length of a list -> non-empty list"
 
 [c0bc8962-30e2-4bec-9ae4-668b8ecd75aa]
-description = "empty list"
+description = "return a list of elements whose values equal the list value transformed by the mapping function -> empty list"
 
 [11e71a95-e78b-4909-b8e4-60cdcaec0e91]
-description = "non-empty list"
+description = "return a list of elements whose values equal the list value transformed by the mapping function -> non-empty list"
+
+[613b20b7-1873-4070-a3a6-70ae5f50d7cc]
+description = "folds (reduces) the given list from the left with a function -> empty list"
+include = false
+
+[e56df3eb-9405-416a-b13a-aabb4c3b5194]
+description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
+include = false
+
+[d2cf5644-aee1-4dfc-9b88-06896676fe27]
+description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
+include = false
 
 [36549237-f765-4a4c-bfd9-5d3a8f7b07d2]
-description = "empty list"
+description = "folds (reduces) the given list from the left with a function -> empty list"
+reimplements = "613b20b7-1873-4070-a3a6-70ae5f50d7cc"
 
 [7a626a3c-03ec-42bc-9840-53f280e13067]
-description = "direction independent function applied to non-empty list"
+description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
+reimplements = "e56df3eb-9405-416a-b13a-aabb4c3b5194"
 
 [d7fcad99-e88e-40e1-a539-4c519681f390]
-description = "direction dependent function applied to non-empty list"
+description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
+reimplements = "d2cf5644-aee1-4dfc-9b88-06896676fe27"
+
+[aeb576b9-118e-4a57-a451-db49fac20fdc]
+description = "folds (reduces) the given list from the right with a function -> empty list"
+include = false
+
+[c4b64e58-313e-4c47-9c68-7764964efb8e]
+description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
+include = false
+
+[be396a53-c074-4db3-8dd6-f7ed003cce7c]
+description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
+include = false
 
 [17214edb-20ba-42fc-bda8-000a5ab525b0]
-description = "empty list"
+description = "folds (reduces) the given list from the right with a function -> empty list"
+reimplements = "aeb576b9-118e-4a57-a451-db49fac20fdc"
 
 [e1c64db7-9253-4a3d-a7c4-5273b9e2a1bd]
-description = "direction independent function applied to non-empty list"
+description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
+reimplements = "c4b64e58-313e-4c47-9c68-7764964efb8e"
 
 [8066003b-f2ff-437e-9103-66e6df474844]
-description = "direction dependent function applied to non-empty list"
+description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
+reimplements = "be396a53-c074-4db3-8dd6-f7ed003cce7c"
 
 [94231515-050e-4841-943d-d4488ab4ee30]
-description = "empty list"
+description = "reverse the elements of the list -> empty list"
 
 [fcc03d1e-42e0-4712-b689-d54ad761f360]
-description = "non-empty list"
+description = "reverse the elements of the list -> non-empty list"
 
 [40872990-b5b8-4cb8-9085-d91fc0d05d26]
-description = "list of lists is not flattened"
+description = "reverse the elements of the list -> list of lists is not flattened"

--- a/exercises/practice/list-ops/test/list_ops_test.exs
+++ b/exercises/practice/list-ops/test/list_ops_test.exs
@@ -109,7 +109,7 @@ defmodule ListOpsTest do
   describe "foldr" do
     @tag :pending
     test "empty list" do
-      assert L.foldr([], 2, &(&1 + &2)) == 2
+      assert L.foldr([], 2, &(&1 * &2)) == 2
     end
 
     @tag :pending

--- a/exercises/practice/luhn/.meta/tests.toml
+++ b/exercises/practice/luhn/.meta/tests.toml
@@ -1,7 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
-
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 [792a7082-feb7-48c7-b88b-bbfec160865e]
 description = "single digit strings can not be valid"
 
@@ -55,3 +61,6 @@ description = "using ascii value for non-doubled non-digit isn't allowed"
 
 [f94cf191-a62f-4868-bc72-7253114aa157]
 description = "using ascii value for doubled non-digit isn't allowed"
+
+[8b72ad26-c8be-49a2-b99c-bcc3bf631b33]
+description = "non-numeric, non-space char in the middle with a sum that's divisible by 10 isn't allowed"

--- a/exercises/practice/luhn/test/luhn_test.exs
+++ b/exercises/practice/luhn/test/luhn_test.exs
@@ -95,4 +95,9 @@ defmodule LuhnTest do
   test "using ascii value for doubled non-digit isn't allowed" do
     refute Luhn.valid?(":9")
   end
+
+  @tag :pending
+  test "non-numeric, non-space char in the middle with a sum that's divisible by 10 isn't allowed" do
+    refute Luhn.valid?("59%59")
+  end
 end

--- a/exercises/practice/prime-factors/.meta/tests.toml
+++ b/exercises/practice/prime-factors/.meta/tests.toml
@@ -1,18 +1,39 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
-
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 [924fc966-a8f5-4288-82f2-6b9224819ccd]
 description = "no factors"
 
 [17e30670-b105-4305-af53-ddde182cb6ad]
 description = "prime number"
 
+[238d57c8-4c12-42ef-af34-ae4929f94789]
+description = "another prime number"
+
 [f59b8350-a180-495a-8fb1-1712fbee1158]
 description = "square of a prime"
 
+[756949d3-3158-4e3d-91f2-c4f9f043ee70]
+description = "product of first prime"
+
 [bc8c113f-9580-4516-8669-c5fc29512ceb]
 description = "cube of a prime"
+
+[7d6a3300-a4cb-4065-bd33-0ced1de6cb44]
+description = "product of second prime"
+
+[073ac0b2-c915-4362-929d-fc45f7b9a9e4]
+description = "product of third prime"
+
+[6e0e4912-7fb6-47f3-a9ad-dbcd79340c75]
+description = "product of first and second prime"
 
 [00485cd3-a3fe-4fbe-a64a-a4308fc1f870]
 description = "product of primes and non-primes"

--- a/exercises/practice/tournament/.meta/tests.toml
+++ b/exercises/practice/tournament/.meta/tests.toml
@@ -1,7 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
-
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 [67e9fab1-07c1-49cf-9159-bc8671cc7c9c]
 description = "just the header if no input"
 
@@ -34,3 +40,6 @@ description = "incomplete competition (not all pairs have played)"
 
 [3aa0386f-150b-4f99-90bb-5195e7b7d3b8]
 description = "ties broken alphabetically"
+
+[f9e20931-8a65-442a-81f6-503c0205b17a]
+description = "ensure points sorted numerically"

--- a/exercises/practice/tournament/test/tournament_test.exs
+++ b/exercises/practice/tournament/test/tournament_test.exs
@@ -230,4 +230,25 @@ defmodule TournamentTest do
 
     assert Tournament.tally(input) == expected
   end
+
+  @tag :pending
+  test "ensure points sorted numerically" do
+    input = [
+      "Devastating Donkeys;Blithering Badgers;win",
+      "Devastating Donkeys;Blithering Badgers;win",
+      "Devastating Donkeys;Blithering Badgers;win",
+      "Devastating Donkeys;Blithering Badgers;win",
+      "Blithering Badgers;Devastating Donkeys;win"
+    ]
+
+    expected =
+      """
+      Team                           | MP |  W |  D |  L |  P
+      Devastating Donkeys            |  5 |  4 |  0 |  1 | 12
+      Blithering Badgers             |  5 |  1 |  0 |  4 |  3
+      """
+      |> String.trim()
+
+    assert Tournament.tally(input) == expected
+  end
 end

--- a/exercises/practice/transpose/.meta/tests.toml
+++ b/exercises/practice/transpose/.meta/tests.toml
@@ -1,7 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
-
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 [404b7262-c050-4df0-a2a2-0cb06cd6a821]
 description = "empty string"
 
@@ -34,3 +40,6 @@ description = "rectangle"
 
 [b80badc9-057e-4543-bd07-ce1296a1ea2c]
 description = "triangle"
+
+[76acfd50-5596-4d05-89f1-5116328a7dd9]
+description = "jagged triangle"


### PR DESCRIPTION
This PR updates all `tests.toml` files that `configlet sync` was complaining about. In a few cases there's a new test added, but mostly it was a mistake in `tests.toml`, e.g. by totally omiting skipped and reimplemented cases.
