### PR TITLE
Adding test for `newsletter`

### DIFF
--- a/exercises/concept/newsletter/.meta/design.md
+++ b/exercises/concept/newsletter/.meta/design.md
@@ -25,4 +25,6 @@
 ## Analyzer
 
 - ensure that `log_sent_email/2`, `close_log/0`, and `send_newsletter/3` don't return `:ok` explicitly, but implicitly (from `File.close` etc.)
-- ensure that `send_newsletter/3` calls `open_log/1` and `close_log/1` exactly once each, and doesn't use `File.write`.
+- ensure that `open_log/1` uses `File.open!` with the option `[:write]`
+- ensure that `send_newsletter/3` calls `open_log/1` and `close_log/1` 
+- ensure that `send_newsletter/3` doesn't use `File.write`.

--- a/exercises/concept/newsletter/.meta/design.md
+++ b/exercises/concept/newsletter/.meta/design.md
@@ -26,5 +26,5 @@
 
 - ensure that `log_sent_email/2`, `close_log/0`, and `send_newsletter/3` don't return `:ok` explicitly, but implicitly (from `File.close` etc.)
 - ensure that `open_log/1` uses `File.open!` with the option `[:write]`
-- ensure that `send_newsletter/3` calls `open_log/1` and `close_log/1` 
+- ensure that `send_newsletter/3` calls `open_log/1` and `close_log/1`
 - ensure that `send_newsletter/3` doesn't use `File.write`.

--- a/exercises/concept/newsletter/test/newsletter_test.exs
+++ b/exercises/concept/newsletter/test/newsletter_test.exs
@@ -147,6 +147,21 @@ defmodule NewsletterTest do
     end
 
     @tag task_id: 5
+    test "sending the same newsletter twice resets the log" do
+      send_fun = fn _ -> :ok end
+      Newsletter.send_newsletter(Path.join(["assets", "emails.txt"]), @temp_file_path, send_fun)
+      Newsletter.send_newsletter(Path.join(["assets", "emails.txt"]), @temp_file_path, send_fun)
+
+      assert File.read!(@temp_file_path) ==
+               """
+               alice@example.com
+               bob@example.com
+               charlie@example.com
+               dave@example.com
+               """
+    end
+
+    @tag task_id: 5
     test "logs the email immediately after it was sent" do
       send_fun = fn email ->
         case email do


### PR DESCRIPTION
Add a test to check if repeated used of `send_newsletter` overwrites log file, to prevent use of `:append`.

Also adjusts `design.md` according to [this discussion](https://github.com/exercism/elixir-analyzer/pull/129).