### PR TITLE
Add headings to instructions.append.md

### DIFF
--- a/exercises/practice/alphametics/.docs/instructions.append.md
+++ b/exercises/practice/alphametics/.docs/instructions.append.md
@@ -1,1 +1,5 @@
+# Instructions append
+
+## Slow tests
+
 One or several of the tests of this exercise have been tagged as `:slow`, because they might take a long time to finish. For this reason, they will not be run on the platform by the automated test runner. If you are solving this exercise directly on the platform in the web editor, you might want to consider downloading this exercise to your machine instead. This will allow you to run all the tests and check the efficiency of your solution.

--- a/exercises/practice/complex-numbers/.docs/instructions.append.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 In this exercise, complex numbers are represented as a tuple-pair containing the real and imaginary parts.
 
 For example, the real number `1` is `{1, 0}`, the imaginary number `i` is `{0, 1}` and the complex number `4+3i` is `{4, 3}'.

--- a/exercises/practice/custom-set/.docs/instructions.append.md
+++ b/exercises/practice/custom-set/.docs/instructions.append.md
@@ -1,1 +1,3 @@
+# Instructions append
+
 For this exercise please refrain from using the `MapSet` API.

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,1 +1,5 @@
+# Instructions append
+
+## Slow tests
+
 One or several of the tests of this exercise have been tagged as `:slow`, because they might take a long time to finish. For this reason, they will not be run on the platform by the automated test runner. If you are solving this exercise directly on the platform in the web editor, you might want to consider downloading this exercise to your machine instead. This will allow you to run all the tests and check the efficiency of your solution.

--- a/exercises/practice/nth-prime/.docs/instructions.append.md
+++ b/exercises/practice/nth-prime/.docs/instructions.append.md
@@ -1,1 +1,5 @@
+# Instructions append
+
+## Slow tests
+
 One or several of the tests of this exercise have been tagged as `:slow`, because they might take a long time to finish. For this reason, they will not be run on the platform by the automated test runner. If you are solving this exercise directly on the platform in the web editor, you might want to consider downloading this exercise to your machine instead. This will allow you to run all the tests and check the efficiency of your solution.

--- a/exercises/practice/palindrome-products/.docs/instructions.append.md
+++ b/exercises/practice/palindrome-products/.docs/instructions.append.md
@@ -1,1 +1,5 @@
+# Instructions append
+
+## Slow tests
+
 One or several of the tests of this exercise have been tagged as `:slow`, because they might take a long time to finish. For this reason, they will not be run on the platform by the automated test runner. If you are solving this exercise directly on the platform in the web editor, you might want to consider downloading this exercise to your machine instead. This will allow you to run all the tests and check the efficiency of your solution.

--- a/exercises/practice/prime-factors/.docs/instructions.append.md
+++ b/exercises/practice/prime-factors/.docs/instructions.append.md
@@ -1,1 +1,5 @@
+# Instructions append
+
+## Slow tests
+
 One or several of the tests of this exercise have been tagged as `:slow`, because they might take a long time to finish. For this reason, they will not be run on the platform by the automated test runner. If you are solving this exercise directly on the platform in the web editor, you might want to consider downloading this exercise to your machine instead. This will allow you to run all the tests and check the efficiency of your solution.

--- a/exercises/practice/pythagorean-triplet/.docs/instructions.append.md
+++ b/exercises/practice/pythagorean-triplet/.docs/instructions.append.md
@@ -1,1 +1,5 @@
+# Instructions append
+
+## Slow tests
+
 One or several of the tests of this exercise have been tagged as `:slow`, because they might take a long time to finish. For this reason, they will not be run on the platform by the automated test runner. If you are solving this exercise directly on the platform in the web editor, you might want to consider downloading this exercise to your machine instead. This will allow you to run all the tests and check the efficiency of your solution.

--- a/exercises/practice/square-root/.docs/instructions.append.md
+++ b/exercises/practice/square-root/.docs/instructions.append.md
@@ -1,3 +1,3 @@
-# Introduction append
+# Instructions append
 
 Make sure you implement an algorithm that doesn't rely on built-in functions such as `:math.sqrt/1` or `Float.pow/2`.


### PR DESCRIPTION
- Each md file should start with an h1. It will be removed by the platform so its content doesn't matter.
- The new sections about slow test blend into the instructions on the platform, so I thought they deserve their own heading @jiegillet 

![Screen Shot 2021-07-30 at 19 01 44](https://user-images.githubusercontent.com/7852553/127734484-f83bf32e-107b-4158-be51-354a78011b98.png)
