### PR TITLE
Fix ambiguity (plural forms) in kitchen-calculator exercise

### DIFF
--- a/exercises/concept/kitchen-calculator/.docs/instructions.md
+++ b/exercises/concept/kitchen-calculator/.docs/instructions.md
@@ -50,6 +50,6 @@ KitchenCalculator.from_milliliter({:milliliter, 1320.0}, :cup)
 Implement the `KitchenCalculator.convert/2` function. Given a volume-pair tuple and the desired unit, it should convert the given volume to the desired unit.
 
 ```elixir
-KitchenCalculator.convert({:teaspoons, 9.0}, :tablespoon)
+KitchenCalculator.convert({:teaspoon, 9.0}, :tablespoon)
 # => {:tablespoon, 3.0}
 ```

--- a/exercises/concept/kitchen-calculator/test/kitchen_calculator_test.exs
+++ b/exercises/concept/kitchen-calculator/test/kitchen_calculator_test.exs
@@ -14,12 +14,12 @@ defmodule KitchenCalculatorTest do
 
     @tag task_id: 1
     test "get teaspoons" do
-      assert KitchenCalculator.get_volume({:teaspoons, 3}) == 3
+      assert KitchenCalculator.get_volume({:teaspoon, 3}) == 3
     end
 
     @tag task_id: 1
     test "get tablespoons" do
-      assert KitchenCalculator.get_volume({:tablespoons, 4}) == 4
+      assert KitchenCalculator.get_volume({:tablespoon, 4}) == 4
     end
 
     @tag task_id: 1


### PR DESCRIPTION
This addresses issue #880 as proposed: all three instances of plural forms of atoms that had slipped through are removed (replaced by their singular counterparts, as specified in the exercise description).