### PR TITLE
update test names & new test showing order semantic differences between from_list/1 and push/2

### DIFF
--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -12,7 +12,8 @@
     "neenjaw",
     "parkerl",
     "percygrunwald",
-    "sotojuan"
+    "sotojuan",
+    "czrpb"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/simple-linked-list/test/linked_list_test.exs
+++ b/exercises/practice/simple-linked-list/test/linked_list_test.exs
@@ -130,7 +130,8 @@ defmodule LinkedListTest do
     ll_via_from_list = LinkedList.from_list(list)
     ll_via_pushed = Enum.reduce(list, LinkedList.new(), &LinkedList.push(&2, &1))
 
-    assert LinkedList.to_list(ll_via_from_list) == LinkedList.to_list(ll_via_pushed) |> Enum.reverse
+    assert LinkedList.to_list(ll_via_from_list) ==
+             LinkedList.to_list(ll_via_pushed) |> Enum.reverse()
   end
 
   @tag :pending

--- a/exercises/practice/simple-linked-list/test/linked_list_test.exs
+++ b/exercises/practice/simple-linked-list/test/linked_list_test.exs
@@ -97,7 +97,7 @@ defmodule LinkedListTest do
   end
 
   @tag :pending
-  test "from_list/1 of 2 element list" do
+  test "from_list/1 of 2 element list, keeping order" do
     list = LinkedList.from_list([:a, :b])
     assert LinkedList.length(list) == 2
     assert {:ok, :a, list} = LinkedList.pop(list)
@@ -118,7 +118,7 @@ defmodule LinkedListTest do
   end
 
   @tag :pending
-  test "to_list/1 of list of 2 datum" do
+  test "to_list/1 of list of 2 datum, keeping order" do
     list = LinkedList.from_list([:mon, :tues])
     assert LinkedList.to_list(list) == [:mon, :tues]
   end

--- a/exercises/practice/simple-linked-list/test/linked_list_test.exs
+++ b/exercises/practice/simple-linked-list/test/linked_list_test.exs
@@ -124,6 +124,16 @@ defmodule LinkedListTest do
   end
 
   @tag :pending
+  test "from_list/1 and successive push/2 of a list result in reversed order" do
+    list = [:mon, :tues]
+
+    ll_via_from_list = LinkedList.from_list(list)
+    ll_via_pushed = Enum.reduce(list, LinkedList.new(), &LinkedList.push(&2, &1))
+
+    assert LinkedList.to_list(ll_via_from_list) == LinkedList.to_list(ll_via_pushed) |> Enum.reverse
+  end
+
+  @tag :pending
   test "reverse/1 of list of 2 datum" do
     list = LinkedList.from_list([1, 2, 3]) |> LinkedList.reverse()
     assert LinkedList.to_list(list) == [3, 2, 1]

--- a/exercises/practice/simple-linked-list/test/linked_list_test.exs
+++ b/exercises/practice/simple-linked-list/test/linked_list_test.exs
@@ -127,11 +127,11 @@ defmodule LinkedListTest do
   test "from_list/1 and successive push/2 of a list result in reversed order" do
     list = [:mon, :tues]
 
-    ll_via_from_list = LinkedList.from_list(list)
-    ll_via_pushed = Enum.reduce(list, LinkedList.new(), &LinkedList.push(&2, &1))
+    from_list = LinkedList.from_list(list)
+    push_list = Enum.reduce(list, LinkedList.new(), &LinkedList.push(&2, &1))
 
-    assert LinkedList.to_list(ll_via_from_list) ==
-             LinkedList.to_list(ll_via_pushed) |> Enum.reverse()
+    assert LinkedList.to_list(from_list) ==
+             LinkedList.to_list(push_list) |> Enum.reverse()
   end
 
   @tag :pending


### PR DESCRIPTION
I initially wrote `from_list/1` as successive `push/2` but that failed the `from_list/1` & `to_list/1` tests.

This is not the intended semantics of `from_list/1`.

This PR updates 2 test names and adds a new test making this (hopefully!) clearer and at least explicit.