### PR TITLE
Prefer Integer.pow over :math.pow |> round

### DIFF
--- a/exercises/practice/diffie-hellman/.docs/hints.md
+++ b/exercises/practice/diffie-hellman/.docs/hints.md
@@ -2,7 +2,7 @@
 
 - For generating random numbers, Erlang's `:rand.uniform` or `Enum.random` are
 good places to start.
-- `:math.pow |> round` can be used to find the power of a number, and `rem` for
+- `Integer.pow` can be used to find the power of a number, and `rem` for
 the modulus.
 - Neither of those works particularly well (or quickly) for very large integers.
 Cryptography generally makes use of numbers larger than 1024 bits. Erlang's


### PR DESCRIPTION
This tweaks the hints for the diffie-hellman exercise such that instead of suggesting to use :math.pow |> round, it points to Integer.pow.

Integer.pow has only been introduced in Elixir v1.12 but is convenient since it produces integers and works with very large powers, too.

The thoughts on runtime speed still apply though, Integer.pow is not fast enough to deal with the large powers used in the test cases.