### PR TITLE
Reorder practice exercises

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,3 +1,3 @@
 [
-  inputs: ["mix.exs", "{exercises}/**/*.{ex,exs}"]
+  inputs: ["mix.exs", "{exercises,bin}/**/*.{ex,exs}"]
 ]

--- a/bin/check_concepts.exs
+++ b/bin/check_concepts.exs
@@ -2,10 +2,12 @@ Mix.install([
   {:jason, "~> 1.2"}
 ])
 
-{opts, _} = OptionParser.parse!(
-  System.argv(),
-  [strict: [verbose: :boolean, no_warn: :boolean], aliases: [v: :verbose]]
-)
+{opts, _} =
+  OptionParser.parse!(
+    System.argv(),
+    strict: [verbose: :boolean, no_warn: :boolean],
+    aliases: [v: :verbose]
+  )
 
 concept_practices_exercise_limit = 10
 
@@ -19,91 +21,89 @@ concept_slugs =
   |> Enum.map(& &1["slug"])
   |> Enum.sort()
 
-print_exercises =
-  fn exercises ->
-    exercises =
-      exercises
-      |> Enum.map(& &1["slug"])
-      |> Enum.sort()
-      |> Enum.join(", ")
+print_exercises = fn exercises ->
+  exercises =
+    exercises
+    |> Enum.map(& &1["slug"])
+    |> Enum.sort()
+    |> Enum.join(", ")
 
-    IO.write("[#{exercises}]")
-  end
+  IO.write("[#{exercises}]")
+end
 
-analyze_concept =
-  fn concept_slug ->
-    {practiced_by, required_by} =
-      config["exercises"]["practice"]
-      |> Enum.reduce({[], []}, fn exercise, {practiced_by_acc, required_by_acc} ->
-        practiced_by_acc =
-          if concept_slug in exercise["practices"] do
-            [exercise | practiced_by_acc]
-          else
-            practiced_by_acc
-          end
+analyze_concept = fn concept_slug ->
+  {practiced_by, required_by} =
+    config["exercises"]["practice"]
+    |> Enum.reduce({[], []}, fn exercise, {practiced_by_acc, required_by_acc} ->
+      practiced_by_acc =
+        if concept_slug in exercise["practices"] do
+          [exercise | practiced_by_acc]
+        else
+          practiced_by_acc
+        end
 
-        required_by_acc =
-          if concept_slug in exercise["prerequisites"] do
-            [exercise | required_by_acc]
-          else
-            required_by_acc
-          end
+      required_by_acc =
+        if concept_slug in exercise["prerequisites"] do
+          [exercise | required_by_acc]
+        else
+          required_by_acc
+        end
 
-        {practiced_by_acc, required_by_acc}
-      end)
+      {practiced_by_acc, required_by_acc}
+    end)
 
-    not_practiced = practiced_by == []
-    not_required = required_by == []
-    practiced_too_often = Enum.count(practiced_by) > concept_practices_exercise_limit
+  not_practiced = practiced_by == []
+  not_required = required_by == []
+  practiced_too_often = Enum.count(practiced_by) > concept_practices_exercise_limit
 
-    status =
-      cond do
-        practiced_too_often -> :error
-        not_required || not_practiced -> :warn
-        true -> :ok
+  status =
+    cond do
+      practiced_too_often -> :error
+      not_required || not_practiced -> :warn
+      true -> :ok
+    end
+
+  IO.write(concept_slug <> " ")
+
+  cond do
+    status == :error ->
+      IO.write("#{IO.ANSI.red()}⨯#{IO.ANSI.reset()}\n")
+
+      if practiced_too_often do
+        IO.write("  Too many exercises practice this concept.\n")
       end
 
-    IO.write(concept_slug <> " ")
+    status == :warn && !opts[:no_warn] ->
+      IO.write("#{IO.ANSI.yellow()}●#{IO.ANSI.reset()}\n")
 
-    cond do
-      status == :error ->
-        IO.write("#{IO.ANSI.red()}⨯#{IO.ANSI.reset()}\n")
+      if not_practiced do
+        IO.write("  This concept is not practiced by any exercise.\n")
+      end
 
-        if practiced_too_often do
-          IO.write("  Too many exercises practice this concept.\n")
-        end
+      if not_required do
+        IO.write("  This concept is not required by any exercise.\n")
+      end
 
-      status == :warn && !opts[:no_warn] ->
-        IO.write("#{IO.ANSI.yellow()}●#{IO.ANSI.reset()}\n")
-
-        if not_practiced do
-          IO.write("  This concept is not practiced by any exercise.\n")
-        end
-
-        if not_required do
-          IO.write("  This concept is not required by any exercise.\n")
-        end
-
-      status == :ok || (status == :warn && opts[:no_warn]) ->
-        IO.write("#{IO.ANSI.green()}✔#{IO.ANSI.reset()}\n")
-    end
-
-    if practiced_too_often || opts[:verbose] do
-      IO.write("  Practiced by (#{Enum.count(practiced_by)}): ")
-      print_exercises.(practiced_by)
-      IO.write("\n")
-    end
-
-    if opts[:verbose] do
-      IO.write("  Required by (#{Enum.count(required_by)}): ")
-      print_exercises.(required_by)
-      IO.write("\n")
-    end
-
-    IO.write("\n")
-
-    status
+    status == :ok || (status == :warn && opts[:no_warn]) ->
+      IO.write("#{IO.ANSI.green()}✔#{IO.ANSI.reset()}\n")
   end
+
+  if practiced_too_often || opts[:verbose] do
+    IO.write("  Practiced by (#{Enum.count(practiced_by)}): ")
+    print_exercises.(practiced_by)
+    IO.write("\n")
+  end
+
+  if opts[:verbose] do
+    IO.write("  Required by (#{Enum.count(required_by)}): ")
+    print_exercises.(required_by)
+    IO.write("\n")
+  end
+
+  IO.write("\n")
+
+  status
+end
 
 {errors, warnings} =
   Enum.reduce(concept_slugs, {[], []}, fn concept_slug, {errors, warnings} ->
@@ -121,7 +121,9 @@ analyze_concept =
     end
   end)
 
-IO.write("\nFinished concept check: #{IO.ANSI.red()}#{Enum.count(errors)} errors#{IO.ANSI.reset()} and #{IO.ANSI.yellow()}#{Enum.count(warnings)} warnings#{IO.ANSI.reset()}\n")
+IO.write(
+  "\nFinished concept check: #{IO.ANSI.red()}#{Enum.count(errors)} errors#{IO.ANSI.reset()} and #{IO.ANSI.yellow()}#{Enum.count(warnings)} warnings#{IO.ANSI.reset()}\n"
+)
 
 if errors != [] do
   exit(1)

--- a/bin/check_practice_exercise_order.exs
+++ b/bin/check_practice_exercise_order.exs
@@ -9,13 +9,15 @@ Mix.install([
     aliases: [w: :write]
   )
 
+max_custom_order = 999
+
 config =
   "./config.json"
   |> File.read!()
   |> Jason.decode!()
 
 sort_by = fn exercise ->
-  {exercise["difficulty"], exercise["name"]}
+  {exercise["difficulty"], exercise["order"] || max_custom_order, exercise["slug"]}
 end
 
 reordered_config =
@@ -36,13 +38,31 @@ actual_exercise_order =
   |> Enum.map(& &1["slug"])
 
 if opts[:write] do
+  # set order to a value if missing because otherwise it's null and null comes before 1
+  {file_with_order_field, 0} =
+    System.cmd("jq", [
+      ".exercises.practice[] |= if .order==null then . + {order: #{max_custom_order + 1}} else . + {order: .order} end",
+      "config.json"
+    ])
+
+  File.write!("config.json", file_with_order_field)
+
+  # reorder exercises based on difficulty, custom order overwrites, and slug
   {reordered_file, 0} =
-    System.cmd("jq", [".exercises.practice|=sort_by(.difficulty, .name)", "config.json"])
+    System.cmd("jq", [".exercises.practice |= sort_by(.difficulty, .order, .slug)", "config.json"])
 
   File.write!("config.json", reordered_file)
+
+  # remove fields added in the first step
+  {reordered_without_order_field_file, 0} =
+    System.cmd("jq", [
+      ".exercises.practice[] |= if .order > #{max_custom_order} then del(.order) else . end",
+      "config.json"
+    ])
+
+  File.write!("config.json", reordered_without_order_field_file)
 else
-  if desired_exercise_order === actual_exercise_order &&
-       Enum.at(desired_exercise_order, 0) == "hello-world" do
+  if desired_exercise_order === actual_exercise_order do
     IO.write("Practice exercises are ordered #{IO.ANSI.green()}✔#{IO.ANSI.reset()}\n")
   else
     IO.write("Practice exercises are not ordered #{IO.ANSI.red()}⨯#{IO.ANSI.reset()}\n")

--- a/bin/check_practice_exercise_order.exs
+++ b/bin/check_practice_exercise_order.exs
@@ -43,5 +43,6 @@ else
   else
     IO.write("Practice exercises are not ordered #{IO.ANSI.red()}⨯#{IO.ANSI.reset()}\n")
     IO.write("Rerun this script with --write to fix that.\n")
+    exit(1)
   end
 end

--- a/bin/check_practice_exercise_order.exs
+++ b/bin/check_practice_exercise_order.exs
@@ -41,7 +41,8 @@ if opts[:write] do
 
   File.write!("config.json", reordered_file)
 else
-  if desired_exercise_order === actual_exercise_order do
+  if desired_exercise_order === actual_exercise_order &&
+       Enum.at(desired_exercise_order, 0) == "hello-world" do
     IO.write("Practice exercises are ordered #{IO.ANSI.green()}✔#{IO.ANSI.reset()}\n")
   else
     IO.write("Practice exercises are not ordered #{IO.ANSI.red()}⨯#{IO.ANSI.reset()}\n")

--- a/bin/check_practice_exercise_order.exs
+++ b/bin/check_practice_exercise_order.exs
@@ -2,23 +2,26 @@ Mix.install([
   {:jason, "~> 1.2"}
 ])
 
-{opts, _} = OptionParser.parse!(
-  System.argv(),
-  [strict: [write: :boolean], aliases: [w: :write]]
-)
+{opts, _} =
+  OptionParser.parse!(
+    System.argv(),
+    strict: [write: :boolean],
+    aliases: [w: :write]
+  )
 
 config =
   "./config.json"
   |> File.read!()
   |> Jason.decode!()
 
-sort_by =
-  fn exercise ->
-    {exercise["difficulty"], exercise["name"]}
-  end
+sort_by = fn exercise ->
+  {exercise["difficulty"], exercise["name"]}
+end
 
 reordered_config =
-  put_in(config, ["exercises", "practice"],
+  put_in(
+    config,
+    ["exercises", "practice"],
     Enum.sort_by(config["exercises"]["practice"], sort_by)
   )
 

--- a/bin/check_practice_exercise_order.exs
+++ b/bin/check_practice_exercise_order.exs
@@ -36,7 +36,10 @@ actual_exercise_order =
   |> Enum.map(& &1["slug"])
 
 if opts[:write] do
-  # TODO
+  {reordered_file, 0} =
+    System.cmd("jq", [".exercises.practice|=sort_by(.difficulty, .name)", "config.json"])
+
+  File.write!("config.json", reordered_file)
 else
   if desired_exercise_order === actual_exercise_order do
     IO.write("Practice exercises are ordered #{IO.ANSI.green()}✔#{IO.ANSI.reset()}\n")

--- a/bin/check_practice_exercise_order.exs
+++ b/bin/check_practice_exercise_order.exs
@@ -1,0 +1,44 @@
+Mix.install([
+  {:jason, "~> 1.2"}
+])
+
+{opts, _} = OptionParser.parse!(
+  System.argv(),
+  [strict: [write: :boolean], aliases: [w: :write]]
+)
+
+config =
+  "./config.json"
+  |> File.read!()
+  |> Jason.decode!()
+
+sort_by =
+  fn exercise ->
+    {exercise["difficulty"], exercise["name"]}
+  end
+
+reordered_config =
+  put_in(config, ["exercises", "practice"],
+    Enum.sort_by(config["exercises"]["practice"], sort_by)
+  )
+
+desired_exercise_order =
+  reordered_config
+  |> get_in(["exercises", "practice"])
+  |> Enum.map(& &1["slug"])
+
+actual_exercise_order =
+  config
+  |> get_in(["exercises", "practice"])
+  |> Enum.map(& &1["slug"])
+
+if opts[:write] do
+  # TODO
+else
+  if desired_exercise_order === actual_exercise_order do
+    IO.write("Practice exercises are ordered #{IO.ANSI.green()}✔#{IO.ANSI.reset()}\n")
+  else
+    IO.write("Practice exercises are not ordered #{IO.ANSI.red()}⨯#{IO.ANSI.reset()}\n")
+    IO.write("Rerun this script with --write to fix that.\n")
+  end
+end

--- a/bin/pr-check.sh
+++ b/bin/pr-check.sh
@@ -19,7 +19,7 @@ echo "Running check_concepts.exs"
 CONCEPTS_EXIT_CODE="$?"
 
 echo "Running check_practice_exercise_order.exs"
-(elixir bin/check_practice_exercise_order.exs --no-warn)
+(elixir bin/check_practice_exercise_order.exs)
 PRACTICE_ORDER_EXIT_CODE="$?"
 
 if [ "$CHECK_FORMAT_EXIT_CODE" -ne 0 -o "$DIALYZER_EXIT_CODE" -ne 0 -o "$CONCEPTS_EXIT_CODE" -ne 0 -o "$PRACTICE_ORDER_EXIT_CODE" -ne 0 ]

--- a/bin/pr-check.sh
+++ b/bin/pr-check.sh
@@ -18,7 +18,11 @@ echo "Running check_concepts.exs"
 (elixir bin/check_concepts.exs --no-warn)
 CONCEPTS_EXIT_CODE="$?"
 
-if [ "$CHECK_FORMAT_EXIT_CODE" -ne 0 -o "$DIALYZER_EXIT_CODE" -ne 0 -o "$CONCEPTS_EXIT_CODE" -ne 0 ]
+echo "Running check_practice_exercise_order.exs"
+(elixir bin/check_practice_exercise_order.exs --no-warn)
+PRACTICE_ORDER_EXIT_CODE="$?"
+
+if [ "$CHECK_FORMAT_EXIT_CODE" -ne 0 -o "$DIALYZER_EXIT_CODE" -ne 0 -o "$CONCEPTS_EXIT_CODE" -ne 0 -o "$PRACTICE_ORDER_EXIT_CODE" -ne 0 ]
 then
   echo "Precheck failed"
   exit 1;

--- a/config.json
+++ b/config.json
@@ -2059,7 +2059,7 @@
         "practices": [
           "regular-expressions"
         ],
-        "difficulty": 5
+        "difficulty": 6
       },
       {
         "slug": "palindrome-products",

--- a/config.json
+++ b/config.json
@@ -603,24 +603,6 @@
         "difficulty": 1
       },
       {
-        "slug": "simple-linked-list",
-        "name": "Simple Linked List",
-        "uuid": "e5d2386a-3021-4329-a4b7-6164e49df776",
-        "prerequisites": [
-          "atoms",
-          "tuples",
-          "pattern-matching",
-          "recursion",
-          "tail-call-recursion"
-        ],
-        "practices": [
-          "atoms",
-          "tuples",
-          "tail-call-recursion"
-        ],
-        "difficulty": 4
-      },
-      {
         "slug": "two-fer",
         "name": "Two Fer",
         "uuid": "6a130540-1b84-4147-8e6f-776dbf750489",
@@ -1880,6 +1862,24 @@
         "difficulty": 4
       },
       {
+        "slug": "simple-linked-list",
+        "name": "Simple Linked List",
+        "uuid": "e5d2386a-3021-4329-a4b7-6164e49df776",
+        "prerequisites": [
+          "atoms",
+          "tuples",
+          "pattern-matching",
+          "recursion",
+          "tail-call-recursion"
+        ],
+        "practices": [
+          "atoms",
+          "tuples",
+          "tail-call-recursion"
+        ],
+        "difficulty": 4
+      },
+      {
         "slug": "spiral-matrix",
         "name": "Spiral Matrix",
         "uuid": "cf28d2b2-763e-404b-90b0-637263d3bba6",
@@ -1940,6 +1940,24 @@
         "practices": [
           "pipe-operator",
           "strings"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "bank-account",
+        "name": "Bank Account",
+        "uuid": "5d5e0f6c-f4b7-418e-88f8-4b1d0f99bfb0",
+        "prerequisites": [
+          "if",
+          "processes",
+          "pids",
+          "agent"
+        ],
+        "practices": [
+          "if",
+          "processes",
+          "pids",
+          "agent"
         ],
         "difficulty": 5
       },
@@ -2040,26 +2058,6 @@
           "integers"
         ],
         "difficulty": 5
-      },
-      {
-        "slug": "markdown",
-        "name": "Markdown",
-        "uuid": "5dfa24bf-e77c-47c6-88e1-e50cbeecd159",
-        "prerequisites": [
-          "strings",
-          "enum",
-          "recursion",
-          "regular-expressions",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "cond",
-          "case",
-          "if"
-        ],
-        "practices": [
-          "regular-expressions"
-        ],
-        "difficulty": 6
       },
       {
         "slug": "palindrome-products",
@@ -2239,6 +2237,26 @@
         "difficulty": 6
       },
       {
+        "slug": "markdown",
+        "name": "Markdown",
+        "uuid": "5dfa24bf-e77c-47c6-88e1-e50cbeecd159",
+        "prerequisites": [
+          "strings",
+          "enum",
+          "recursion",
+          "regular-expressions",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "cond",
+          "case",
+          "if"
+        ],
+        "practices": [
+          "regular-expressions"
+        ],
+        "difficulty": 6
+      },
+      {
         "slug": "ocr-numbers",
         "name": "OCR Numbers",
         "uuid": "3f321191-afb1-4aa1-995b-204aa460269e",
@@ -2368,24 +2386,6 @@
           "pattern-matching"
         ],
         "difficulty": 7
-      },
-      {
-        "slug": "bank-account",
-        "name": "Bank Account",
-        "uuid": "5d5e0f6c-f4b7-418e-88f8-4b1d0f99bfb0",
-        "prerequisites": [
-          "if",
-          "processes",
-          "pids",
-          "agent"
-        ],
-        "practices": [
-          "if",
-          "processes",
-          "pids",
-          "agent"
-        ],
-        "difficulty": 5
       },
       {
         "slug": "change",

--- a/config.json
+++ b/config.json
@@ -618,7 +618,7 @@
           "tuples",
           "tail-call-recursion"
         ],
-        "difficulty": 1
+        "difficulty": 4
       },
       {
         "slug": "two-fer",

--- a/config.json
+++ b/config.json
@@ -585,7 +585,8 @@
         "uuid": "cc96d65d-1c79-40d0-8fd2-9a6665a43b01",
         "prerequisites": [],
         "practices": [],
-        "difficulty": 1
+        "difficulty": 1,
+        "order": 999
       },
       {
         "slug": "resistor-color",
@@ -880,22 +881,6 @@
         "difficulty": 2
       },
       {
-        "slug": "rna-transcription",
-        "name": "RNA Transcription",
-        "uuid": "a4629a60-752f-4234-99f1-6b3ac0b4ba18",
-        "prerequisites": [
-          "charlists",
-          "pattern-matching",
-          "multiple-clause-functions",
-          "case",
-          "enum"
-        ],
-        "practices": [
-          "charlists"
-        ],
-        "difficulty": 2
-      },
-      {
         "slug": "raindrops",
         "name": "Raindrops",
         "uuid": "4522b139-6f0c-4172-a4fa-6a6adef33a9e",
@@ -926,6 +911,22 @@
         "practices": [
           "atoms",
           "maps"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "rna-transcription",
+        "name": "RNA Transcription",
+        "uuid": "a4629a60-752f-4234-99f1-6b3ac0b4ba18",
+        "prerequisites": [
+          "charlists",
+          "pattern-matching",
+          "multiple-clause-functions",
+          "case",
+          "enum"
+        ],
+        "practices": [
+          "charlists"
         ],
         "difficulty": 2
       },

--- a/config.json
+++ b/config.json
@@ -2385,7 +2385,7 @@
           "pids",
           "agent"
         ],
-        "difficulty": 7
+        "difficulty": 5
       },
       {
         "slug": "change",

--- a/config.json
+++ b/config.json
@@ -16,7 +16,7 @@
     "highlightjs_language": "elixir"
   },
   "test_runner": {
-    "average_run_time": 4
+    "average_run_time": 4.1
   },
   "files": {
     "solution": [

--- a/config.json
+++ b/config.json
@@ -586,7 +586,7 @@
         "prerequisites": [],
         "practices": [],
         "difficulty": 1,
-        "order": 999
+        "order": 1
       },
       {
         "slug": "resistor-color",

--- a/config.json
+++ b/config.json
@@ -16,7 +16,7 @@
     "highlightjs_language": "elixir"
   },
   "test_runner": {
-    "average_run_time": 4.0
+    "average_run_time": 4
   },
   "files": {
     "solution": [
@@ -588,241 +588,6 @@
         "difficulty": 1
       },
       {
-        "slug": "rna-transcription",
-        "name": "RNA Transcription",
-        "uuid": "a4629a60-752f-4234-99f1-6b3ac0b4ba18",
-        "prerequisites": [
-          "charlists",
-          "pattern-matching",
-          "multiple-clause-functions",
-          "case",
-          "enum"
-        ],
-        "practices": [
-          "charlists"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "word-count",
-        "name": "Word Count",
-        "uuid": "4a24ba2f-ae92-4095-be53-64bc881422ea",
-        "prerequisites": [
-          "strings",
-          "regular-expressions",
-          "enum",
-          "maps",
-          "pipe-operator"
-        ],
-        "practices": [
-          "regular-expressions",
-          "pipe-operator"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "roman-numerals",
-        "name": "Roman Numerals",
-        "uuid": "4c0ece49-5710-43a1-88b3-2fb149de8552",
-        "prerequisites": [
-          "strings",
-          "recursion",
-          "guards",
-          "default-arguments",
-          "multiple-clause-functions",
-          "enum",
-          "maps",
-          "cond",
-          "case"
-        ],
-        "practices": [
-          "recursion"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "bob",
-        "name": "Bob",
-        "uuid": "d20b49dc-cb6d-45fc-a168-78d002072c75",
-        "prerequisites": [
-          "booleans",
-          "strings",
-          "regular-expressions",
-          "cond"
-        ],
-        "practices": [
-          "booleans",
-          "cond"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "beer-song",
-        "name": "Beer Song",
-        "uuid": "24db624b-7c80-409d-97d5-e1177f025c67",
-        "prerequisites": [
-          "strings",
-          "multiple-clause-functions",
-          "default-arguments",
-          "ranges",
-          "enum",
-          "recursion"
-        ],
-        "practices": [
-          "multiple-clause-functions",
-          "default-arguments"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "robot-simulator",
-        "name": "Robot Simulator",
-        "uuid": "e5e55560-852f-4551-b4da-c9f4a3141470",
-        "prerequisites": [
-          "atoms",
-          "multiple-clause-functions",
-          "guards",
-          "pattern-matching",
-          "case",
-          "strings",
-          "enum",
-          "structs",
-          "default-arguments"
-        ],
-        "practices": [
-          "structs",
-          "multiple-clause-functions"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "list-ops",
-        "name": "List Ops",
-        "uuid": "86658a31-d401-401b-80df-2c4df35f9b15",
-        "prerequisites": [
-          "lists",
-          "recursion",
-          "tail-call-recursion",
-          "multiple-clause-functions",
-          "pattern-matching"
-        ],
-        "practices": [
-          "lists",
-          "tail-call-recursion"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "markdown",
-        "name": "Markdown",
-        "uuid": "5dfa24bf-e77c-47c6-88e1-e50cbeecd159",
-        "prerequisites": [
-          "strings",
-          "enum",
-          "recursion",
-          "regular-expressions",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "cond",
-          "case",
-          "if"
-        ],
-        "practices": [
-          "regular-expressions"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "bank-account",
-        "name": "Bank Account",
-        "uuid": "5d5e0f6c-f4b7-418e-88f8-4b1d0f99bfb0",
-        "prerequisites": [
-          "if",
-          "processes",
-          "pids",
-          "agent"
-        ],
-        "practices": [
-          "if",
-          "processes",
-          "pids",
-          "agent"
-        ],
-        "difficulty": 7
-      },
-      {
-        "slug": "zipper",
-        "name": "Zipper",
-        "uuid": "bc315734-051c-4735-9a8a-3aacb094d2ca",
-        "prerequisites": [
-          "recursion",
-          "structs",
-          "protocols",
-          "if",
-          "nil",
-          "case",
-          "pattern-matching",
-          "multiple-clause-functions"
-        ],
-        "practices": [
-          "structs"
-        ],
-        "difficulty": 8
-      },
-      {
-        "slug": "bowling",
-        "name": "Bowling",
-        "uuid": "3b252cc6-cc55-4187-891e-c10aaabac81f",
-        "prerequisites": [
-          "pattern-matching",
-          "multiple-clause-functions",
-          "guards",
-          "lists",
-          "enum",
-          "recursion",
-          "cond",
-          "if",
-          "case",
-          "structs"
-        ],
-        "practices": [
-          "pattern-matching",
-          "guards",
-          "structs",
-          "multiple-clause-functions"
-        ],
-        "difficulty": 8
-      },
-      {
-        "slug": "forth",
-        "name": "Forth",
-        "uuid": "2abfa3e5-d358-4a07-91f9-d4ad04eb719d",
-        "prerequisites": [
-          "pattern-matching",
-          "multiple-clause-functions",
-          "guards",
-          "strings",
-          "regular-expressions",
-          "maps",
-          "lists",
-          "enum",
-          "recursion",
-          "cond",
-          "if",
-          "case",
-          "structs",
-          "errors",
-          "exceptions",
-          "dynamic-dispatch"
-        ],
-        "practices": [
-          "regular-expressions",
-          "errors",
-          "exceptions"
-        ],
-        "difficulty": 10
-      },
-      {
         "slug": "resistor-color",
         "name": "Resistor Color",
         "uuid": "c1532449-bf9e-446a-8e8f-97a6c19608e5",
@@ -833,6 +598,24 @@
         "practices": [
           "atoms",
           "maps"
+        ],
+        "difficulty": 1
+      },
+      {
+        "slug": "simple-linked-list",
+        "name": "Simple Linked List",
+        "uuid": "e5d2386a-3021-4329-a4b7-6164e49df776",
+        "prerequisites": [
+          "atoms",
+          "tuples",
+          "pattern-matching",
+          "recursion",
+          "tail-call-recursion"
+        ],
+        "practices": [
+          "atoms",
+          "tuples",
+          "tail-call-recursion"
         ],
         "difficulty": 1
       },
@@ -852,6 +635,178 @@
         "difficulty": 1
       },
       {
+        "slug": "accumulate",
+        "name": "Accumulate",
+        "uuid": "e7c6a0d2-6aaf-4d55-99e2-8ffa65a5e8f0",
+        "prerequisites": [
+          "anonymous-functions",
+          "lists",
+          "recursion"
+        ],
+        "practices": [
+          "anonymous-functions",
+          "lists"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "acronym",
+        "name": "Acronym",
+        "uuid": "23989815-1b3f-4377-b6bf-ce9536432517",
+        "prerequisites": [
+          "strings",
+          "enum",
+          "regular-expressions",
+          "pipe-operator"
+        ],
+        "practices": [
+          "regular-expressions",
+          "pipe-operator"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "all-your-base",
+        "name": "All Your Base",
+        "uuid": "f71d5f38-fcc9-4044-ade9-f779a8686c69",
+        "prerequisites": [
+          "atoms",
+          "tuples",
+          "integers",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "cond",
+          "case",
+          "if",
+          "recursion",
+          "tail-call-recursion",
+          "enum"
+        ],
+        "practices": [
+          "integers",
+          "multiple-clause-functions"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "anagram",
+        "name": "Anagram",
+        "uuid": "21e70267-097e-476f-aaff-233483514802",
+        "prerequisites": [
+          "strings",
+          "enum"
+        ],
+        "practices": [
+          "strings",
+          "enum"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "armstrong-numbers",
+        "name": "Armstrong Numbers",
+        "uuid": "8f40f0f6-95e6-4a4c-a576-3d677ffbbd9f",
+        "prerequisites": [
+          "integers",
+          "lists",
+          "enum",
+          "erlang-libraries"
+        ],
+        "practices": [
+          "integers"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "collatz-conjecture",
+        "name": "Collatz Conjecture",
+        "uuid": "01f7ce73-ad6a-42bb-a401-cbd485c081d4",
+        "prerequisites": [
+          "integers",
+          "recursion",
+          "multiple-clause-functions",
+          "guards"
+        ],
+        "practices": [
+          "integers",
+          "guards"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "darts",
+        "name": "Darts",
+        "uuid": "a68113f8-92be-40e0-a97f-eb4239303ef5",
+        "prerequisites": [
+          "cond",
+          "integers",
+          "floating-point-numbers"
+        ],
+        "practices": [
+          "cond"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "etl",
+        "name": "ETL",
+        "uuid": "b3a4c561-344a-403e-b5b3-3533d51e65f4",
+        "prerequisites": [
+          "strings",
+          "maps",
+          "enum",
+          "list-comprehensions"
+        ],
+        "practices": [
+          "list-comprehensions"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "hamming",
+        "name": "Hamming",
+        "uuid": "aca03bcb-eb70-4646-be34-8c1a44026e9b",
+        "prerequisites": [
+          "atoms",
+          "tuples",
+          "charlists",
+          "multiple-clause-functions",
+          "guards",
+          "enum",
+          "recursion"
+        ],
+        "practices": [
+          "enum"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "nth-prime",
+        "name": "Nth Prime",
+        "uuid": "6d0c0785-3514-44fc-9b5a-0758989d1c6a",
+        "prerequisites": [
+          "integers",
+          "cond",
+          "case",
+          "if",
+          "enum",
+          "recursion",
+          "multiple-clause-functions",
+          "guards",
+          "ranges",
+          "streams",
+          "errors",
+          "exceptions"
+        ],
+        "practices": [
+          "integers",
+          "ranges",
+          "errors"
+        ],
+        "difficulty": 2
+      },
+      {
         "slug": "nucleotide-count",
         "name": "Nucleotide Count",
         "uuid": "7404e885-747a-46fc-be0c-c53f4b0e162f",
@@ -862,6 +817,23 @@
         ],
         "practices": [
           "charlists"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "pangram",
+        "name": "Pangram",
+        "uuid": "20a0bbf8-751c-477a-a2cb-dd7cf4e4896c",
+        "prerequisites": [
+          "strings",
+          "charlists",
+          "enum",
+          "recursion",
+          "ranges"
+        ],
+        "practices": [
+          "charlists",
+          "ranges"
         ],
         "difficulty": 2
       },
@@ -908,6 +880,76 @@
         "difficulty": 2
       },
       {
+        "slug": "rna-transcription",
+        "name": "RNA Transcription",
+        "uuid": "a4629a60-752f-4234-99f1-6b3ac0b4ba18",
+        "prerequisites": [
+          "charlists",
+          "pattern-matching",
+          "multiple-clause-functions",
+          "case",
+          "enum"
+        ],
+        "practices": [
+          "charlists"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "raindrops",
+        "name": "Raindrops",
+        "uuid": "4522b139-6f0c-4172-a4fa-6a6adef33a9e",
+        "prerequisites": [
+          "integers",
+          "multiple-clause-functions",
+          "guards",
+          "if",
+          "strings",
+          "maps",
+          "enum"
+        ],
+        "practices": [
+          "enum"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "resistor-color-duo",
+        "name": "Resistor Color Duo",
+        "uuid": "92387ac7-4c6d-4568-819e-e037b1d86a72",
+        "prerequisites": [
+          "atoms",
+          "lists",
+          "pattern-matching",
+          "maps"
+        ],
+        "practices": [
+          "atoms",
+          "maps"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "roman-numerals",
+        "name": "Roman Numerals",
+        "uuid": "4c0ece49-5710-43a1-88b3-2fb149de8552",
+        "prerequisites": [
+          "strings",
+          "recursion",
+          "guards",
+          "default-arguments",
+          "multiple-clause-functions",
+          "enum",
+          "maps",
+          "cond",
+          "case"
+        ],
+        "practices": [
+          "recursion"
+        ],
+        "difficulty": 2
+      },
+      {
         "slug": "rotational-cipher",
         "name": "Rotational Cipher",
         "uuid": "99b344ff-b74c-4af5-9952-7738b493ee7b",
@@ -929,6 +971,39 @@
         "difficulty": 2
       },
       {
+        "slug": "run-length-encoding",
+        "name": "Run Length Encoding",
+        "uuid": "f4f759ea-53e1-42d6-a580-6e7b7d6a99a0",
+        "prerequisites": [
+          "strings",
+          "regular-expressions",
+          "enum",
+          "if"
+        ],
+        "practices": [
+          "strings",
+          "regular-expressions"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "scrabble-score",
+        "name": "Scrabble Score",
+        "uuid": "cc198564-72e6-444b-93b6-6b7ecf4d1759",
+        "prerequisites": [
+          "strings",
+          "maps",
+          "enum",
+          "recursion",
+          "pipe-operator"
+        ],
+        "practices": [
+          "pipe-operator",
+          "maps"
+        ],
+        "difficulty": 2
+      },
+      {
         "slug": "secret-handshake",
         "name": "Secret Handshake",
         "uuid": "ea7da409-6bda-4cff-b26e-0909ba36f4f5",
@@ -944,6 +1019,22 @@
         ],
         "practices": [
           "bit-manipulation"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "series",
+        "name": "Series",
+        "uuid": "4a084cb7-335d-41f1-8148-5d3abbce8ab0",
+        "prerequisites": [
+          "multiple-clause-functions",
+          "guards",
+          "strings",
+          "enum",
+          "pipe-operator"
+        ],
+        "practices": [
+          "pipe-operator"
         ],
         "difficulty": 2
       },
@@ -987,216 +1078,6 @@
         "difficulty": 2
       },
       {
-        "slug": "accumulate",
-        "name": "Accumulate",
-        "uuid": "e7c6a0d2-6aaf-4d55-99e2-8ffa65a5e8f0",
-        "prerequisites": [
-          "anonymous-functions",
-          "lists",
-          "recursion"
-        ],
-        "practices": [
-          "anonymous-functions",
-          "lists"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "acronym",
-        "name": "Acronym",
-        "uuid": "23989815-1b3f-4377-b6bf-ce9536432517",
-        "prerequisites": [
-          "strings",
-          "enum",
-          "regular-expressions",
-          "pipe-operator"
-        ],
-        "practices": [
-          "regular-expressions",
-          "pipe-operator"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "raindrops",
-        "name": "Raindrops",
-        "uuid": "4522b139-6f0c-4172-a4fa-6a6adef33a9e",
-        "prerequisites": [
-          "integers",
-          "multiple-clause-functions",
-          "guards",
-          "if",
-          "strings",
-          "maps",
-          "enum"
-        ],
-        "practices": [
-          "enum"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "run-length-encoding",
-        "name": "Run Length Encoding",
-        "uuid": "f4f759ea-53e1-42d6-a580-6e7b7d6a99a0",
-        "prerequisites": [
-          "strings",
-          "regular-expressions",
-          "enum",
-          "if"
-        ],
-        "practices": [
-          "strings",
-          "regular-expressions"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "series",
-        "name": "Series",
-        "uuid": "4a084cb7-335d-41f1-8148-5d3abbce8ab0",
-        "prerequisites": [
-          "multiple-clause-functions",
-          "guards",
-          "strings",
-          "enum",
-          "pipe-operator"
-        ],
-        "practices": [
-          "pipe-operator"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "dnd-character",
-        "name": "DnD Character",
-        "uuid": "bd15a0e0-c19e-4a52-be6c-1a61d14c54cd",
-        "prerequisites": [
-          "integers",
-          "enum",
-          "recursion",
-          "structs",
-          "ranges",
-          "randomness"
-        ],
-        "practices": [
-          "structs",
-          "randomness"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "pangram",
-        "name": "Pangram",
-        "uuid": "20a0bbf8-751c-477a-a2cb-dd7cf4e4896c",
-        "prerequisites": [
-          "strings",
-          "charlists",
-          "enum",
-          "recursion",
-          "ranges"
-        ],
-        "practices": [
-          "charlists",
-          "ranges"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "scrabble-score",
-        "name": "Scrabble Score",
-        "uuid": "cc198564-72e6-444b-93b6-6b7ecf4d1759",
-        "prerequisites": [
-          "strings",
-          "maps",
-          "enum",
-          "recursion",
-          "pipe-operator"
-        ],
-        "practices": [
-          "pipe-operator",
-          "maps"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "sum-of-multiples",
-        "name": "Sum Of Multiples",
-        "uuid": "5b8eece1-845f-4a5a-8a2f-fe2bf66f5e57",
-        "prerequisites": [
-          "enum",
-          "ranges"
-        ],
-        "practices": [
-          "enum",
-          "ranges"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "grade-school",
-        "name": "Grade School",
-        "uuid": "4e6d3ddf-b696-40dc-ba02-ed998e595be7",
-        "prerequisites": [
-          "lists",
-          "maps",
-          "enum"
-        ],
-        "practices": [
-          "maps"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "isogram",
-        "name": "Isogram",
-        "uuid": "55a20a0f-0131-4e4e-b14f-f3cb49e3cc04",
-        "prerequisites": [
-          "strings",
-          "enum",
-          "regular-expressions"
-        ],
-        "practices": [
-          "regular-expressions"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "twelve-days",
-        "name": "Twelve Days",
-        "uuid": "9dfb5dfc-1123-492b-9383-2a4312c219a4",
-        "prerequisites": [
-          "lists",
-          "strings",
-          "multiple-clause-functions",
-          "case",
-          "enum",
-          "recursion",
-          "maps",
-          "ranges"
-        ],
-        "practices": [
-          "multiple-clause-functions"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "collatz-conjecture",
-        "name": "Collatz Conjecture",
-        "uuid": "01f7ce73-ad6a-42bb-a401-cbd485c081d4",
-        "prerequisites": [
-          "integers",
-          "recursion",
-          "multiple-clause-functions",
-          "guards"
-        ],
-        "practices": [
-          "integers",
-          "guards"
-        ],
-        "difficulty": 2
-      },
-      {
         "slug": "sublist",
         "name": "Sublist",
         "uuid": "146dd0ed-5210-4b3c-bb4b-8d0a8e832aab",
@@ -1211,6 +1092,20 @@
         ],
         "practices": [
           "lists"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "sum-of-multiples",
+        "name": "Sum Of Multiples",
+        "uuid": "5b8eece1-845f-4a5a-8a2f-fe2bf66f5e57",
+        "prerequisites": [
+          "enum",
+          "ranges"
+        ],
+        "practices": [
+          "enum",
+          "ranges"
         ],
         "difficulty": 2
       },
@@ -1236,166 +1131,63 @@
         "difficulty": 2
       },
       {
-        "slug": "flatten-array",
-        "name": "Flatten Array",
-        "uuid": "0aae3af1-7c35-4d7c-aecf-8f89c7fbc300",
-        "prerequisites": [
-          "lists",
-          "recursion",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "nil"
-        ],
-        "practices": [
-          "lists",
-          "nil"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "matching-brackets",
-        "name": "Matching Brackets",
-        "uuid": "cf0084a0-7b1d-4714-b7b2-618e3ad6e147",
+        "slug": "atbash-cipher",
+        "name": "Atbash Cipher",
+        "uuid": "eab8a96f-74af-4e3d-8039-d1d74714f72b",
         "prerequisites": [
           "strings",
-          "regular-expressions",
-          "cond",
-          "case",
-          "if",
-          "recursion",
-          "enum",
-          "maps",
-          "pattern-matching",
-          "multiple-clause-functions",
-          "binaries"
-        ],
-        "practices": [
-          "recursion"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "anagram",
-        "name": "Anagram",
-        "uuid": "21e70267-097e-476f-aaff-233483514802",
-        "prerequisites": [
-          "strings",
-          "enum"
-        ],
-        "practices": [
-          "strings",
-          "enum"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "hamming",
-        "name": "Hamming",
-        "uuid": "aca03bcb-eb70-4646-be34-8c1a44026e9b",
-        "prerequisites": [
-          "atoms",
-          "tuples",
           "charlists",
-          "multiple-clause-functions",
-          "guards",
+          "regular-expressions",
+          "ranges",
+          "maps",
           "enum",
           "recursion"
         ],
         "practices": [
-          "enum"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "matrix",
-        "name": "Matrix",
-        "uuid": "f0df392c-8ace-4639-b555-5e61e54a854e",
-        "prerequisites": [
           "strings",
-          "enum",
-          "structs",
-          "tuples",
-          "maps"
-        ],
-        "practices": [
-          "structs",
-          "tuples"
+          "charlists"
         ],
         "difficulty": 3
       },
       {
-        "slug": "phone-number",
-        "name": "Phone Number",
-        "uuid": "e8b049b7-6648-412c-8a11-0c95a15e2641",
+        "slug": "beer-song",
+        "name": "Beer Song",
+        "uuid": "24db624b-7c80-409d-97d5-e1177f025c67",
         "prerequisites": [
-          "atoms",
-          "tuples",
-          "if",
-          "case",
-          "cond",
-          "charlists",
-          "enum",
           "strings",
-          "regular-expressions",
+          "multiple-clause-functions",
+          "default-arguments",
+          "ranges",
+          "enum",
+          "recursion"
+        ],
+        "practices": [
+          "multiple-clause-functions",
+          "default-arguments"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "binary",
+        "name": "Binary",
+        "uuid": "29c3c9ff-c7f3-4646-9612-7cd768d237ab",
+        "prerequisites": [
+          "cond",
+          "case",
+          "if",
           "multiple-clause-functions",
           "pattern-matching",
-          "binaries"
-        ],
-        "practices": [
-          "strings",
-          "regular-expressions"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "say",
-        "name": "Say",
-        "uuid": "5ecbe1c9-12e3-42b6-921a-bc2d32011930",
-        "prerequisites": [
-          "integers",
-          "atoms",
-          "tuples",
-          "strings",
-          "multiple-clause-functions",
-          "case",
-          "guards",
-          "enum",
+          "binaries",
           "recursion",
-          "maps",
-          "ranges",
-          "module-attributes-as-constants"
-        ],
-        "practices": [
-          "guards",
-          "module-attributes-as-constants"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "nth-prime",
-        "name": "Nth Prime",
-        "uuid": "6d0c0785-3514-44fc-9b5a-0758989d1c6a",
-        "prerequisites": [
-          "integers",
-          "cond",
-          "case",
-          "if",
+          "tail-call-recursion",
           "enum",
-          "recursion",
-          "multiple-clause-functions",
-          "guards",
-          "ranges",
-          "streams",
-          "errors",
-          "exceptions"
+          "strings"
         ],
         "practices": [
-          "integers",
-          "ranges",
-          "errors"
+          "tail-call-recursion"
         ],
-        "difficulty": 2
+        "difficulty": 3,
+        "status": "deprecated"
       },
       {
         "slug": "binary-search",
@@ -1417,89 +1209,6 @@
         "difficulty": 3
       },
       {
-        "slug": "isbn-verifier",
-        "name": "ISBN Verifier",
-        "uuid": "0fb09d01-1f8b-4654-9004-52baa057412e",
-        "prerequisites": [
-          "strings",
-          "regular-expressions",
-          "if",
-          "cond",
-          "case",
-          "ranges",
-          "enum"
-        ],
-        "practices": [
-          "regular-expressions",
-          "ranges"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "leap",
-        "name": "Leap",
-        "uuid": "f231c263-61fa-4139-a1c9-a69e6986a4cd",
-        "prerequisites": [
-          "integers",
-          "booleans",
-          "multiple-clause-functions",
-          "guards"
-        ],
-        "practices": [
-          "integers",
-          "booleans",
-          "multiple-clause-functions",
-          "guards"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "tournament",
-        "name": "Tournament",
-        "uuid": "29a6f3f4-0d20-4447-8916-b98270780e0e",
-        "prerequisites": [
-          "tuples",
-          "strings",
-          "maps",
-          "enum",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "cond",
-          "case",
-          "if"
-        ],
-        "practices": [
-          "maps",
-          "pattern-matching"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "all-your-base",
-        "name": "All Your Base",
-        "uuid": "f71d5f38-fcc9-4044-ade9-f779a8686c69",
-        "prerequisites": [
-          "atoms",
-          "tuples",
-          "integers",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "cond",
-          "case",
-          "if",
-          "recursion",
-          "tail-call-recursion",
-          "enum"
-        ],
-        "practices": [
-          "integers",
-          "multiple-clause-functions"
-        ],
-        "difficulty": 2
-      },
-      {
         "slug": "binary-search-tree",
         "name": "Binary Search Tree",
         "uuid": "77fe5eb6-a35b-4af4-9512-275f140c25d6",
@@ -1519,6 +1228,85 @@
           "maps",
           "recursion",
           "nil"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "bob",
+        "name": "Bob",
+        "uuid": "d20b49dc-cb6d-45fc-a168-78d002072c75",
+        "prerequisites": [
+          "booleans",
+          "strings",
+          "regular-expressions",
+          "cond"
+        ],
+        "practices": [
+          "booleans",
+          "cond"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "dnd-character",
+        "name": "DnD Character",
+        "uuid": "bd15a0e0-c19e-4a52-be6c-1a61d14c54cd",
+        "prerequisites": [
+          "integers",
+          "enum",
+          "recursion",
+          "structs",
+          "ranges",
+          "randomness"
+        ],
+        "practices": [
+          "structs",
+          "randomness"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "flatten-array",
+        "name": "Flatten Array",
+        "uuid": "0aae3af1-7c35-4d7c-aecf-8f89c7fbc300",
+        "prerequisites": [
+          "lists",
+          "recursion",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "nil"
+        ],
+        "practices": [
+          "lists",
+          "nil"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "gigasecond",
+        "name": "Gigasecond",
+        "uuid": "287331a4-64d5-4b35-b4c1-a1171dc338e1",
+        "prerequisites": [
+          "integers",
+          "dates-and-time"
+        ],
+        "practices": [
+          "dates-and-time"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "grade-school",
+        "name": "Grade School",
+        "uuid": "4e6d3ddf-b696-40dc-ba02-ed998e595be7",
+        "prerequisites": [
+          "lists",
+          "maps",
+          "enum"
+        ],
+        "practices": [
+          "maps"
         ],
         "difficulty": 3
       },
@@ -1545,137 +1333,71 @@
         "difficulty": 3
       },
       {
-        "slug": "meetup",
-        "name": "Meetup",
-        "uuid": "68fee2cd-a5bc-40f2-8936-a3bb10463498",
-        "prerequisites": [
-          "atoms",
-          "cond",
-          "case",
-          "if",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "enum",
-          "ranges",
-          "dates-and-time"
-        ],
-        "practices": [
-          "atoms",
-          "pattern-matching",
-          "dates-and-time"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "simple-linked-list",
-        "name": "Simple Linked List",
-        "uuid": "e5d2386a-3021-4329-a4b7-6164e49df776",
-        "prerequisites": [
-          "atoms",
-          "tuples",
-          "pattern-matching",
-          "recursion",
-          "tail-call-recursion"
-        ],
-        "practices": [
-          "atoms",
-          "tuples",
-          "tail-call-recursion"
-        ],
-        "difficulty": 1
-      },
-      {
-        "slug": "etl",
-        "name": "ETL",
-        "uuid": "b3a4c561-344a-403e-b5b3-3533d51e65f4",
+        "slug": "hexadecimal",
+        "name": "Hexadecimal",
+        "uuid": "8154a099-5d6f-4e71-83fe-45ab23475778",
         "prerequisites": [
           "strings",
-          "maps",
-          "enum",
-          "list-comprehensions"
-        ],
-        "practices": [
-          "list-comprehensions"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "binary",
-        "name": "Binary",
-        "uuid": "29c3c9ff-c7f3-4646-9612-7cd768d237ab",
-        "prerequisites": [
-          "cond",
-          "case",
-          "if",
+          "charlists",
+          "ranges",
           "multiple-clause-functions",
+          "guards",
           "pattern-matching",
-          "binaries",
+          "case",
           "recursion",
-          "tail-call-recursion",
-          "enum",
-          "strings"
+          "enum"
         ],
         "practices": [
-          "tail-call-recursion"
+          "charlists"
         ],
         "difficulty": 3,
         "status": "deprecated"
       },
       {
-        "slug": "change",
-        "name": "Change",
-        "uuid": "14bddd31-a68f-4a16-830f-6e8ecf8199f2",
+        "slug": "house",
+        "name": "House",
+        "uuid": "5ff34497-3a3f-4aaf-b50c-872e7a7b8f51",
         "prerequisites": [
-          "integers",
-          "atoms",
-          "tuples",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "recursion",
+          "lists",
           "enum",
-          "maps"
+          "strings",
+          "ranges"
         ],
-        "practices": [
-          "integers"
-        ],
-        "difficulty": 7
+        "practices": [],
+        "difficulty": 3
       },
       {
-        "slug": "transpose",
-        "name": "Transpose",
-        "uuid": "ce270a34-add1-422c-bb86-53b310f05e27",
+        "slug": "isbn-verifier",
+        "name": "ISBN Verifier",
+        "uuid": "0fb09d01-1f8b-4654-9004-52baa057412e",
         "prerequisites": [
           "strings",
-          "enum"
-        ],
-        "practices": [
-          "enum"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "ocr-numbers",
-        "name": "OCR Numbers",
-        "uuid": "3f321191-afb1-4aa1-995b-204aa460269e",
-        "prerequisites": [
-          "strings",
-          "charlists",
-          "multiple-clause-functions",
-          "pattern-matching",
+          "regular-expressions",
+          "if",
           "cond",
           "case",
-          "if",
-          "enum",
-          "maps",
-          "binaries"
+          "ranges",
+          "enum"
         ],
         "practices": [
-          "strings",
-          "multiple-clause-functions"
+          "regular-expressions",
+          "ranges"
         ],
-        "difficulty": 6
+        "difficulty": 3
+      },
+      {
+        "slug": "isogram",
+        "name": "Isogram",
+        "uuid": "55a20a0f-0131-4e4e-b14f-f3cb49e3cc04",
+        "prerequisites": [
+          "strings",
+          "enum",
+          "regular-expressions"
+        ],
+        "practices": [
+          "regular-expressions"
+        ],
+        "difficulty": 3
       },
       {
         "slug": "kindergarten-garden",
@@ -1702,123 +1424,75 @@
         "difficulty": 3
       },
       {
-        "slug": "diamond",
-        "name": "Diamond",
-        "uuid": "89633764-ace4-4ad5-a1aa-22cae7be7d18",
-        "prerequisites": [
-          "charlists",
-          "strings",
-          "enum",
-          "recursion",
-          "ranges"
-        ],
-        "practices": [
-          "charlists"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "luhn",
-        "name": "Luhn",
-        "uuid": "c38ca1a8-9f0e-49de-81f9-5712ce459839",
+        "slug": "leap",
+        "name": "Leap",
+        "uuid": "f231c263-61fa-4139-a1c9-a69e6986a4cd",
         "prerequisites": [
           "integers",
+          "booleans",
+          "multiple-clause-functions",
+          "guards"
+        ],
+        "practices": [
+          "integers",
+          "booleans",
+          "multiple-clause-functions",
+          "guards"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "matching-brackets",
+        "name": "Matching Brackets",
+        "uuid": "cf0084a0-7b1d-4714-b7b2-618e3ad6e147",
+        "prerequisites": [
           "strings",
           "regular-expressions",
           "cond",
           "case",
           "if",
-          "multiple-clause-functions",
-          "guards",
-          "pattern-matching",
-          "recursion",
-          "enum"
-        ],
-        "practices": [
-          "integers"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "scale-generator",
-        "name": "Scale Generator",
-        "uuid": "94de8b3f-79d7-4367-821c-e239c95e32ca",
-        "prerequisites": [
-          "lists",
-          "strings",
-          "binaries",
-          "cond",
-          "case",
-          "if",
-          "multiple-clause-functions",
-          "guards",
-          "pattern-matching",
           "recursion",
           "enum",
-          "module-attributes-as-constants",
-          "default-arguments"
-        ],
-        "practices": [
-          "lists",
-          "module-attributes-as-constants"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "rail-fence-cipher",
-        "name": "Rail Fence Cipher",
-        "uuid": "3daeb229-0638-443f-9ae2-222ebb88c11a",
-        "prerequisites": [
-          "strings",
-          "cond",
-          "case",
-          "if",
-          "multiple-clause-functions",
-          "guards",
+          "maps",
           "pattern-matching",
-          "recursion",
-          "enum",
-          "ranges",
-          "streams"
+          "multiple-clause-functions",
+          "binaries"
         ],
         "practices": [
-          "ranges"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "gigasecond",
-        "name": "Gigasecond",
-        "uuid": "287331a4-64d5-4b35-b4c1-a1171dc338e1",
-        "prerequisites": [
-          "integers",
-          "dates-and-time"
-        ],
-        "practices": [
-          "dates-and-time"
+          "recursion"
         ],
         "difficulty": 3
       },
       {
-        "slug": "hexadecimal",
-        "name": "Hexadecimal",
-        "uuid": "8154a099-5d6f-4e71-83fe-45ab23475778",
+        "slug": "matrix",
+        "name": "Matrix",
+        "uuid": "f0df392c-8ace-4639-b555-5e61e54a854e",
         "prerequisites": [
           "strings",
-          "charlists",
-          "ranges",
-          "multiple-clause-functions",
-          "guards",
-          "pattern-matching",
-          "case",
-          "recursion",
-          "enum"
+          "enum",
+          "structs",
+          "tuples",
+          "maps"
         ],
         "practices": [
-          "charlists"
+          "structs",
+          "tuples"
         ],
-        "difficulty": 3,
-        "status": "deprecated"
+        "difficulty": 3
+      },
+      {
+        "slug": "pascals-triangle",
+        "name": "Pascals Triangle",
+        "uuid": "b85c37c7-a76e-41fa-9ce6-abcdba2bd683",
+        "prerequisites": [
+          "enum",
+          "ranges",
+          "recursion"
+        ],
+        "practices": [
+          "recursion"
+        ],
+        "difficulty": 3
       },
       {
         "slug": "perfect-numbers",
@@ -1862,6 +1536,187 @@
         "difficulty": 3
       },
       {
+        "slug": "proverb",
+        "name": "Proverb",
+        "uuid": "e230f49d-e92a-4440-8e7d-733755451cf5",
+        "prerequisites": [
+          "lists",
+          "strings",
+          "pattern-matching",
+          "multiple-clause-functions",
+          "enum"
+        ],
+        "practices": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "resistor-color-trio",
+        "name": "Resistor Color Trio",
+        "uuid": "f1bad952-302b-4754-a439-a8c60c1d22a4",
+        "prerequisites": [
+          "atoms",
+          "tuples",
+          "integers",
+          "lists",
+          "pattern-matching",
+          "if",
+          "maps"
+        ],
+        "practices": [
+          "atoms",
+          "integers",
+          "maps"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "say",
+        "name": "Say",
+        "uuid": "5ecbe1c9-12e3-42b6-921a-bc2d32011930",
+        "prerequisites": [
+          "integers",
+          "atoms",
+          "tuples",
+          "strings",
+          "multiple-clause-functions",
+          "case",
+          "guards",
+          "enum",
+          "recursion",
+          "maps",
+          "ranges",
+          "module-attributes-as-constants"
+        ],
+        "practices": [
+          "guards",
+          "module-attributes-as-constants"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "simple-cipher",
+        "name": "Simple Cipher",
+        "uuid": "dbea6e3b-1c0c-471f-9af3-f8fd3cbb957a",
+        "prerequisites": [
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "ranges",
+          "strings",
+          "charlists",
+          "binaries",
+          "enum",
+          "streams",
+          "randomness",
+          "erlang-libraries"
+        ],
+        "practices": [
+          "charlists",
+          "randomness"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "twelve-days",
+        "name": "Twelve Days",
+        "uuid": "9dfb5dfc-1123-492b-9383-2a4312c219a4",
+        "prerequisites": [
+          "lists",
+          "strings",
+          "multiple-clause-functions",
+          "case",
+          "enum",
+          "recursion",
+          "maps",
+          "ranges"
+        ],
+        "practices": [
+          "multiple-clause-functions"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "word-count",
+        "name": "Word Count",
+        "uuid": "4a24ba2f-ae92-4095-be53-64bc881422ea",
+        "prerequisites": [
+          "strings",
+          "regular-expressions",
+          "enum",
+          "maps",
+          "pipe-operator"
+        ],
+        "practices": [
+          "regular-expressions",
+          "pipe-operator"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "allergies",
+        "name": "Allergies",
+        "uuid": "9a1b599c-3175-4166-9b53-491a2f565db6",
+        "prerequisites": [
+          "lists",
+          "maps",
+          "enum",
+          "bit-manipulation"
+        ],
+        "practices": [
+          "bit-manipulation"
+        ],
+        "difficulty": 4
+      },
+      {
+        "slug": "complex-numbers",
+        "name": "Complex Numbers",
+        "uuid": "0cc86a92-7118-4cb9-8417-db4557baf364",
+        "prerequisites": [
+          "pattern-matching",
+          "erlang-libraries",
+          "floating-point-numbers",
+          "tuples"
+        ],
+        "practices": [
+          "erlang-libraries",
+          "floating-point-numbers"
+        ],
+        "difficulty": 4
+      },
+      {
+        "slug": "crypto-square",
+        "name": "Crypto Square",
+        "uuid": "132981c5-d3cd-426a-8a93-8a72b1cd8564",
+        "prerequisites": [
+          "integers",
+          "floating-point-numbers",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "strings",
+          "regular-expressions",
+          "enum",
+          "erlang-libraries"
+        ],
+        "practices": [
+          "strings"
+        ],
+        "difficulty": 4
+      },
+      {
+        "slug": "difference-of-squares",
+        "name": "Difference Of Squares",
+        "uuid": "bb9b24da-1ee6-42fb-936f-5fc41d97ee27",
+        "prerequisites": [
+          "integers",
+          "enum",
+          "ranges"
+        ],
+        "practices": [
+          "ranges"
+        ],
+        "difficulty": 4
+      },
+      {
         "slug": "diffie-hellman",
         "name": "Diffie Hellman",
         "uuid": "92caf2b9-3fca-401c-8daa-aaa0193e704f",
@@ -1874,6 +1729,94 @@
           "ranges",
           "randomness",
           "erlang-libraries"
+        ],
+        "difficulty": 4
+      },
+      {
+        "slug": "dominoes",
+        "name": "Dominoes",
+        "uuid": "9fdeb525-90d8-45ca-9a24-ca46b4363e03",
+        "prerequisites": [
+          "tuples",
+          "atoms",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "case",
+          "cond",
+          "if",
+          "enum",
+          "recursion",
+          "tail-call-recursion"
+        ],
+        "practices": [
+          "tail-call-recursion"
+        ],
+        "difficulty": 4
+      },
+      {
+        "slug": "grep",
+        "name": "Grep",
+        "uuid": "b2630a58-6ee1-4b3b-ad5c-e09b8bfe2a30",
+        "prerequisites": [
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "case",
+          "cond",
+          "if",
+          "enum",
+          "strings",
+          "regular-expressions",
+          "file"
+        ],
+        "practices": [
+          "case",
+          "regular-expressions",
+          "file"
+        ],
+        "difficulty": 4
+      },
+      {
+        "slug": "largest-series-product",
+        "name": "Largest Series Product",
+        "uuid": "79525094-76dd-4cf0-8956-fdd33de855e2",
+        "prerequisites": [
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "integers",
+          "strings",
+          "enum",
+          "ranges",
+          "errors",
+          "exceptions"
+        ],
+        "practices": [
+          "integers"
+        ],
+        "difficulty": 4
+      },
+      {
+        "slug": "meetup",
+        "name": "Meetup",
+        "uuid": "68fee2cd-a5bc-40f2-8936-a3bb10463498",
+        "prerequisites": [
+          "atoms",
+          "cond",
+          "case",
+          "if",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "enum",
+          "ranges",
+          "dates-and-time"
+        ],
+        "practices": [
+          "atoms",
+          "pattern-matching",
+          "dates-and-time"
         ],
         "difficulty": 4
       },
@@ -1896,37 +1839,44 @@
         "difficulty": 4
       },
       {
-        "slug": "palindrome-products",
-        "name": "Palindrome Products",
-        "uuid": "5ab8275f-bf1d-472d-9545-8ac622ce6f5d",
+        "slug": "phone-number",
+        "name": "Phone Number",
+        "uuid": "e8b049b7-6648-412c-8a11-0c95a15e2641",
         "prerequisites": [
-          "strings",
+          "atoms",
+          "tuples",
+          "if",
+          "case",
+          "cond",
+          "charlists",
           "enum",
-          "ranges",
-          "list-comprehensions",
-          "default-arguments",
-          "errors",
-          "exceptions"
+          "strings",
+          "regular-expressions",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "binaries"
         ],
         "practices": [
-          "ranges",
-          "list-comprehensions"
+          "strings",
+          "regular-expressions"
         ],
-        "difficulty": 5
+        "difficulty": 4
       },
       {
-        "slug": "pascals-triangle",
-        "name": "Pascals Triangle",
-        "uuid": "b85c37c7-a76e-41fa-9ce6-abcdba2bd683",
+        "slug": "rational-numbers",
+        "name": "Rational Numbers",
+        "uuid": "e2777a03-d890-453e-af5b-d61f60adbbf5",
         "prerequisites": [
-          "enum",
-          "ranges",
-          "recursion"
+          "pattern-matching",
+          "basics",
+          "integers",
+          "floating-point-numbers",
+          "guards"
         ],
         "practices": [
-          "recursion"
+          "basics"
         ],
-        "difficulty": 3
+        "difficulty": 4
       },
       {
         "slug": "spiral-matrix",
@@ -1942,6 +1892,78 @@
           "recursion"
         ],
         "difficulty": 4
+      },
+      {
+        "slug": "tournament",
+        "name": "Tournament",
+        "uuid": "29a6f3f4-0d20-4447-8916-b98270780e0e",
+        "prerequisites": [
+          "tuples",
+          "strings",
+          "maps",
+          "enum",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "cond",
+          "case",
+          "if"
+        ],
+        "practices": [
+          "maps",
+          "pattern-matching"
+        ],
+        "difficulty": 4
+      },
+      {
+        "slug": "affine-cipher",
+        "name": "Affine Cipher",
+        "uuid": "18d12bac-ead0-456c-bcef-ccb2fd06fe72",
+        "prerequisites": [
+          "pattern-matching",
+          "guards",
+          "multiple-clause-functions",
+          "atoms",
+          "pipe-operator",
+          "enum",
+          "integers",
+          "if",
+          "cond",
+          "case",
+          "strings",
+          "tuples",
+          "maps",
+          "list-comprehensions",
+          "charlists"
+        ],
+        "practices": [
+          "pipe-operator",
+          "strings"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "clock",
+        "name": "Clock",
+        "uuid": "e7cb9cd0-5893-4ebb-b801-f5d548945531",
+        "prerequisites": [
+          "integers",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "if",
+          "case",
+          "cond",
+          "strings",
+          "structs",
+          "protocols"
+        ],
+        "practices": [
+          "integers",
+          "structs",
+          "protocols"
+        ],
+        "difficulty": 5
       },
       {
         "slug": "custom-set",
@@ -1965,6 +1987,115 @@
         "difficulty": 5
       },
       {
+        "slug": "diamond",
+        "name": "Diamond",
+        "uuid": "89633764-ace4-4ad5-a1aa-22cae7be7d18",
+        "prerequisites": [
+          "charlists",
+          "strings",
+          "enum",
+          "recursion",
+          "ranges"
+        ],
+        "practices": [
+          "charlists"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "food-chain",
+        "name": "Food Chain",
+        "uuid": "7541eeac-169f-4b28-b9d2-7125225b121b",
+        "prerequisites": [
+          "lists",
+          "strings",
+          "pattern-matching",
+          "multiple-clause-functions",
+          "enum"
+        ],
+        "practices": [
+          "strings"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "luhn",
+        "name": "Luhn",
+        "uuid": "c38ca1a8-9f0e-49de-81f9-5712ce459839",
+        "prerequisites": [
+          "integers",
+          "strings",
+          "regular-expressions",
+          "cond",
+          "case",
+          "if",
+          "multiple-clause-functions",
+          "guards",
+          "pattern-matching",
+          "recursion",
+          "enum"
+        ],
+        "practices": [
+          "integers"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "markdown",
+        "name": "Markdown",
+        "uuid": "5dfa24bf-e77c-47c6-88e1-e50cbeecd159",
+        "prerequisites": [
+          "strings",
+          "enum",
+          "recursion",
+          "regular-expressions",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "cond",
+          "case",
+          "if"
+        ],
+        "practices": [
+          "regular-expressions"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "palindrome-products",
+        "name": "Palindrome Products",
+        "uuid": "5ab8275f-bf1d-472d-9545-8ac622ce6f5d",
+        "prerequisites": [
+          "strings",
+          "enum",
+          "ranges",
+          "list-comprehensions",
+          "default-arguments",
+          "errors",
+          "exceptions"
+        ],
+        "practices": [
+          "ranges",
+          "list-comprehensions"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "pythagorean-triplet",
+        "name": "Pythagorean Triplet",
+        "uuid": "087a2a3b-71e2-4473-ab2f-3be5240567b5",
+        "prerequisites": [
+          "integers",
+          "ranges",
+          "enum",
+          "list-comprehensions",
+          "recursion"
+        ],
+        "practices": [
+          "enum"
+        ],
+        "difficulty": 5
+      },
+      {
         "slug": "saddle-points",
         "name": "Saddle Points",
         "uuid": "8e5c050a-ff42-4a23-ba32-84595b7476f4",
@@ -1978,6 +2109,302 @@
           "maps"
         ],
         "difficulty": 5
+      },
+      {
+        "slug": "scale-generator",
+        "name": "Scale Generator",
+        "uuid": "94de8b3f-79d7-4367-821c-e239c95e32ca",
+        "prerequisites": [
+          "lists",
+          "strings",
+          "binaries",
+          "cond",
+          "case",
+          "if",
+          "multiple-clause-functions",
+          "guards",
+          "pattern-matching",
+          "recursion",
+          "enum",
+          "module-attributes-as-constants",
+          "default-arguments"
+        ],
+        "practices": [
+          "lists",
+          "module-attributes-as-constants"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "sieve",
+        "name": "Sieve",
+        "uuid": "78cfa21b-bc7f-426b-9ef3-57b8639e887b",
+        "prerequisites": [
+          "integers",
+          "lists",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "ranges",
+          "enum",
+          "recursion"
+        ],
+        "practices": [
+          "lists",
+          "recursion"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "square-root",
+        "name": "Square Root",
+        "uuid": "bf9e6251-105b-4fd7-b388-c6f5a652d174",
+        "prerequisites": [
+          "if",
+          "cond",
+          "integer",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "recursion"
+        ],
+        "practices": [
+          "integer"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "transpose",
+        "name": "Transpose",
+        "uuid": "ce270a34-add1-422c-bb86-53b310f05e27",
+        "prerequisites": [
+          "strings",
+          "enum"
+        ],
+        "practices": [
+          "enum"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "yacht",
+        "name": "Yacht",
+        "uuid": "d2ee3ff4-2f01-404a-a4f0-d15823ac0482",
+        "prerequisites": [
+          "lists",
+          "cond",
+          "case",
+          "if",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "enum"
+        ],
+        "practices": [
+          "multiple-clause-functions"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "knapsack",
+        "name": "Knapsack",
+        "uuid": "1770aab6-2289-4134-b6ac-7d346e421e06",
+        "prerequisites": [
+          "atoms",
+          "integers",
+          "lists",
+          "maps",
+          "pattern-matching",
+          "recursion",
+          "guards"
+        ],
+        "practices": [],
+        "difficulty": 6
+      },
+      {
+        "slug": "list-ops",
+        "name": "List Ops",
+        "uuid": "86658a31-d401-401b-80df-2c4df35f9b15",
+        "prerequisites": [
+          "lists",
+          "recursion",
+          "tail-call-recursion",
+          "multiple-clause-functions",
+          "pattern-matching"
+        ],
+        "practices": [
+          "lists",
+          "tail-call-recursion"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "ocr-numbers",
+        "name": "OCR Numbers",
+        "uuid": "3f321191-afb1-4aa1-995b-204aa460269e",
+        "prerequisites": [
+          "strings",
+          "charlists",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "cond",
+          "case",
+          "if",
+          "enum",
+          "maps",
+          "binaries"
+        ],
+        "practices": [
+          "strings",
+          "multiple-clause-functions"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "rail-fence-cipher",
+        "name": "Rail Fence Cipher",
+        "uuid": "3daeb229-0638-443f-9ae2-222ebb88c11a",
+        "prerequisites": [
+          "strings",
+          "cond",
+          "case",
+          "if",
+          "multiple-clause-functions",
+          "guards",
+          "pattern-matching",
+          "recursion",
+          "enum",
+          "ranges",
+          "streams"
+        ],
+        "practices": [
+          "ranges"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "robot-simulator",
+        "name": "Robot Simulator",
+        "uuid": "e5e55560-852f-4551-b4da-c9f4a3141470",
+        "prerequisites": [
+          "atoms",
+          "multiple-clause-functions",
+          "guards",
+          "pattern-matching",
+          "case",
+          "strings",
+          "enum",
+          "structs",
+          "default-arguments"
+        ],
+        "practices": [
+          "structs",
+          "multiple-clause-functions"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "satellite",
+        "name": "Satellite",
+        "uuid": "a07e01e6-7cea-4db9-a514-7c95788e90a9",
+        "prerequisites": [
+          "pattern-matching",
+          "tuples",
+          "cond",
+          "recursion",
+          "atoms",
+          "lists",
+          "enum"
+        ],
+        "practices": [
+          "recursion"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "variable-length-quantity",
+        "name": "Variable Length Quantity",
+        "uuid": "2e8b9b75-609d-4c99-947c-28274a9dbf27",
+        "prerequisites": [
+          "atoms",
+          "tuples",
+          "lists",
+          "enum",
+          "case",
+          "cond",
+          "if",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "integers",
+          "bit-manipulation",
+          "bitstrings"
+        ],
+        "practices": [
+          "bit-manipulation",
+          "bitstrings"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "alphametics",
+        "name": "Alphametics",
+        "uuid": "7ed99829-acd8-4724-b92f-85146f1709f9",
+        "prerequisites": [
+          "strings",
+          "regular-expressions",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "case",
+          "cond",
+          "if",
+          "enum",
+          "charlists",
+          "ranges"
+        ],
+        "practices": [
+          "strings",
+          "pattern-matching"
+        ],
+        "difficulty": 7
+      },
+      {
+        "slug": "bank-account",
+        "name": "Bank Account",
+        "uuid": "5d5e0f6c-f4b7-418e-88f8-4b1d0f99bfb0",
+        "prerequisites": [
+          "if",
+          "processes",
+          "pids",
+          "agent"
+        ],
+        "practices": [
+          "if",
+          "processes",
+          "pids",
+          "agent"
+        ],
+        "difficulty": 7
+      },
+      {
+        "slug": "change",
+        "name": "Change",
+        "uuid": "14bddd31-a68f-4a16-830f-6e8ecf8199f2",
+        "prerequisites": [
+          "integers",
+          "atoms",
+          "tuples",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "recursion",
+          "enum",
+          "maps"
+        ],
+        "practices": [
+          "integers"
+        ],
+        "difficulty": 7
       },
       {
         "slug": "connect",
@@ -2050,279 +2477,68 @@
         "difficulty": 7
       },
       {
-        "slug": "armstrong-numbers",
-        "name": "Armstrong Numbers",
-        "uuid": "8f40f0f6-95e6-4a4c-a576-3d677ffbbd9f",
-        "prerequisites": [
-          "integers",
-          "lists",
-          "enum",
-          "erlang-libraries"
-        ],
-        "practices": [
-          "integers"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "simple-cipher",
-        "name": "Simple Cipher",
-        "uuid": "dbea6e3b-1c0c-471f-9af3-f8fd3cbb957a",
-        "prerequisites": [
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "ranges",
-          "strings",
-          "charlists",
-          "binaries",
-          "enum",
-          "streams",
-          "randomness",
-          "erlang-libraries"
-        ],
-        "practices": [
-          "charlists",
-          "randomness"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "allergies",
-        "name": "Allergies",
-        "uuid": "9a1b599c-3175-4166-9b53-491a2f565db6",
-        "prerequisites": [
-          "lists",
-          "maps",
-          "enum",
-          "bit-manipulation"
-        ],
-        "practices": [
-          "bit-manipulation"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "crypto-square",
-        "name": "Crypto Square",
-        "uuid": "132981c5-d3cd-426a-8a93-8a72b1cd8564",
-        "prerequisites": [
-          "integers",
-          "floating-point-numbers",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "strings",
-          "regular-expressions",
-          "enum",
-          "erlang-libraries"
-        ],
-        "practices": [
-          "strings"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "largest-series-product",
-        "name": "Largest Series Product",
-        "uuid": "79525094-76dd-4cf0-8956-fdd33de855e2",
-        "prerequisites": [
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "integers",
-          "strings",
-          "enum",
-          "ranges",
-          "errors",
-          "exceptions"
-        ],
-        "practices": [
-          "integers"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "clock",
-        "name": "Clock",
-        "uuid": "e7cb9cd0-5893-4ebb-b801-f5d548945531",
-        "prerequisites": [
-          "integers",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "if",
-          "case",
-          "cond",
-          "strings",
-          "structs",
-          "protocols"
-        ],
-        "practices": [
-          "integers",
-          "structs",
-          "protocols"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "sieve",
-        "name": "Sieve",
-        "uuid": "78cfa21b-bc7f-426b-9ef3-57b8639e887b",
-        "prerequisites": [
-          "integers",
-          "lists",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "ranges",
-          "enum",
-          "recursion"
-        ],
-        "practices": [
-          "lists",
-          "recursion"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "poker",
-        "name": "Poker",
-        "uuid": "53d67dde-5a53-4d89-b77c-027d144135b9",
+        "slug": "rectangles",
+        "name": "Rectangles",
+        "uuid": "bc7f9ea3-4e67-406a-91fe-807859fb9c7f",
         "prerequisites": [
           "tuples",
-          "lists",
           "maps",
-          "enum",
-          "recursion",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "case",
-          "cond",
-          "if",
-          "structs"
-        ],
-        "practices": [
-          "pattern-matching"
-        ],
-        "difficulty": 8
-      },
-      {
-        "slug": "atbash-cipher",
-        "name": "Atbash Cipher",
-        "uuid": "eab8a96f-74af-4e3d-8039-d1d74714f72b",
-        "prerequisites": [
           "strings",
           "charlists",
-          "regular-expressions",
-          "ranges",
-          "maps",
-          "enum",
-          "recursion"
-        ],
-        "practices": [
-          "strings",
-          "charlists"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "grep",
-        "name": "Grep",
-        "uuid": "b2630a58-6ee1-4b3b-ad5c-e09b8bfe2a30",
-        "prerequisites": [
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "case",
-          "cond",
-          "if",
-          "enum",
-          "strings",
-          "regular-expressions",
-          "file"
-        ],
-        "practices": [
-          "case",
-          "regular-expressions",
-          "file"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "difference-of-squares",
-        "name": "Difference Of Squares",
-        "uuid": "bb9b24da-1ee6-42fb-936f-5fc41d97ee27",
-        "prerequisites": [
-          "integers",
+          "list-comprehensions",
           "enum",
           "ranges"
         ],
         "practices": [
-          "ranges"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "dominoes",
-        "name": "Dominoes",
-        "uuid": "9fdeb525-90d8-45ca-9a24-ca46b4363e03",
-        "prerequisites": [
-          "tuples",
-          "atoms",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "case",
-          "cond",
-          "if",
-          "enum",
-          "recursion",
-          "tail-call-recursion"
-        ],
-        "practices": [
-          "tail-call-recursion"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "alphametics",
-        "name": "Alphametics",
-        "uuid": "7ed99829-acd8-4724-b92f-85146f1709f9",
-        "prerequisites": [
-          "strings",
-          "regular-expressions",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "case",
-          "cond",
-          "if",
-          "enum",
-          "charlists",
-          "ranges"
-        ],
-        "practices": [
-          "strings",
-          "pattern-matching"
+          "list-comprehensions"
         ],
         "difficulty": 7
       },
       {
-        "slug": "pythagorean-triplet",
-        "name": "Pythagorean Triplet",
-        "uuid": "087a2a3b-71e2-4473-ab2f-3be5240567b5",
+        "slug": "two-bucket",
+        "name": "Two Bucket",
+        "uuid": "07b4679a-3d9f-42bc-ad1e-b9ba272a1c15",
         "prerequisites": [
+          "atoms",
+          "tuples",
           "integers",
-          "ranges",
+          "lists",
+          "pattern-matching",
+          "if",
+          "cond",
+          "case",
+          "structs",
           "enum",
-          "list-comprehensions",
           "recursion"
         ],
-        "practices": [
-          "enum"
+        "practices": [],
+        "difficulty": 7
+      },
+      {
+        "slug": "word-search",
+        "name": "Word Search",
+        "uuid": "41ab29d0-e094-4910-bb51-b99bdedc7f17",
+        "prerequisites": [
+          "atoms",
+          "tuples",
+          "lists",
+          "enum",
+          "case",
+          "cond",
+          "if",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "strings",
+          "charlists",
+          "list-comprehensions",
+          "maps",
+          "structs"
         ],
-        "difficulty": 5
+        "practices": [
+          "list-comprehensions"
+        ],
+        "difficulty": 7
       },
       {
         "slug": "wordy",
@@ -2347,223 +2563,6 @@
         "difficulty": 7
       },
       {
-        "slug": "dot-dsl",
-        "name": "Dot DSL",
-        "uuid": "c316b8ef-7b2d-43d4-b402-f7d28b0cdaa7",
-        "prerequisites": [
-          "structs",
-          "regular-expressions",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "case",
-          "cond",
-          "if",
-          "enum",
-          "errors",
-          "exceptions",
-          "keyword-lists",
-          "nil",
-          "macros"
-        ],
-        "practices": [
-          "keyword-lists",
-          "macros"
-        ],
-        "difficulty": 8
-      },
-      {
-        "slug": "pov",
-        "name": "POV",
-        "uuid": "abc93451-451d-4497-b590-68cbf82e0a20",
-        "prerequisites": [
-          "pattern-matching",
-          "case",
-          "if",
-          "errors",
-          "recursion",
-          "enum",
-          "protocols",
-          "nil",
-          "structs",
-          "multiple-clause-functions"
-        ],
-        "practices": [
-          "recursion"
-        ],
-        "difficulty": 9
-      },
-      {
-        "slug": "satellite",
-        "name": "Satellite",
-        "uuid": "a07e01e6-7cea-4db9-a514-7c95788e90a9",
-        "prerequisites": [
-          "pattern-matching",
-          "tuples",
-          "cond",
-          "recursion",
-          "atoms",
-          "lists",
-          "enum"
-        ],
-        "practices": [
-          "recursion"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "zebra-puzzle",
-        "name": "Zebra Puzzle",
-        "uuid": "0a561b08-6e61-4415-a3f1-e7d411a4a0e2",
-        "prerequisites": [
-          "pattern-matching",
-          "case",
-          "cond",
-          "if",
-          "enum",
-          "maps",
-          "atoms"
-        ],
-        "practices": [
-          "enum",
-          "cond"
-        ],
-        "difficulty": 9
-      },
-      {
-        "slug": "rational-numbers",
-        "name": "Rational Numbers",
-        "uuid": "e2777a03-d890-453e-af5b-d61f60adbbf5",
-        "prerequisites": [
-          "pattern-matching",
-          "basics",
-          "integers",
-          "floating-point-numbers",
-          "guards"
-        ],
-        "practices": [
-          "basics"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "complex-numbers",
-        "name": "Complex Numbers",
-        "uuid": "0cc86a92-7118-4cb9-8417-db4557baf364",
-        "prerequisites": [
-          "pattern-matching",
-          "erlang-libraries",
-          "floating-point-numbers",
-          "tuples"
-        ],
-        "practices": [
-          "erlang-libraries",
-          "floating-point-numbers"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "go-counting",
-        "name": "Go Counting",
-        "uuid": "560347a2-9f20-4bad-b932-72a75ee08e14",
-        "prerequisites": [
-          "atoms",
-          "if",
-          "case",
-          "cond",
-          "strings",
-          "enum",
-          "default-arguments",
-          "guards",
-          "integers",
-          "list-comprehensions",
-          "maps",
-          "pattern-matching",
-          "pipe-operator",
-          "recursion"
-        ],
-        "practices": [
-          "list-comprehensions"
-        ],
-        "difficulty": 9
-      },
-      {
-        "slug": "yacht",
-        "name": "Yacht",
-        "uuid": "d2ee3ff4-2f01-404a-a4f0-d15823ac0482",
-        "prerequisites": [
-          "lists",
-          "cond",
-          "case",
-          "if",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "enum"
-        ],
-        "practices": [
-          "multiple-clause-functions"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "darts",
-        "name": "Darts",
-        "uuid": "a68113f8-92be-40e0-a97f-eb4239303ef5",
-        "prerequisites": [
-          "cond",
-          "integers",
-          "floating-point-numbers"
-        ],
-        "practices": [
-          "cond"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "food-chain",
-        "name": "Food Chain",
-        "uuid": "7541eeac-169f-4b28-b9d2-7125225b121b",
-        "prerequisites": [
-          "lists",
-          "strings",
-          "pattern-matching",
-          "multiple-clause-functions",
-          "enum"
-        ],
-        "practices": [
-          "strings"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "affine-cipher",
-        "name": "Affine Cipher",
-        "uuid": "18d12bac-ead0-456c-bcef-ccb2fd06fe72",
-        "prerequisites": [
-          "pattern-matching",
-          "guards",
-          "multiple-clause-functions",
-          "atoms",
-          "pipe-operator",
-          "enum",
-          "integers",
-          "if",
-          "cond",
-          "case",
-          "strings",
-          "tuples",
-          "maps",
-          "list-comprehensions",
-          "charlists"
-        ],
-        "practices": [
-          "pipe-operator",
-          "strings"
-        ],
-        "difficulty": 5
-      },
-      {
         "slug": "book-store",
         "name": "Book Store",
         "uuid": "d6d9687c-8bf0-482e-8309-4f3d706ba753",
@@ -2581,6 +2580,30 @@
         ],
         "practices": [
           "list-comprehensions"
+        ],
+        "difficulty": 8
+      },
+      {
+        "slug": "bowling",
+        "name": "Bowling",
+        "uuid": "3b252cc6-cc55-4187-891e-c10aaabac81f",
+        "prerequisites": [
+          "pattern-matching",
+          "multiple-clause-functions",
+          "guards",
+          "lists",
+          "enum",
+          "recursion",
+          "cond",
+          "if",
+          "case",
+          "structs"
+        ],
+        "practices": [
+          "pattern-matching",
+          "guards",
+          "structs",
+          "multiple-clause-functions"
         ],
         "difficulty": 8
       },
@@ -2612,21 +2635,53 @@
         "difficulty": 8
       },
       {
-        "slug": "square-root",
-        "name": "Square Root",
-        "uuid": "bf9e6251-105b-4fd7-b388-c6f5a652d174",
+        "slug": "dot-dsl",
+        "name": "Dot DSL",
+        "uuid": "c316b8ef-7b2d-43d4-b402-f7d28b0cdaa7",
         "prerequisites": [
-          "if",
-          "cond",
-          "integer",
+          "structs",
+          "regular-expressions",
           "multiple-clause-functions",
           "pattern-matching",
-          "recursion"
+          "guards",
+          "case",
+          "cond",
+          "if",
+          "enum",
+          "errors",
+          "exceptions",
+          "keyword-lists",
+          "nil",
+          "macros"
         ],
         "practices": [
-          "integer"
+          "keyword-lists",
+          "macros"
         ],
-        "difficulty": 5
+        "difficulty": 8
+      },
+      {
+        "slug": "poker",
+        "name": "Poker",
+        "uuid": "53d67dde-5a53-4d89-b77c-027d144135b9",
+        "prerequisites": [
+          "tuples",
+          "lists",
+          "maps",
+          "enum",
+          "recursion",
+          "multiple-clause-functions",
+          "pattern-matching",
+          "guards",
+          "case",
+          "cond",
+          "if",
+          "structs"
+        ],
+        "practices": [
+          "pattern-matching"
+        ],
+        "difficulty": 8
       },
       {
         "slug": "sgf-parsing",
@@ -2652,175 +2707,120 @@
           "regular-expressions"
         ],
         "difficulty": 8
-       },
-       {
-        "slug": "variable-length-quantity",
-        "name": "Variable Length Quantity",
-        "uuid": "2e8b9b75-609d-4c99-947c-28274a9dbf27",
+      },
+      {
+        "slug": "zipper",
+        "name": "Zipper",
+        "uuid": "bc315734-051c-4735-9a8a-3aacb094d2ca",
         "prerequisites": [
-          "atoms",
-          "tuples",
-          "lists",
-          "enum",
-          "case",
-          "cond",
-          "if",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "guards",
-          "integers",
-          "bit-manipulation",
-          "bitstrings"
-        ],
-        "practices": [
-          "bit-manipulation",
-          "bitstrings"
-        ],
-        "difficulty": 6
-       },
-       {
-        "slug": "resistor-color-duo",
-        "name": "Resistor Color Duo",
-        "uuid": "92387ac7-4c6d-4568-819e-e037b1d86a72",
-        "prerequisites": [
-          "atoms",
-          "lists",
-          "pattern-matching",
-          "maps"
-        ],
-        "practices": [
-          "atoms",
-          "maps"
-        ],
-        "difficulty": 2
-       },
-       {
-        "slug": "resistor-color-trio",
-        "name": "Resistor Color Trio",
-        "uuid": "f1bad952-302b-4754-a439-a8c60c1d22a4",
-        "prerequisites": [
-          "atoms",
-          "tuples",
-          "integers",
-          "lists",
-          "pattern-matching",
-          "if",
-          "maps"
-        ],
-        "practices": [
-          "atoms",
-          "integers",
-          "maps"
-        ],
-        "difficulty": 3
-       },
-       {
-        "slug": "two-bucket",
-        "name": "Two Bucket",
-        "uuid": "07b4679a-3d9f-42bc-ad1e-b9ba272a1c15",
-        "prerequisites": [
-          "atoms",
-          "tuples",
-          "integers",
-          "lists",
-          "pattern-matching",
-          "if",
-          "cond",
-          "case",
-          "structs",
-          "enum",
-          "recursion"
-        ],
-        "practices": [],
-        "difficulty": 7
-       },
-       {
-        "slug": "knapsack",
-        "name": "Knapsack",
-        "uuid": "1770aab6-2289-4134-b6ac-7d346e421e06",
-        "prerequisites": [
-          "atoms",
-          "integers",
-          "lists",
-          "maps",
-          "pattern-matching",
           "recursion",
-          "guards"
-        ],
-        "practices": [],
-        "difficulty": 6
-       },
-       {
-        "slug": "word-search",
-        "name": "Word Search",
-        "uuid": "41ab29d0-e094-4910-bb51-b99bdedc7f17",
-        "prerequisites": [
-          "atoms",
-          "tuples",
-          "lists",
-          "enum",
-          "case",
-          "cond",
+          "structs",
+          "protocols",
           "if",
-          "multiple-clause-functions",
+          "nil",
+          "case",
           "pattern-matching",
-          "guards",
-          "strings",
-          "charlists",
-          "list-comprehensions",
-          "maps",
+          "multiple-clause-functions"
+        ],
+        "practices": [
           "structs"
         ],
+        "difficulty": 8
+      },
+      {
+        "slug": "go-counting",
+        "name": "Go Counting",
+        "uuid": "560347a2-9f20-4bad-b932-72a75ee08e14",
+        "prerequisites": [
+          "atoms",
+          "if",
+          "case",
+          "cond",
+          "strings",
+          "enum",
+          "default-arguments",
+          "guards",
+          "integers",
+          "list-comprehensions",
+          "maps",
+          "pattern-matching",
+          "pipe-operator",
+          "recursion"
+        ],
         "practices": [
           "list-comprehensions"
         ],
-        "difficulty": 7
-       },
-       {
-         "slug": "proverb",
-         "name": "Proverb",
-         "uuid": "e230f49d-e92a-4440-8e7d-733755451cf5",
-         "prerequisites": [
-           "lists",
-           "strings",
-           "pattern-matching",
-           "multiple-clause-functions",
-           "enum"
-         ],
-         "practices": [],
-         "difficulty": 3
-       },
-       {
-        "slug": "house",
-        "name": "House",
-        "uuid": "5ff34497-3a3f-4aaf-b50c-872e7a7b8f51",
+        "difficulty": 9
+      },
+      {
+        "slug": "pov",
+        "name": "POV",
+        "uuid": "abc93451-451d-4497-b590-68cbf82e0a20",
         "prerequisites": [
+          "pattern-matching",
+          "case",
+          "if",
+          "errors",
+          "recursion",
+          "enum",
+          "protocols",
+          "nil",
+          "structs",
+          "multiple-clause-functions"
+        ],
+        "practices": [
+          "recursion"
+        ],
+        "difficulty": 9
+      },
+      {
+        "slug": "zebra-puzzle",
+        "name": "Zebra Puzzle",
+        "uuid": "0a561b08-6e61-4415-a3f1-e7d411a4a0e2",
+        "prerequisites": [
+          "pattern-matching",
+          "case",
+          "cond",
+          "if",
+          "enum",
+          "maps",
+          "atoms"
+        ],
+        "practices": [
+          "enum",
+          "cond"
+        ],
+        "difficulty": 9
+      },
+      {
+        "slug": "forth",
+        "name": "Forth",
+        "uuid": "2abfa3e5-d358-4a07-91f9-d4ad04eb719d",
+        "prerequisites": [
+          "pattern-matching",
+          "multiple-clause-functions",
+          "guards",
+          "strings",
+          "regular-expressions",
+          "maps",
           "lists",
           "enum",
-          "strings",
-          "ranges"
-        ],
-        "practices": [],
-        "difficulty": 3
-       },
-       {
-        "slug": "rectangles",
-        "name": "Rectangles",
-        "uuid": "bc7f9ea3-4e67-406a-91fe-807859fb9c7f",
-        "prerequisites": [
-          "tuples",
-          "maps",
-          "strings",
-          "charlists",
-          "list-comprehensions",
-          "enum",
-          "ranges"
+          "recursion",
+          "cond",
+          "if",
+          "case",
+          "structs",
+          "errors",
+          "exceptions",
+          "dynamic-dispatch"
         ],
         "practices": [
-          "list-comprehensions"
+          "regular-expressions",
+          "errors",
+          "exceptions"
         ],
-        "difficulty": 7
-       }
+        "difficulty": 10
+      }
     ],
     "foregone": [
       "linked-list",


### PR DESCRIPTION
Approach:
- For the automated check that exercises are ordered, I'm using Elixir because writing Elixir scripts is much easier for me than bash, also probably for every other maintainer.
- For the automated reordering, I'm using `jq` because Elixir JSON parsers all parse objects into maps, losing key order information, and thus producing very bad git diffs when encoding the file again.
- To ensure that hello-world is always first, I added a custom `order` field to that exercise only. It will be used before `slug`

Updated questionable difficulties:
- simple-linked-list: 1 -> 4
- markdown: 5 -> 6
- bank-account: 7 -> 5

Unrelated change: mix format on `exs` files in `bin`

Closes https://github.com/exercism/elixir/issues/821