### PR TITLE
Remove duplicate `@type acc` definition in ListOps

### DIFF
--- a/exercises/practice/list-ops/lib/list_ops.ex
+++ b/exercises/practice/list-ops/lib/list_ops.ex
@@ -26,7 +26,6 @@ defmodule ListOps do
   def foldl(l, acc, f) do
   end
 
-  @type acc :: any
   @spec foldr(list, acc, (any, acc -> acc)) :: acc
   def foldr(l, acc, f) do
   end


### PR DESCRIPTION
This stops the tests from running on a fresh exercise start:

```
== Compilation error in file lib/list_ops.ex ==
** (CompileError) lib/list_ops.ex:29: type acc/0 is already defined in lib/list_ops.ex:24
```