### PR TITLE
Point language-list hints to specific functions

### DIFF
--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -49,12 +49,14 @@ We can achieve the same result by prepending an element to the reversed list, an
 [6 | [5 | [4 | [3, 2, 1]]]] # then reverse!
 ```
 
-There are several common functions for lists:
+There are several common `Kernel` functions for lists:
 
 - [`hd/1`][hd] returns the _head_ of a list -- the _first_ item in a list.
 - [`tl/1`][tl] returns the _tail_ of the list -- the list _minus_ the _first_ item.
 - [`length/1`][length] returns the number items in the list.
 - [`in/2`][in] returns a boolean value indicating whether the item is an element in the list.
+
+There is also the [`List` module][list].
 
 Lists may contain any data type and a mix of different data types.
 

--- a/concepts/lists/introduction.md
+++ b/concepts/lists/introduction.md
@@ -29,7 +29,7 @@ list = [2, 1]
 # => true
 ```
 
-There are several Elixir Kernel functions for working with lists, e.g.
+There are several functions in the `Kernel` module for working with lists, as well as the whole `List` module.
 
 ```elixir
 # Check if 1 is a member of the list

--- a/exercises/concept/language-list/.docs/hints.md
+++ b/exercises/concept/language-list/.docs/hints.md
@@ -16,24 +16,27 @@
 ## 3. Define a function to remove a language from the list
 
 - You need to define a [named function][named-function] with 1 argument. The first argument is a [list][list] of language [string-literals][string].
-- Elixir [provides a function][list-ref] to return a list with the first item removed.
+- Elixir [provides a function][tl] to return a list with the first item removed.
 
 ## 4. Define a function to return the first item in the list
 
 - You need to define a [named function][named-function] with 1 argument. The first argument is a [list][list] of language [string-literals][string].
-- Elixir [provides a function][list-ref] to the first item from a list.
+- Elixir [provides a function][hd] to get the first item from a list.
 
 ## 5. Define a function to return how many languages are in the list
 
 - You need to define a [named function][named-function] with 1 argument. The first argument is a [list][list] of language [string-literals][string].
-- Elixir [provides a function][list-ref] to count the length of a list.
+- Elixir [provides a function][length] to count the length of a list.
 
 ## 6. Define a function to determine if the list is exciting
 
 - You need to define a [named function][named-function] with 1 argument. The first argument is a [list][list] of language [string-literals][string].
-- Your function should return a boolean value indicating whether "Elixir" is a member of the list. Elixir [provides a function][list-ref] to test list membership.
+- Your function should return a boolean value indicating whether `"Elixir"` is a member of the list. Elixir [provides a function][in] to test list membership.
 
 [list]: https://elixir-lang.org/getting-started/basic-types.html#linked-lists
 [named-function]: https://elixir-lang.org/getting-started/modules-and-functions.html#named-functions
 [string]: https://elixir-lang.org/getting-started/basic-types.html#strings
-[list-ref]: https://hexdocs.pm/elixir/List.html
+[hd]: https://hexdocs.pm/elixir/Kernel.html#hd/1
+[tl]: https://hexdocs.pm/elixir/Kernel.html#tl/1
+[length]: https://hexdocs.pm/elixir/Kernel.html#length/1
+[in]: https://hexdocs.pm/elixir/Kernel.html#in/2

--- a/exercises/concept/language-list/.docs/introduction.md
+++ b/exercises/concept/language-list/.docs/introduction.md
@@ -31,7 +31,7 @@ list = [2, 1]
 # => true
 ```
 
-There are several Elixir Kernel functions for working with lists, e.g.
+There are several functions in the `Kernel` module for working with lists, as well as the whole `List` module.
 
 ```elixir
 # Check if 1 is a member of the list


### PR DESCRIPTION
I noticed that the hints for `language-list` all lead to the `List` module, but the intention for the solution was to use the `Kernel` functions like `hd`, `tl` etc. I rewrote the docs a bit to mention that the `List` module exists too, but edited the hints to point to specific functions that should be used in each step.