### PR TITLE
Fixed typo in High Score exercise section 5 description

### DIFF
--- a/exercises/concept/high-score/.docs/instructions.md
+++ b/exercises/concept/high-score/.docs/instructions.md
@@ -64,7 +64,7 @@ score_map = HighScore.reset_score(score_map, "José Valim")
 
 ## 5. Update a player's score
 
-To update a players score by adding to the previous score, define `HighScore.update_score/3`, which takes 3 arguments:
+To update a player's score by adding to the previous score, define `HighScore.update_score/3`, which takes 3 arguments:
 
 - The first argument is the map of scores.
 - The second argument is the name of the player as a string, whose score you wish to update.


### PR DESCRIPTION
The description of section 5 of the High Score exercise has a "players" where it should read "player's".

This PR fixes said typo.