### PR TITLE
#907 - Date Parser - Removed a line from instructions to better match the tests

### DIFF
--- a/exercises/concept/date-parser/.docs/instructions.md
+++ b/exercises/concept/date-parser/.docs/instructions.md
@@ -12,8 +12,6 @@ You can see there are some similarities between each of them, and decide to writ
 
 Implement `day/0`, `month/0`, and `year/0` to return a string pattern which, when compiled, would match the numeric components in `"01/01/1970"` (`dd/mm/yyyy`). The day and month may appear as `1` or `01` (left padded with zeroes).
 
-Do not worry about error checking. You can assume you will always be passed a valid numeric component.
-
 ```elixir
 "31" =~ DateParser.day() |> Regex.compile!()
 # => true


### PR DESCRIPTION
The instructions say it can be assumed that the code will always be passed a valid numeric component. The tests, however, do not always pass a numeric component nor a valid numeric component, so I removed that line from the instructions.