### PR TITLE
Do not care about emtpy lists in language-list

### DIFF
--- a/exercises/concept/language-list/.docs/instructions.md
+++ b/exercises/concept/language-list/.docs/instructions.md
@@ -24,7 +24,7 @@ LanguageList.new()
 
 ## 3. Define a function to remove a language from the list
 
-Define the `remove/2` function that takes 1 argument (a _language list_). It should return the list without the first item.
+Define the `remove/2` function that takes 1 argument (a _language list_). It should return the list without the first item. Assume the list will always have at least one item.
 
 ```elixir
 LanguageList.new()
@@ -36,7 +36,7 @@ LanguageList.new()
 
 ## 4. Define a function to return the first item in the list
 
-Define the `first/1` function that takes 1 argument (a _language list_). It should return the the first language in the list.
+Define the `first/1` function that takes 1 argument (a _language list_). It should return the the first language in the list. Assume the list will always have at least one item.
 
 ```elixir
 LanguageList.new()

--- a/exercises/concept/language-list/test/language_list_test.exs
+++ b/exercises/concept/language-list/test/language_list_test.exs
@@ -33,11 +33,6 @@ defmodule LanguageListTest do
 
   describe "remove/0" do
     @tag task_id: 3
-    test "remove on an empty list results in error" do
-      assert_raise ArgumentError, fn -> LanguageList.new() |> LanguageList.remove() end
-    end
-
-    @tag task_id: 3
     test "add then remove results in empty list" do
       list =
         LanguageList.new()
@@ -60,11 +55,6 @@ defmodule LanguageListTest do
   end
 
   describe "first/0" do
-    @tag task_id: 4
-    test "first on an empty list raises an error" do
-      assert_raise ArgumentError, fn -> LanguageList.new() |> LanguageList.first() end
-    end
-
     @tag task_id: 4
     test "add one language, then get the first" do
       assert LanguageList.new() |> LanguageList.add("Elixir") |> LanguageList.first() == "Elixir"


### PR DESCRIPTION
Closes https://github.com/exercism/elixir/issues/813

There are at least two different idiomatic solutions that fail those tests, e.g. pattern matching fails because a different error is raised, `List.first` fails because no error is raised. Teaching the difference between those is IMO too detailed for a complete beginner, and rarely of consequence.