### PR TITLE
Correct WineCellar.filter examples

### DIFF
--- a/exercises/concept/wine-cellar/.docs/instructions.md
+++ b/exercises/concept/wine-cellar/.docs/instructions.md
@@ -29,10 +29,10 @@ A bottle of wine is represented as a 3-tuple of grape variety, year, and country
 ]
 ```
 
-Implement the `WineCellar.filter/3` function. It should take a keyword list of wines sorted by color and a keyword list of options, with a default value of `[]`. The function should return a list of wines of a given color.
+Implement the `WineCellar.filter/3` function. It should take a keyword list of wines, a color atom and a keyword list of options, with a default value of `[]`. The function should return a list of wines of a given color.
 
 ```elixir
-WineCellar.filter([
+WineCellar.filter(
   [
     white: {"Chardonnay", 2015, "Italy"},
     white: {"Pinot grigio", 2017, "Germany"},
@@ -40,7 +40,7 @@ WineCellar.filter([
     rose: {"Dornfelder", 2018, "Germany"}
   ],
   :white
-])
+)
 # => [
 #      {"Chardonnay", 2015, "Italy"},
 #      {"Pinot grigio", 2017, "Germany"}
@@ -54,7 +54,7 @@ Extend the `WineCellar.filter/3` function. When given a `:year` option, the func
 Use the already-implemented `WineCellar.filter_by_year/2` function. It takes a list of wines and a year as arguments and returns a list of wines from a given year.
 
 ```elixir
-WineCellar.filter([
+WineCellar.filter(
   [
     white: {"Chardonnay", 2015, "Italy"},
     white: {"Pinot grigio", 2017, "Germany"},
@@ -63,7 +63,7 @@ WineCellar.filter([
   ],
   :white,
   year: 2017
-])
+)
 # => [
 #      {"Chardonnay", 2015, "Italy"},
 #    ]
@@ -78,7 +78,7 @@ Use the already-implemented `WineCellar.filter_by_country/2` function. It takes 
 Make sure that the function works when given both the `:year` and the `:country` option, in any order.
 
 ```elixir
-WineCellar.filter([
+WineCellar.filter(
   [
     white: {"Chardonnay", 2015, "Italy"},
     white: {"Pinot grigio", 2017, "Germany"},
@@ -88,6 +88,6 @@ WineCellar.filter([
   :white,
   year: 2017,
   country: "Germany"
-])
+)
 # => []
 ```

--- a/exercises/concept/wine-cellar/.docs/instructions.md
+++ b/exercises/concept/wine-cellar/.docs/instructions.md
@@ -62,10 +62,10 @@ WineCellar.filter(
     rose: {"Dornfelder", 2018, "Germany"}
   ],
   :white,
-  year: 2017
+  year: 2015
 )
 # => [
-#      {"Chardonnay", 2015, "Italy"},
+#      {"Chardonnay", 2015, "Italy"}
 #    ]
 ```
 
@@ -86,7 +86,7 @@ WineCellar.filter(
     rose: {"Dornfelder", 2018, "Germany"}
   ],
   :white,
-  year: 2017,
+  year: 2015,
   country: "Germany"
 )
 # => []


### PR DESCRIPTION
For `filter(cellar, color, opts \\ [])` we show examples like `WineCellar.filter([[...], x, y])` (a list in a list as the only argument).

In a task the required color atom was not mentioned, instead it told us `fn takes wines sorted by color`. I fixed that small typo there, as we even test with unsorted lists, eg.:
```
cellar = [
  white: {"Chardonnay", 2015, "Italy"},
  white: {"Chardonnay", 2014, "France"},
  rose: {"Dornfelder", 2018, "Germany"},
  red: {"Merlot", 2015, "France"},
  white: {"Riesling ", 2017, "Germany"},
  white: {"Pinot grigio", 2015, "Germany"},
  red: {"Pinot noir", 2016, "France"},
  red: {"Pinot noir", 2013, "Italy"}
]
```
