### PR TITLE
Reorder concept exercises to follow concept tree order

### DIFF
--- a/config.json
+++ b/config.json
@@ -303,6 +303,22 @@
         "status": "beta"
       },
       {
+        "slug": "library-fees",
+        "name": "Library Fees",
+        "uuid": "b5629003-638c-47c0-ad76-a0769f285053",
+        "concepts": [
+          "dates-and-time"
+        ],
+        "prerequisites": [
+          "integers",
+          "floating-point-numbers",
+          "tuples",
+          "atoms",
+          "if"
+        ],
+        "status": "beta"
+      },
+      {
         "slug": "basketball-website",
         "name": "Basketball Website",
         "uuid": "ba03df1d-20e4-4527-a8a7-afc97a834975",
@@ -314,21 +330,6 @@
           "strings",
           "recursion",
           "nil"
-        ],
-        "status": "beta"
-      },
-      {
-        "slug": "file-sniffer",
-        "name": "File Sniffer",
-        "uuid": "1653d476-5354-4d99-a990-1db418a7281c",
-        "concepts": [
-          "binaries"
-        ],
-        "prerequisites": [
-          "strings",
-          "pattern-matching",
-          "if",
-          "bitstrings"
         ],
         "status": "beta"
       },
@@ -346,6 +347,21 @@
           "tuples",
           "nil",
           "anonymous-functions"
+        ],
+        "status": "beta"
+      },
+      {
+        "slug": "file-sniffer",
+        "name": "File Sniffer",
+        "uuid": "1653d476-5354-4d99-a990-1db418a7281c",
+        "concepts": [
+          "binaries"
+        ],
+        "prerequisites": [
+          "strings",
+          "pattern-matching",
+          "if",
+          "bitstrings"
         ],
         "status": "beta"
       },
@@ -506,22 +522,6 @@
           "io",
           "processes",
           "pids"
-        ],
-        "status": "beta"
-      },
-      {
-        "slug": "library-fees",
-        "name": "Library Fees",
-        "uuid": "b5629003-638c-47c0-ad76-a0769f285053",
-        "concepts": [
-          "dates-and-time"
-        ],
-        "prerequisites": [
-          "integers",
-          "floating-point-numbers",
-          "tuples",
-          "atoms",
-          "if"
         ],
         "status": "beta"
       },

--- a/config.json
+++ b/config.json
@@ -45,6 +45,19 @@
         "status": "beta"
       },
       {
+        "slug": "secrets",
+        "name": "Secrets",
+        "uuid": "1e3ceb20-715c-4157-9192-13284217affc",
+        "concepts": [
+          "anonymous-functions",
+          "bit-manipulation"
+        ],
+        "prerequisites": [
+          "basics"
+        ],
+        "status": "beta"
+      },
+      {
         "slug": "pacman-rules",
         "name": "Pacman Rules",
         "uuid": "5e743355-1ef3-4b5d-b59d-03bbc9697e6c",
@@ -105,19 +118,6 @@
         ],
         "prerequisites": [
           "cond"
-        ],
-        "status": "beta"
-      },
-      {
-        "slug": "secrets",
-        "name": "Secrets",
-        "uuid": "1e3ceb20-715c-4157-9192-13284217affc",
-        "concepts": [
-          "anonymous-functions",
-          "bit-manipulation"
-        ],
-        "prerequisites": [
-          "basics"
         ],
         "status": "beta"
       },

--- a/config.json
+++ b/config.json
@@ -151,16 +151,17 @@
         "status": "beta"
       },
       {
-        "slug": "name-badge",
-        "name": "Name Badge",
-        "uuid": "b6ae6cb4-f908-436f-916c-fa847e4a82fb",
+        "slug": "bird-count",
+        "name": "Bird Count",
+        "uuid": "e17088c8-c40f-4d4c-b5dd-d32f62b8087b",
         "concepts": [
-          "nil",
-          "if"
+          "recursion"
         ],
         "prerequisites": [
-          "strings",
-          "booleans"
+          "lists",
+          "pattern-matching",
+          "multiple-clause-functions",
+          "guards"
         ],
         "status": "beta"
       },
@@ -181,17 +182,16 @@
         "status": "beta"
       },
       {
-        "slug": "bird-count",
-        "name": "Bird Count",
-        "uuid": "e17088c8-c40f-4d4c-b5dd-d32f62b8087b",
+        "slug": "name-badge",
+        "name": "Name Badge",
+        "uuid": "b6ae6cb4-f908-436f-916c-fa847e4a82fb",
         "concepts": [
-          "recursion"
+          "nil",
+          "if"
         ],
         "prerequisites": [
-          "lists",
-          "pattern-matching",
-          "multiple-clause-functions",
-          "guards"
+          "strings",
+          "booleans"
         ],
         "status": "beta"
       },

--- a/config.json
+++ b/config.json
@@ -45,19 +45,6 @@
         "status": "beta"
       },
       {
-        "slug": "secrets",
-        "name": "Secrets",
-        "uuid": "1e3ceb20-715c-4157-9192-13284217affc",
-        "concepts": [
-          "anonymous-functions",
-          "bit-manipulation"
-        ],
-        "prerequisites": [
-          "basics"
-        ],
-        "status": "beta"
-      },
-      {
         "slug": "pacman-rules",
         "name": "Pacman Rules",
         "uuid": "5e743355-1ef3-4b5d-b59d-03bbc9697e6c",
@@ -76,6 +63,19 @@
         "concepts": [
           "integers",
           "floating-point-numbers"
+        ],
+        "prerequisites": [
+          "basics"
+        ],
+        "status": "beta"
+      },
+      {
+        "slug": "secrets",
+        "name": "Secrets",
+        "uuid": "1e3ceb20-715c-4157-9192-13284217affc",
+        "concepts": [
+          "anonymous-functions",
+          "bit-manipulation"
         ],
         "prerequisites": [
           "basics"

--- a/config.json
+++ b/config.json
@@ -182,16 +182,20 @@
         "status": "beta"
       },
       {
-        "slug": "name-badge",
-        "name": "Name Badge",
-        "uuid": "b6ae6cb4-f908-436f-916c-fa847e4a82fb",
+        "slug": "city-office",
+        "name": "City Office",
+        "uuid": "07125322-4dce-4275-936e-4452a6aad32a",
         "concepts": [
-          "nil",
-          "if"
+          "docs",
+          "typespecs"
         ],
         "prerequisites": [
+          "integers",
+          "tuples",
+          "lists",
           "strings",
-          "booleans"
+          "maps",
+          "multiple-clause-functions"
         ],
         "status": "beta"
       },
@@ -208,6 +212,32 @@
           "recursion",
           "pattern-matching",
           "guards"
+        ],
+        "status": "beta"
+      },
+      {
+        "slug": "date-parser",
+        "name": "Date Parser",
+        "uuid": "57198686-71c9-4f38-973a-a111435560e7",
+        "concepts": [
+          "regular-expressions"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
+        "status": "beta"
+      },
+      {
+        "slug": "name-badge",
+        "name": "Name Badge",
+        "uuid": "b6ae6cb4-f908-436f-916c-fa847e4a82fb",
+        "concepts": [
+          "nil",
+          "if"
+        ],
+        "prerequisites": [
+          "strings",
+          "booleans"
         ],
         "status": "beta"
       },
@@ -388,18 +418,6 @@
         "status": "beta"
       },
       {
-        "slug": "date-parser",
-        "name": "Date Parser",
-        "uuid": "57198686-71c9-4f38-973a-a111435560e7",
-        "concepts": [
-          "regular-expressions"
-        ],
-        "prerequisites": [
-          "strings"
-        ],
-        "status": "beta"
-      },
-      {
         "slug": "boutique-suggestions",
         "name": "Boutique Suggestions",
         "uuid": "f8208858-901e-4e5a-9f34-689bf8ad156c",
@@ -538,24 +556,6 @@
           "lists",
           "anonymous-functions",
           "errors"
-        ],
-        "status": "beta"
-      },
-      {
-        "slug": "city-office",
-        "name": "City Office",
-        "uuid": "07125322-4dce-4275-936e-4452a6aad32a",
-        "concepts": [
-          "docs",
-          "typespecs"
-        ],
-        "prerequisites": [
-          "integers",
-          "tuples",
-          "lists",
-          "strings",
-          "maps",
-          "multiple-clause-functions"
         ],
         "status": "beta"
       },

--- a/config.json
+++ b/config.json
@@ -366,6 +366,37 @@
         "status": "beta"
       },
       {
+        "slug": "newsletter",
+        "name": "Newsletter",
+        "uuid": "5564c89c-4706-4a48-99a4-2ad26457f66f",
+        "concepts": [
+          "file"
+        ],
+        "prerequisites": [
+          "strings",
+          "enum",
+          "io",
+          "processes",
+          "pids"
+        ],
+        "status": "beta"
+      },
+      {
+        "slug": "chessboard",
+        "name": "Chessboard",
+        "uuid": "6ea28f3e-a59a-45b0-83a7-38a2e96bdff7",
+        "concepts": [
+          "ranges"
+        ],
+        "prerequisites": [
+          "enum",
+          "integers",
+          "bitstrings",
+          "charlists"
+        ],
+        "status": "beta"
+      },
+      {
         "slug": "rpn-calculator",
         "name": "RPN Calculator",
         "uuid": "f660a2e1-bb50-4626-8d3f-6cd7c44fa8db",
@@ -491,37 +522,6 @@
           "strings",
           "charlists",
           "atoms"
-        ],
-        "status": "beta"
-      },
-      {
-        "slug": "chessboard",
-        "name": "Chessboard",
-        "uuid": "6ea28f3e-a59a-45b0-83a7-38a2e96bdff7",
-        "concepts": [
-          "ranges"
-        ],
-        "prerequisites": [
-          "enum",
-          "integers",
-          "bitstrings",
-          "charlists"
-        ],
-        "status": "beta"
-      },
-      {
-        "slug": "newsletter",
-        "name": "Newsletter",
-        "uuid": "5564c89c-4706-4a48-99a4-2ad26457f66f",
-        "concepts": [
-          "file"
-        ],
-        "prerequisites": [
-          "strings",
-          "enum",
-          "io",
-          "processes",
-          "pids"
         ],
         "status": "beta"
       },

--- a/config.json
+++ b/config.json
@@ -415,14 +415,6 @@
         "status": "beta"
       },
       {
-        "slug": "mensch-aergere-dich-nicht",
-        "name": "Mensch Ärgere Dich Nicht",
-        "uuid": "3e2f8bc6-20b4-4e8f-a658-9c270342208e",
-        "concepts": [],
-        "prerequisites": [],
-        "status": "deprecated"
-      },
-      {
         "slug": "boutique-suggestions",
         "name": "Boutique Suggestions",
         "uuid": "f8208858-901e-4e5a-9f34-689bf8ad156c",
@@ -576,6 +568,14 @@
           "errors"
         ],
         "status": "beta"
+      },
+      {
+        "slug": "mensch-aergere-dich-nicht",
+        "name": "Mensch Ärgere Dich Nicht",
+        "uuid": "3e2f8bc6-20b4-4e8f-a658-9c270342208e",
+        "concepts": [],
+        "prerequisites": [],
+        "status": "deprecated"
       }
     ],
     "practice": [

--- a/config.json
+++ b/config.json
@@ -272,6 +272,37 @@
         "status": "beta"
       },
       {
+        "slug": "wine-cellar",
+        "name": "Wine Cellar",
+        "uuid": "921a03be-662a-4aea-b8fc-a87d199b1528",
+        "concepts": [
+          "keyword-lists"
+        ],
+        "prerequisites": [
+          "lists",
+          "tuples",
+          "atoms",
+          "if",
+          "default-arguments"
+        ],
+        "status": "beta"
+      },
+      {
+        "slug": "dna-encoding",
+        "name": "DNA Encoding",
+        "uuid": "994c8760-8a58-4ef3-8a28-a0f9182f4d9f",
+        "concepts": [
+          "bitstrings",
+          "tail-call-recursion"
+        ],
+        "prerequisites": [
+          "charlists",
+          "recursion",
+          "pattern-matching"
+        ],
+        "status": "beta"
+      },
+      {
         "slug": "basketball-website",
         "name": "Basketball Website",
         "uuid": "ba03df1d-20e4-4527-a8a7-afc97a834975",
@@ -298,21 +329,6 @@
           "pattern-matching",
           "if",
           "bitstrings"
-        ],
-        "status": "beta"
-      },
-      {
-        "slug": "dna-encoding",
-        "name": "DNA Encoding",
-        "uuid": "994c8760-8a58-4ef3-8a28-a0f9182f4d9f",
-        "concepts": [
-          "bitstrings",
-          "tail-call-recursion"
-        ],
-        "prerequisites": [
-          "charlists",
-          "recursion",
-          "pattern-matching"
         ],
         "status": "beta"
       },
@@ -376,22 +392,6 @@
         "prerequisites": [
           "access-behaviour",
           "errors"
-        ],
-        "status": "beta"
-      },
-      {
-        "slug": "wine-cellar",
-        "name": "Wine Cellar",
-        "uuid": "921a03be-662a-4aea-b8fc-a87d199b1528",
-        "concepts": [
-          "keyword-lists"
-        ],
-        "prerequisites": [
-          "lists",
-          "tuples",
-          "atoms",
-          "if",
-          "default-arguments"
         ],
         "status": "beta"
       },

--- a/config.json
+++ b/config.json
@@ -228,6 +228,20 @@
         "status": "beta"
       },
       {
+        "slug": "rpg-character-sheet",
+        "name": "RPG Character Sheet",
+        "uuid": "83c31f5f-fc94-4315-9053-df5a5f5d5fb7",
+        "concepts": [
+          "io"
+        ],
+        "prerequisites": [
+          "strings",
+          "maps",
+          "atoms"
+        ],
+        "status": "beta"
+      },
+      {
         "slug": "name-badge",
         "name": "Name Badge",
         "uuid": "b6ae6cb4-f908-436f-916c-fa847e4a82fb",
@@ -238,6 +252,22 @@
         "prerequisites": [
           "strings",
           "booleans"
+        ],
+        "status": "beta"
+      },
+      {
+        "slug": "take-a-number",
+        "name": "Take-A-Number",
+        "uuid": "bec0b00f-816e-443a-af94-14ab4125e505",
+        "concepts": [
+          "processes",
+          "pids"
+        ],
+        "prerequisites": [
+          "atoms",
+          "recursion",
+          "pattern-matching",
+          "tuples"
         ],
         "status": "beta"
       },
@@ -380,22 +410,6 @@
         "status": "wip"
       },
       {
-        "slug": "take-a-number",
-        "name": "Take-A-Number",
-        "uuid": "bec0b00f-816e-443a-af94-14ab4125e505",
-        "concepts": [
-          "processes",
-          "pids"
-        ],
-        "prerequisites": [
-          "atoms",
-          "recursion",
-          "pattern-matching",
-          "tuples"
-        ],
-        "status": "beta"
-      },
-      {
         "slug": "mensch-aergere-dich-nicht",
         "name": "Mensch Ärgere Dich Nicht",
         "uuid": "3e2f8bc6-20b4-4e8f-a658-9c270342208e",
@@ -443,20 +457,6 @@
         "prerequisites": [
           "structs",
           "nil"
-        ],
-        "status": "beta"
-      },
-      {
-        "slug": "rpg-character-sheet",
-        "name": "RPG Character Sheet",
-        "uuid": "83c31f5f-fc94-4315-9053-df5a5f5d5fb7",
-        "concepts": [
-          "io"
-        ],
-        "prerequisites": [
-          "strings",
-          "maps",
-          "atoms"
         ],
         "status": "beta"
       },

--- a/config.json
+++ b/config.json
@@ -415,48 +415,6 @@
         "status": "beta"
       },
       {
-        "slug": "rpn-calculator",
-        "name": "RPN Calculator",
-        "uuid": "f660a2e1-bb50-4626-8d3f-6cd7c44fa8db",
-        "concepts": [
-          "errors",
-          "try-rescue"
-        ],
-        "prerequisites": [
-          "anonymous-functions",
-          "pattern-matching",
-          "structs"
-        ],
-        "status": "beta"
-      },
-      {
-        "slug": "stack-underflow",
-        "name": "Stack Underflow",
-        "uuid": "9f698b46-fe8d-4641-a928-bcebfd9678df",
-        "concepts": [
-          "exceptions"
-        ],
-        "prerequisites": [
-          "access-behaviour",
-          "errors"
-        ],
-        "status": "beta"
-      },
-      {
-        "slug": "rpn-calculator-output",
-        "name": "RPN Calculator Output",
-        "uuid": "68a8f721-5db4-4b31-95c8-fa6c38f64327",
-        "concepts": [
-          "try-rescue-else-after",
-          "dynamic-dispatch"
-        ],
-        "prerequisites": [
-          "file",
-          "try-rescue"
-        ],
-        "status": "wip"
-      },
-      {
         "slug": "mensch-aergere-dich-nicht",
         "name": "Mensch Ärgere Dich Nicht",
         "uuid": "3e2f8bc6-20b4-4e8f-a658-9c270342208e",
@@ -526,6 +484,66 @@
         "status": "beta"
       },
       {
+        "slug": "need-for-speed",
+        "name": "Need For Speed",
+        "uuid": "ed189325-7c73-49c7-8572-3dfc0b18b983",
+        "concepts": [
+          "alias",
+          "import"
+        ],
+        "prerequisites": [
+          "strings",
+          "tuples",
+          "keyword-lists",
+          "enum",
+          "structs",
+          "io"
+        ],
+        "status": "beta"
+      },
+      {
+        "slug": "rpn-calculator",
+        "name": "RPN Calculator",
+        "uuid": "f660a2e1-bb50-4626-8d3f-6cd7c44fa8db",
+        "concepts": [
+          "errors",
+          "try-rescue"
+        ],
+        "prerequisites": [
+          "anonymous-functions",
+          "pattern-matching",
+          "structs"
+        ],
+        "status": "beta"
+      },
+      {
+        "slug": "stack-underflow",
+        "name": "Stack Underflow",
+        "uuid": "9f698b46-fe8d-4641-a928-bcebfd9678df",
+        "concepts": [
+          "exceptions"
+        ],
+        "prerequisites": [
+          "access-behaviour",
+          "errors"
+        ],
+        "status": "beta"
+      },
+      {
+        "slug": "rpn-calculator-output",
+        "name": "RPN Calculator Output",
+        "uuid": "68a8f721-5db4-4b31-95c8-fa6c38f64327",
+        "concepts": [
+          "try-rescue-else-after",
+          "dynamic-dispatch"
+        ],
+        "prerequisites": [
+          "file",
+          "try-rescue"
+        ],
+        "status": "wip"
+      },
+      {
         "slug": "rpn-calculator-inspection",
         "name": "RPN Calculator Inspection",
         "uuid": "d99155cd-e03e-48a9-b1f0-ea8d2070a2fb",
@@ -556,24 +574,6 @@
           "lists",
           "anonymous-functions",
           "errors"
-        ],
-        "status": "beta"
-      },
-      {
-        "slug": "need-for-speed",
-        "name": "Need For Speed",
-        "uuid": "ed189325-7c73-49c7-8572-3dfc0b18b983",
-        "concepts": [
-          "alias",
-          "import"
-        ],
-        "prerequisites": [
-          "strings",
-          "tuples",
-          "keyword-lists",
-          "enum",
-          "structs",
-          "io"
         ],
         "status": "beta"
       }

--- a/config.json
+++ b/config.json
@@ -465,20 +465,6 @@
         "status": "deprecated"
       },
       {
-        "slug": "community-garden",
-        "name": "Community Garden",
-        "uuid": "1d6be9ec-5b5c-4c81-9bfa-2e3fc78c978f",
-        "concepts": [
-          "agent"
-        ],
-        "prerequisites": [
-          "processes",
-          "maps",
-          "structs"
-        ],
-        "status": "beta"
-      },
-      {
         "slug": "boutique-suggestions",
         "name": "Boutique Suggestions",
         "uuid": "f8208858-901e-4e5a-9f34-689bf8ad156c",
@@ -491,6 +477,20 @@
           "maps",
           "keyword-lists",
           "tuples"
+        ],
+        "status": "beta"
+      },
+      {
+        "slug": "community-garden",
+        "name": "Community Garden",
+        "uuid": "1d6be9ec-5b5c-4c81-9bfa-2e3fc78c978f",
+        "concepts": [
+          "agent"
+        ],
+        "prerequisites": [
+          "processes",
+          "maps",
+          "structs"
         ],
         "status": "beta"
       },

--- a/config.json
+++ b/config.json
@@ -397,21 +397,6 @@
         "status": "beta"
       },
       {
-        "slug": "rpn-calculator",
-        "name": "RPN Calculator",
-        "uuid": "f660a2e1-bb50-4626-8d3f-6cd7c44fa8db",
-        "concepts": [
-          "errors",
-          "try-rescue"
-        ],
-        "prerequisites": [
-          "anonymous-functions",
-          "pattern-matching",
-          "structs"
-        ],
-        "status": "beta"
-      },
-      {
         "slug": "remote-control-car",
         "name": "Remote Control Car",
         "uuid": "d8d25b93-d918-421e-bb57-cbdaf428d9e2",
@@ -426,6 +411,21 @@
           "nil",
           "default-arguments",
           "keyword-lists"
+        ],
+        "status": "beta"
+      },
+      {
+        "slug": "rpn-calculator",
+        "name": "RPN Calculator",
+        "uuid": "f660a2e1-bb50-4626-8d3f-6cd7c44fa8db",
+        "concepts": [
+          "errors",
+          "try-rescue"
+        ],
+        "prerequisites": [
+          "anonymous-functions",
+          "pattern-matching",
+          "structs"
         ],
         "status": "beta"
       },


### PR DESCRIPTION
The order of concept exercises in the config is important as it's used on the website a lot.

I think it makes most sense to order them roughly in the same order as you would see their concepts in the concept tree. That should correspond to "easiest to most difficult" of practice exercises.

I did the reordering manually by looking at the concept tree. Github won't be very useful in displaying the diff...

Here's the new order

```
[
  'lasagna',
  'secrets',
  'pacman-rules',
  'freelancer-rates',
  'log-level',
  'language-list',
  'guessing-game',
  'kitchen-calculator',
  'high-school-sweetheart',
  'bird-count',
  'high-score',
  'city-office',
  'german-sysadmin',
  'date-parser',
  'rpg-character-sheet',
  'name-badge',
  'take-a-number',
  'wine-cellar',
  'dna-encoding',
  'library-fees',
  'basketball-website',
  'boutique-inventory',
  'file-sniffer',
  'newsletter',
  'chessboard',
  'remote-control-car',
  'boutique-suggestions',
  'community-garden',
  'bread-and-potions',
  'captains-log',
  'need-for-speed',
  'rpn-calculator',
  'stack-underflow',
  'rpn-calculator-output',
  'rpn-calculator-inspection',
  'lucas-numbers',
  'mensch-aergere-dich-nicht'
]
```

old order:
```
[
  'lasagna',
  'pacman-rules',
  'freelancer-rates',
  'log-level',
  'language-list',
  'guessing-game',
  'secrets',
  'kitchen-calculator',
  'high-school-sweetheart',
  'name-badge',
  'high-score',
  'bird-count',
  'german-sysadmin',
  'basketball-website',
  'file-sniffer',
  'dna-encoding',
  'boutique-inventory',
  'rpn-calculator',
  'remote-control-car',
  'stack-underflow',
  'wine-cellar',
  'rpn-calculator-output',
  'take-a-number',
  'mensch-aergere-dich-nicht',
  'community-garden',
  'date-parser',
  'boutique-suggestions',
  'bread-and-potions',
  'rpg-character-sheet',
  'captains-log',
  'chessboard',
  'newsletter',
  'library-fees',
  'rpn-calculator-inspection',
  'lucas-numbers',
  'city-office',
  'need-for-speed'
]
```
