### PR TITLE
Fixed typo in Date Parser exercise section 2 description

### DIFF
--- a/exercises/concept/date-parser/.docs/instructions.md
+++ b/exercises/concept/date-parser/.docs/instructions.md
@@ -25,7 +25,7 @@ Do not worry about error checking. You can assume you will always be passed a va
 
 ## 2. Match the day of the week and the month of the year
 
-Implement `day_names/0` and `month_names/0` to return a string pattern which, when compiled, would match the any named day of the week and the named month of the year respectively.
+Implement `day_names/0` and `month_names/0` to return a string pattern which, when compiled, would match the named day of the week and the named month of the year respectively.
 
 ```elixir
 "Tuesday" =~ DateParser.day_names() |> Regex.compile!()


### PR DESCRIPTION
The description of section 2 of the Date Parser exercise has a "the any named day" where it should read "the named day".

This PR fixes said typo.