### PR TITLE
Fix typos in the HighScore exercise introduction

### DIFF
--- a/concepts/maps/introduction.md
+++ b/concepts/maps/introduction.md
@@ -23,4 +23,4 @@ While there is no canonical format, choose a consistent way to represent the key
 
 ## Map module functions
 
-Elixir provides many functions for working with maps in the _Map module_. Some _Map module_ functions require an _anonymous_ function_ to be passed into the function to assist with the map transformation.
+Elixir provides many functions for working with maps in the _Map module_. Some _Map module_ functions require an _anonymous_ function to be passed into the function to assist with the map transformation.

--- a/concepts/module-attributes-as-constants/introduction.md
+++ b/concepts/module-attributes-as-constants/introduction.md
@@ -9,7 +9,7 @@ defmodule Example do
   @constant_number 1
 
   def example_value() do
-    # Returns the value 2
+    # Returns the value 1
     @constant_number
   end
 end

--- a/exercises/concept/high-score/.docs/introduction.md
+++ b/exercises/concept/high-score/.docs/introduction.md
@@ -25,7 +25,7 @@ While there is no canonical format, choose a consistent way to represent the key
 
 ### Map module functions
 
-Elixir provides many functions for working with maps in the _Map module_. Some _Map module_ functions require an _anonymous_ function_ to be passed into the function to assist with the map transformation.
+Elixir provides many functions for working with maps in the _Map module_. Some _Map module_ functions require an _anonymous_ function to be passed into the function to assist with the map transformation.
 
 ## Module Attributes As Constants
 
@@ -38,7 +38,7 @@ defmodule Example do
   @constant_number 1
 
   def example_value() do
-    # Returns the value 2
+    # Returns the value 1
     @constant_number
   end
 end


### PR DESCRIPTION
`Example.example_value/0` definitely shouldn't return the value `2`!

<img width="408" alt="Screen Shot 2021-09-04 at 11 32 38 am" src="https://user-images.githubusercontent.com/543859/132081080-9c47b653-0965-45f3-acc5-045694fc7495.png">
