### PR TITLE
Fixed extra comman in Boutique Inventory exercise section 2 example

### DIFF
--- a/exercises/concept/boutique-inventory/.docs/instructions.md
+++ b/exercises/concept/boutique-inventory/.docs/instructions.md
@@ -46,7 +46,7 @@ BoutiqueInventory.with_missing_price([
 ])
 # => [
 #      %{price: nil, name: "Denim Pants", quantity_by_size: %{}},
-#      %{price: nil, name: "Denim Skirt", quantity_by_size: %{}},
+#      %{price: nil, name: "Denim Skirt", quantity_by_size: %{}}
 #    ]
 ```
 


### PR DESCRIPTION
The example in section 2 of the Boutique Inventory exercise has an extra comma. This is of course harmless, but fixing it is convenient for students to copy & paste while solving the exercise.

This PR fixes said extra comma.