### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/.meta/example.ex
+++ b/exercises/practice/hello-world/.meta/example.ex
@@ -1,8 +1,8 @@
 defmodule HelloWorld do
   @doc """
-  Greets the user by name, or by saying "Hello, World!"
-  if no name is given
+  Simply returns "Hello, World!"
   """
+  @spec hello :: String.t()
   def hello do
     "Hello, World!"
   end

--- a/exercises/practice/hello-world/lib/hello_world.ex
+++ b/exercises/practice/hello-world/lib/hello_world.ex
@@ -2,6 +2,7 @@ defmodule HelloWorld do
   @doc """
   Simply returns "Hello, World!"
   """
+  @spec hello :: String.t()
   def hello do
     "Goodbye, Mars!"
   end

--- a/exercises/practice/hello-world/lib/hello_world.ex
+++ b/exercises/practice/hello-world/lib/hello_world.ex
@@ -2,8 +2,7 @@ defmodule HelloWorld do
   @doc """
   Simply returns "Hello, World!"
   """
-  @spec hello :: String.t()
   def hello do
-    "Your implementation goes here"
+    "Goodbye, Mars!"
   end
 end


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46
