### PR TITLE
Remove prerequisites from deprecated Practice Exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -1154,18 +1154,7 @@
         "slug": "binary",
         "name": "Binary",
         "uuid": "29c3c9ff-c7f3-4646-9612-7cd768d237ab",
-        "prerequisites": [
-          "cond",
-          "case",
-          "if",
-          "multiple-clause-functions",
-          "pattern-matching",
-          "binaries",
-          "recursion",
-          "tail-call-recursion",
-          "enum",
-          "strings"
-        ],
+        "prerequisites": [],
         "practices": [
           "tail-call-recursion"
         ],
@@ -1319,17 +1308,7 @@
         "slug": "hexadecimal",
         "name": "Hexadecimal",
         "uuid": "8154a099-5d6f-4e71-83fe-45ab23475778",
-        "prerequisites": [
-          "strings",
-          "charlists",
-          "ranges",
-          "multiple-clause-functions",
-          "guards",
-          "pattern-matching",
-          "case",
-          "recursion",
-          "enum"
-        ],
+        "prerequisites": [],
         "practices": [
           "charlists"
         ],


### PR DESCRIPTION
From [the spec](https://github.com/exercism/docs/blob/14de83e5305b/building/configlet/lint.md#rule-configjson-file-is-valid):

> - The `"exercises.practice[].prerequisites"` value must be an empty
    array if `"exercises.practice[].status"` is equal to `deprecated`

---

This PR resolves an otherwise-upcoming CI failure - `configlet lint` will enforce this rule in the future.

The `mensch-aergere-dich-nicht` concept exercise is also deprecated, but already had an empty `prerequisites` array.

