### PR TITLE
Simple cipher remove test: do not check what happens with invalid input

### DIFF
--- a/exercises/practice/simple-cipher/test/simple_cipher_test.exs
+++ b/exercises/practice/simple-cipher/test/simple_cipher_test.exs
@@ -73,18 +73,6 @@ defmodule SimpleCipherTest do
   end
 
   @tag :pending
-  test "only lowercase a-z are translated, rest are passed through" do
-    assert SimpleCipher.encode("this is a test!", "d") == "wklv lv d whvw!"
-    assert SimpleCipher.decode("wklv lv d whvw!", "d") == "this is a test!"
-  end
-
-  @tag :pending
-  test "passed through letters consume key letters" do
-    assert SimpleCipher.encode("this is a test!", "abc") == "tiks ks c ugsu!"
-    assert SimpleCipher.decode("tiks ks c ugsu!", "abc") == "this is a test!"
-  end
-
-  @tag :pending
   test "can encode messages longer than the key" do
     assert SimpleCipher.encode("abc", "a") == "abc"
     assert SimpleCipher.encode("abcdefghi", "abc") == "acedfhgik"


### PR DESCRIPTION
Fix #851.

I'm not pushing this particular fix, dropping `"only lowercase a-z are translated, rest are passed through"` is another valid resolution, but I made the change on my work laptop, and I probably won't have it later. Feel free to pick your preferred fix @angelikatyborska  :)

PS: sorry for the messy commits, I have to rush a bit.