### PR TITLE
commented pending tag typo fix

### DIFF
--- a/exercises/practice/pascals-triangle/test/pascals_triangle_test.exs
+++ b/exercises/practice/pascals-triangle/test/pascals_triangle_test.exs
@@ -1,7 +1,7 @@
 defmodule PascalsTriangleTest do
   use ExUnit.Case
 
-  # @tag pending
+  # @tag :pending
   test "one row" do
     assert PascalsTriangle.rows(1) == [[1]]
   end


### PR DESCRIPTION
I noticed this typo while doing the exercise and trying to just run one test when I commented the pending tag back in and it went boom :rofl: