### PR TITLE
Remove `practices` from deprecated Practice Exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -1155,9 +1155,7 @@
         "name": "Binary",
         "uuid": "29c3c9ff-c7f3-4646-9612-7cd768d237ab",
         "prerequisites": [],
-        "practices": [
-          "tail-call-recursion"
-        ],
+        "practices": [],
         "difficulty": 3,
         "status": "deprecated"
       },
@@ -1309,9 +1307,7 @@
         "name": "Hexadecimal",
         "uuid": "8154a099-5d6f-4e71-83fe-45ab23475778",
         "prerequisites": [],
-        "practices": [
-          "charlists"
-        ],
+        "practices": [],
         "difficulty": 3,
         "status": "deprecated"
       },


### PR DESCRIPTION
This commit resolves an otherwise-upcoming CI failure, because
`configlet lint` will enforce this rule in the future.

From the spec [1]:

- The `"exercises.practice[].practices"` value must be an empty array if
  `"exercises.practice[].status"` is equal to `deprecated`

[1] https://github.com/exercism/docs/blob/14de83e5305b/building/configlet/lint.md#rule-configjson-file-is-valid

---

This PR is a follow-up from https://github.com/exercism/elixir/pull/889#issuecomment-913819317