### PR TITLE
Add more tests in `rpn-calculator` concept

### DIFF
--- a/exercises/concept/rpn-calculator/.meta/config.json
+++ b/exercises/concept/rpn-calculator/.meta/config.json
@@ -5,7 +5,8 @@
     "neenjaw"
   ],
   "contributors": [
-    "angelikatyborska"
+    "angelikatyborska",
+    "cjmaxik"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/rpn-calculator/test/rpn_calculator_test.exs
+++ b/exercises/concept/rpn-calculator/test/rpn_calculator_test.exs
@@ -33,9 +33,7 @@ defmodule RPNCalculatorTest do
 
   @tag task_id: 3
   test "rescue the crash, get error tuple with message" do
-    assert RPNCalculator.calculate_verbose(
-             [],
-             operation = fn _ -> raise ArgumentError, "test error" end
-           ) == @test_error
+    assert RPNCalculator.calculate_verbose([], fn _ -> raise ArgumentError, "test error" end) ==
+             @test_error
   end
 end

--- a/exercises/concept/rpn-calculator/test/rpn_calculator_test.exs
+++ b/exercises/concept/rpn-calculator/test/rpn_calculator_test.exs
@@ -1,9 +1,6 @@
 defmodule RPNCalculatorTest do
   use ExUnit.Case
 
-  @success {:ok, "operation completed"}
-  @test_error {:error, "test error"}
-
   @tag task_id: 1
   test "calculate! returns an :ok atom" do
     assert RPNCalculator.calculate!([], fn _ -> :ok end) == :ok
@@ -18,7 +15,8 @@ defmodule RPNCalculatorTest do
 
   @tag task_id: 2
   test "calculate returns a tuple" do
-    assert RPNCalculator.calculate([], fn _ -> "operation completed" end) == @success
+    assert RPNCalculator.calculate([], fn _ -> "operation completed" end) ==
+             {:ok, "operation completed"}
   end
 
   @tag task_id: 2
@@ -28,12 +26,13 @@ defmodule RPNCalculatorTest do
 
   @tag task_id: 3
   test "calculate_verbose returns a tuple" do
-    assert RPNCalculator.calculate_verbose([], fn _ -> "operation completed" end) == @success
+    assert RPNCalculator.calculate_verbose([], fn _ -> "operation completed" end) ==
+             {:ok, "operation completed"}
   end
 
   @tag task_id: 3
   test "rescue the crash, get error tuple with message" do
     assert RPNCalculator.calculate_verbose([], fn _ -> raise ArgumentError, "test error" end) ==
-             @test_error
+             {:error, "test error"}
   end
 end

--- a/exercises/concept/rpn-calculator/test/rpn_calculator_test.exs
+++ b/exercises/concept/rpn-calculator/test/rpn_calculator_test.exs
@@ -33,7 +33,9 @@ defmodule RPNCalculatorTest do
 
   @tag task_id: 3
   test "rescue the crash, get error tuple with message" do
-    assert RPNCalculator.calculate_verbose([], fn _ -> raise "test error" end) ==
-             {:error, "test error"}
+    assert RPNCalculator.calculate_verbose(
+             [],
+             operation = fn _ -> raise ArgumentError, "test error" end
+           ) == @test_error
   end
 end

--- a/exercises/concept/rpn-calculator/test/rpn_calculator_test.exs
+++ b/exercises/concept/rpn-calculator/test/rpn_calculator_test.exs
@@ -1,6 +1,14 @@
 defmodule RPNCalculatorTest do
   use ExUnit.Case
 
+  @success {:ok, "operation completed"}
+  @test_error {:error, "test error"}
+
+  @tag task_id: 1
+  test "calculate! returns an :ok atom" do
+    assert RPNCalculator.calculate!([], fn _ -> :ok end) == :ok
+  end
+
   @tag task_id: 1
   test "let it crash" do
     assert_raise(RuntimeError, fn ->
@@ -9,8 +17,18 @@ defmodule RPNCalculatorTest do
   end
 
   @tag task_id: 2
+  test "calculate returns a tuple" do
+    assert RPNCalculator.calculate([], fn _ -> "operation completed" end) == @success
+  end
+
+  @tag task_id: 2
   test "rescue the crash, no message" do
     assert RPNCalculator.calculate([], fn _ -> raise "test error" end) == :error
+  end
+
+  @tag task_id: 3
+  test "calculate_verbose returns a tuple" do
+    assert RPNCalculator.calculate_verbose([], fn _ -> "operation completed" end) == @success
   end
 
   @tag task_id: 3


### PR DESCRIPTION
This PR adds more tests in `rpn-calculator` concept to make the test more in line with the README exposition.

Namely, it says the following, but it is not checked during the exercise:
> When doing more research you notice that many functions _**use atoms and tuples to indicate their success/failure**_.