### PR TITLE
Add more test cases for bread-and-potions

### DIFF
--- a/concepts/protocols/introduction.md
+++ b/concepts/protocols/introduction.md
@@ -2,7 +2,7 @@
 
 Protocols are a mechanism to achieve polymorphism in Elixir when you want behavior to vary depending on the data type.
 
-Protocols are defined using `defprotocol` and contain one or more function header.
+Protocols are defined using `defprotocol` and contain one or more function headers.
 
 ```elixir
 defprotocol Reversible do

--- a/exercises/concept/bread-and-potions/.docs/introduction.md
+++ b/exercises/concept/bread-and-potions/.docs/introduction.md
@@ -4,7 +4,7 @@
 
 Protocols are a mechanism to achieve polymorphism in Elixir when you want behavior to vary depending on the data type.
 
-Protocols are defined using `defprotocol` and contain one or more function header.
+Protocols are defined using `defprotocol` and contain one or more function headers.
 
 ```elixir
 defprotocol Reversible do

--- a/exercises/concept/bread-and-potions/test/rpg_test.exs
+++ b/exercises/concept/bread-and-potions/test/rpg_test.exs
@@ -41,6 +41,13 @@ defmodule RPGTest do
       {byproduct, %Character{}} = Edible.eat(%LoafOfBread{}, character)
       assert byproduct == nil
     end
+
+    @tag task_id: 2
+    test "eating it does not affect mana" do
+      character = %Character{mana: 77}
+      {_byproduct, %Character{} = character} = Edible.eat(%LoafOfBread{}, character)
+      assert character.mana == 77
+    end
   end
 
   describe "ManaPotion" do
@@ -63,6 +70,13 @@ defmodule RPGTest do
       {byproduct, %Character{}} = Edible.eat(%ManaPotion{}, character)
       assert byproduct == %EmptyBottle{}
     end
+
+    @tag task_id: 3
+    test "eating it does not affect health" do
+      character = %Character{health: 4}
+      {_byproduct, %Character{} = character} = Edible.eat(%ManaPotion{strength: 6}, character)
+      assert character.health == 4
+    end
   end
 
   describe "Poison" do
@@ -84,6 +98,13 @@ defmodule RPGTest do
       character = %Character{}
       {byproduct, %Character{}} = Edible.eat(%Poison{}, character)
       assert byproduct == %EmptyBottle{}
+    end
+
+    @tag task_id: 4
+    test "eating it does not affect mana" do
+      character = %Character{mana: 99}
+      {_byproduct, %Character{} = character} = Edible.eat(%Poison{}, character)
+      assert character.mana == 99
     end
   end
 


### PR DESCRIPTION
Adding an extra test case for each edible item to check that it doesn't affect the other property (mana vs health). If you accidentally overwrite one of those in the protocol implementation, only the last test will fail which might not be that straight-forward to debug.