### PR TITLE
Fixed example format in German Sysadmin exercise

### DIFF
--- a/exercises/concept/german-sysadmin/.docs/instructions.md
+++ b/exercises/concept/german-sysadmin/.docs/instructions.md
@@ -39,5 +39,5 @@ Extend the `sanitize/1` function. It should substitute German characters accordi
 
 ```elixir
 Username.sanitize('cäcilie_weiß')
-'caecilie_weiss'
+# => 'caecilie_weiss'
 ```


### PR DESCRIPTION
The last example in the German Sysadmin exercise description has a different format from the rest that students find thus far.

IMO, the format of this example would be preferable, since it is slightly confusing to find the `# =>`  prefix before the expected outputs in examples, given that both `#`  and especially `=>` are meaningful symbols in Elixir. Thus, a better alternative (but this might be opinionated, and this opinion based on my lack of knowledge about Exercism restrictions or the like) would be to eliminate said prefix from all other examples in the track. Given that this seems rather extreme, at least this PR makes this example layout coherent with all the rest.