### PR TITLE
Fixed name of function in Basketball Website exercise.

### DIFF
--- a/exercises/concept/basketball-website/.docs/instructions.md
+++ b/exercises/concept/basketball-website/.docs/instructions.md
@@ -4,7 +4,7 @@ You are working with a web development team to maintain a website for a local ba
 
 ## 1. Extract data from a nested map structure
 
-Implement the `extract_from/2` function to take two arguments:
+Implement the `extract_from_path/2` function to take two arguments:
 
 - `data`: a nested map structure with data about the basketball team.
 - `path`: a string consisting of period-delimited keys to obtain the value associated with the last key.
@@ -20,9 +20,9 @@ data = %{
     }
   }
 }
-BasketballWebsite.extract_from(data, "team_mascot.animal")
+BasketballWebsite.extract_from_path(data, "team_mascot.animal")
 # => "bear"
-BasketballWebsite.extract_from(data, "team_mascot.colors")
+BasketballWebsite.extract_from_path(data, "team_mascot.colors")
 # => nil
 ```
 


### PR DESCRIPTION
The Basketball Website uses the name `extract_from/2`, but the code skeleton (and tests) uses `extract_from_path/2`.

The latter is consistent with the `get_in_path/2`, which cannot be named just `get_in/2` because of a collision with the `Kernel` function the student is supposed to use.

Hence, the coherent way of solving this issue is sticking with the `extract_from_path/2` name, and using it in the exercise description. This PR solves the issue in this way.