### PR TITLE
Student-facing docs refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![GitHub contributors](https://img.shields.io/github/contributors-anon/exercism/elixir)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/exercism/elixir)
 
-[Exercism Exercises in Elixir](https://exercism.io/my/tracks/elixir)
+[Exercism Exercises in Elixir](https://exercism.io/tracks/elixir)
 
 ## Setup
 

--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -36,7 +36,7 @@ Or, you can enable all the tests by commenting out the
 ```
 
 If you're stuck on something, it may help to look at some of
-the [available resources](https://exercism.io/tracks/elixir/resources)
+the [available resources](https://exercism.io/docs/tracks/elixir/resources)
 out there where answers might be found.
 {{ with .Spec.Credits }}
 ## Source

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -2,7 +2,7 @@
 
 [Elixir](http://elixir-lang.org/), initially released in 2012, extends upon the already robust features of Erlang while also being easier for beginners to access, read, test, and write.
 
-José Valim, the creator of Elixir, explains [here](https://vimeo.com/53221562) how he built the language for applications to be:
+José Valim, the creator of Elixir, explains [in his 2012 conference talk](https://vimeo.com/53221562) how he built the language for applications to be:
 
   1. Distributed
   2. Fault-Tolerant

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,6 +2,6 @@
 
 ## Installation
 
-Detailed installation instructions can be found at [http://elixir-lang.org/install.html](http://elixir-lang.org/install.html).
+Detailed installation instructions can be found at [elixir-lang.org/install](http://elixir-lang.org/install.html).
 
 Help can be found on [Exercism's BEAM Gitter channel](https://gitter.im/exercism/xerlang)

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,8 +1,11 @@
 # Learning
 
-Exercism provides exercises and feedback but can be difficult to jump into for
-those learning Elixir for the first time. These resources can help you get
-started:
+We recommend learning Elixir by working through the syllabus and learning exercises on Exercism.
+They were designed to teach you Elixir from scratch.
+
+The official [Elixir Getting Started Guide](http://elixir-lang.org/getting-started/introduction.html) is also an excellent place to start.
+
+## Additional learning resources
 
 * [Elixir Getting Started Guide](http://elixir-lang.org/getting-started/introduction.html)
 * [Elixir Documentation](https://hexdocs.pm/elixir/)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -2,32 +2,27 @@
 
 ## Elixir Documentation
 
-* [Elixir Docs](https://hexdocs.pm/elixir/)
+* [Elixir](https://hexdocs.pm/elixir/)
+* [ExUnit](https://hexdocs.pm/ex_unit/ExUnit.html) - unit testing framework for Elixir
+* [Hex](https://hex.pm/) - a package manager for the Erlang ecosystem
 
-## Hex - A package manager for the Erlang ecosystem.
+## Communication channels
 
-* [Hex Docs](https://hex.pm/)
-
-## Testing with ExUnit
-
-* [ExUnit](https://hexdocs.pm/ex_unit/ExUnit.html)
-
-## Elixir IRC
-
+* [Exercism's BEAM Gitter Channel](https://gitter.im/exercism/xerlang)
+* [Elixir Forum](https://elixirforum.com/)
+* [Slack](https://elixir-slackin.herokuapp.com/)
+* [Discord](https://discord.gg/elixir)
 * [Official #elixir on irc.libera.chat](irc://irc.libera.chat/elixir)
 
-## Slack
+## Elixir Podcasts
 
-* [Request an Invite](https://elixir-slackin.herokuapp.com/)
+- [Thinking Elixir](https://thinkingelixir.com/the-podcast/)
+- [Elixir Wizards](https://smartlogic.io/podcast/elixir-wizards/)
+- [Elixir Mix](https://devchat.tv/elixir-mix/)
+- [Elixir Outlaws](https://elixiroutlaws.com/)
+- [BEAM Radio](https://www.beamrad.io/)
 
-## Discord
+## Elixir Newsletters
 
-* [Request an Invite](https://discord.gg/elixir)
-
-## Exercism's BEAM Gitter Channel
-
-* [Gitter channel](https://gitter.im/exercism/xerlang)
-
-## Elixir Forum
-
-* [Elixir Forum](https://elixirforum.com/)
+- [ElixirWeekly](https://elixirweekly.net/)
+- [Elixir Radar](https://elixir-radar.com/)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -20,6 +20,10 @@
 
 * [Request an Invite](https://elixir-slackin.herokuapp.com/)
 
+## Discord
+
+* [Request an Invite](https://discord.gg/elixir)
+
 ## Exercism's BEAM Gitter Channel
 
 * [Gitter channel](https://gitter.im/exercism/xerlang)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -14,7 +14,7 @@
 
 ## Elixir IRC
 
-* [Elixir IRC](http://irc.lc/freenode/elixir)
+* [Official #elixir on irc.libera.chat](irc://irc.libera.chat/elixir)
 
 ## Slack
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -42,7 +42,7 @@ format. These are used in Elixir and Erlang as documentation and
 in conjunction with a tool called Dialyzer to find type inconsistencies
 and possible bugs. For more information see the
 [Elixir typespecs guide](http://elixir-lang.org/getting-started/typespecs-and-behaviours.html)
-or the [typespecs documentation](http://elixir-lang.org/docs/stable/elixir/typespecs.html). For
+or the [typespecs documentation](https://hexdocs.pm/elixir/typespecs.html). For
 documentation about Dialyzer see [Erlang -- dialyzer](http://erlang.org/doc/man/dialyzer.html).
 
 Optionally, you may want to check

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -1,4 +1,4 @@
 # Help
 
-If you're stuck on something, it may help to look at some of the [available resources](https://exercism.io/tracks/elixir/resources) out there where answers might be found.
+If you're stuck on something, it may help to look at some of the [available resources](https://exercism.io/docs/tracks/elixir/resources) out there where answers might be found.
 If you can't find what you're looking for in the documentation, feel free to ask help in the Exercism's BEAM [gitter channel](https://gitter.im/exercism/xerlang).


### PR DESCRIPTION
At first I only wanted to fix links for v3, e.g.:
- `https://exercism.io/tracks/elixir/resources` -> `https://exercism.io/docs/tracks/elixir/resources`
- `https://exercism.io/my/tracks/elixir` -> `https://exercism.io/tracks/elixir`

But then I read the docs and also decided to:
- Rephrase "learning" because it suggested that Exercism is not good for LEARNING Elixir, which is no longer true with the syllabus.
- Reformat resources because it was a bit silly to have each link in a one-element list with its own heading. I also added a list of podcasts and newsletters.
- I fixed the outdated IRC link and added a Discord link.

Closes https://github.com/exercism/elixir/issues/850