### PR TITLE
Simplify resistor-color

### DIFF
--- a/config.json
+++ b/config.json
@@ -861,8 +861,7 @@
           "enum"
         ],
         "practices": [
-          "charlists",
-          "maps"
+          "charlists"
         ],
         "difficulty": 2
       },
@@ -1321,8 +1320,7 @@
         ],
         "practices": [
           "structs",
-          "tuples",
-          "maps"
+          "tuples"
         ],
         "difficulty": 3
       },

--- a/config.json
+++ b/config.json
@@ -827,11 +827,12 @@
         "name": "Resistor Color",
         "uuid": "c1532449-bf9e-446a-8e8f-97a6c19608e5",
         "prerequisites": [
-          "lists",
-          "enum"
+          "atoms",
+          "maps"
         ],
         "practices": [
-          "enum"
+          "atoms",
+          "maps"
         ],
         "difficulty": 1
       },
@@ -2673,6 +2674,7 @@
           "maps"
         ],
         "practices": [
+          "atoms",
           "maps"
         ],
         "difficulty": 2
@@ -2692,7 +2694,8 @@
         ],
         "practices": [
           "atoms",
-          "integers"
+          "integers",
+          "maps"
         ],
         "difficulty": 3
        }

--- a/exercises/practice/resistor-color/.meta/design.md
+++ b/exercises/practice/resistor-color/.meta/design.md
@@ -1,0 +1,11 @@
+# Design
+
+Conceptually, `resistor-color` needs to come before `resistor-color-duo` and `resistor-color-trio`.
+
+To make that possible, we need to drop the function `colors` that list all of the colors from this exercise.
+It doesn't appear in the duo or trio exercises.
+
+The necessity to list all of the colors in order demands knowledge of `Enum` because there are those idiomatic approaches possible:
+- a list of colors and find the colors value by its position in the list (`Enum.find_index`)
+- a list of tuples with colors and values and map the list to be a list of colors
+- a map, which becomes a list of tuples and needs to be sorted because map keys aren't sorted

--- a/exercises/practice/resistor-color/.meta/example.ex
+++ b/exercises/practice/resistor-color/.meta/example.ex
@@ -1,26 +1,20 @@
 defmodule ResistorColor do
-  @colors [
-    :black,
-    :brown,
-    :red,
-    :orange,
-    :yellow,
-    :green,
-    :blue,
-    :violet,
-    :grey,
-    :white
-  ]
-
-  @doc """
-  Return a list of all colors
-  """
-  @spec colors() :: list(atom)
-  def colors, do: @colors
+  @colors %{
+    black: 0,
+    brown: 1,
+    red: 2,
+    orange: 3,
+    yellow: 4,
+    green: 5,
+    blue: 6,
+    violet: 7,
+    grey: 8,
+    white: 9
+  }
 
   @doc """
   Return the value of a color band
   """
   @spec code(atom) :: integer()
-  def code(color), do: Enum.find_index(@colors, &(&1 == color))
+  def code(color), do: @colors[color]
 end

--- a/exercises/practice/resistor-color/.meta/tests.toml
+++ b/exercises/practice/resistor-color/.meta/tests.toml
@@ -13,3 +13,4 @@ description = "Orange"
 
 [581d68fa-f968-4be2-9f9d-880f2fb73cf7]
 description = "Colors"
+include = false

--- a/exercises/practice/resistor-color/lib/resistor_color.ex
+++ b/exercises/practice/resistor-color/lib/resistor_color.ex
@@ -1,12 +1,5 @@
 defmodule ResistorColor do
   @doc """
-  Return a list of all colors
-  """
-  @spec colors() :: list(atom)
-  def colors do
-  end
-
-  @doc """
   Return the value of a color band
   """
   @spec code(atom) :: integer()

--- a/exercises/practice/resistor-color/test/resistor_color_test.exs
+++ b/exercises/practice/resistor-color/test/resistor_color_test.exs
@@ -50,22 +50,4 @@ defmodule ResistorColorTest do
   test "returns white color code" do
     assert ResistorColor.code(:white) == 9
   end
-
-  @tag :pending
-  test "returns all colors" do
-    colors = [
-      :black,
-      :brown,
-      :red,
-      :orange,
-      :yellow,
-      :green,
-      :blue,
-      :violet,
-      :grey,
-      :white
-    ]
-
-    assert ResistorColor.colors() == colors
-  end
 end


### PR DESCRIPTION
@SleeplessByte says the intention behind `resistor-color` was that it will be solved before `resistor-color-duo` and `resistor-color-trio`.

This PR simplifies `resistor-color` so that it can get unlocked before or at the same time as its big brothers.

It we don't like that, we could also modify the big brothers to add a `colors` function to each.