### PR TITLE
Dont shadow kernel length

### DIFF
--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -6,6 +6,8 @@ The above description of this exercise is shared between all Exercism tracks.
 
 To be consistent with Elixir's standard library, the functions used by `foldl` and `foldr` should take the item as the first argument, and the accumulator as the second.
 
+Additionally, in order not to conflict with the automatically imported function `Kernel.length/1`, the function counting the length will be named `count` instead.
+
 ## Slow tests
 
 One or several of the tests of this exercise have been tagged as `:slow`, because they might take a long time to finish. For this reason, they will not be run on the platform by the automated test runner. If you are solving this exercise directly on the platform in the web editor, you might want to consider downloading this exercise to your machine instead. This will allow you to run all the tests and check the efficiency of your solution.

--- a/exercises/practice/list-ops/.docs/instructions.md
+++ b/exercises/practice/list-ops/.docs/instructions.md
@@ -2,7 +2,7 @@
 
 Implement basic list operations.
 
-In functional languages list operations like `count`, `map`, and
+In functional languages list operations like `length`, `map`, and
 `reduce` are very common. Implement a series of basic list operations,
 without using existing functions.
 
@@ -13,7 +13,7 @@ operations you will implement include:
 * `append` (*given two lists, add all items in the second list to the end of the first list*);
 * `concatenate` (*given a series of lists, combine all items in all lists into one flattened list*);
 * `filter` (*given a predicate and a list, return the list of all items for which `predicate(item)` is True*);
-* `count` (*given a list, return the total number of items within it*);
+* `length` (*given a list, return the total number of items within it*);
 * `map` (*given a function and a list, return the list of the results of applying `function(item)` on all items*);
 * `foldl` (*given a function, a list, and initial accumulator, fold (reduce) each item into the accumulator from the left using `function(accumulator, item)`*);
 * `foldr` (*given a function, a list, and an initial accumulator, fold (reduce) each item into the accumulator from the right using `function(item, accumulator)`*);

--- a/exercises/practice/list-ops/.docs/instructions.md
+++ b/exercises/practice/list-ops/.docs/instructions.md
@@ -2,7 +2,7 @@
 
 Implement basic list operations.
 
-In functional languages list operations like `length`, `map`, and
+In functional languages list operations like `count`, `map`, and
 `reduce` are very common. Implement a series of basic list operations,
 without using existing functions.
 
@@ -13,7 +13,7 @@ operations you will implement include:
 * `append` (*given two lists, add all items in the second list to the end of the first list*);
 * `concatenate` (*given a series of lists, combine all items in all lists into one flattened list*);
 * `filter` (*given a predicate and a list, return the list of all items for which `predicate(item)` is True*);
-* `length` (*given a list, return the total number of items within it*);
+* `count` (*given a list, return the total number of items within it*);
 * `map` (*given a function and a list, return the list of the results of applying `function(item)` on all items*);
 * `foldl` (*given a function, a list, and initial accumulator, fold (reduce) each item into the accumulator from the left using `function(accumulator, item)`*);
 * `foldr` (*given a function, a list, and an initial accumulator, fold (reduce) each item into the accumulator from the right using `function(item, accumulator)`*);

--- a/exercises/practice/list-ops/.meta/example.ex
+++ b/exercises/practice/list-ops/.meta/example.ex
@@ -5,11 +5,11 @@ defmodule ListOps do
   # for adding numbers), but please do not use Kernel functions for Lists like
   # `++`, `--`, `hd`, `tl`, `in`, and `length`.
 
-  @spec length(list) :: non_neg_integer
-  def length(l), do: do_length(l, 0)
+  @spec count(list) :: non_neg_integer
+  def count(l), do: do_count(l, 0)
 
-  defp do_length([], acc), do: acc
-  defp do_length([_ | t], acc), do: do_length(t, acc + 1)
+  defp do_count([], acc), do: acc
+  defp do_count([_ | t], acc), do: do_count(t, acc + 1)
 
   @spec reverse(list) :: list
   def reverse(l), do: do_reverse(l, [])

--- a/exercises/practice/list-ops/lib/list_ops.ex
+++ b/exercises/practice/list-ops/lib/list_ops.ex
@@ -5,8 +5,8 @@ defmodule ListOps do
   # for adding numbers), but please do not use Kernel functions for Lists like
   # `++`, `--`, `hd`, `tl`, `in`, and `length`.
 
-  @spec length(list) :: non_neg_integer
-  def length(l) do
+  @spec count(list) :: non_neg_integer
+  def count(l) do
   end
 
   @spec reverse(list) :: list

--- a/exercises/practice/list-ops/test/list_ops_test.exs
+++ b/exercises/practice/list-ops/test/list_ops_test.exs
@@ -5,21 +5,21 @@ defmodule ListOpsTest do
 
   defp odd?(n), do: rem(n, 2) == 1
 
-  describe "length" do
+  describe "count" do
     # @tag :pending
     test "empty list" do
-      assert L.length([]) == 0
+      assert L.count([]) == 0
     end
 
     @tag :pending
     test "normal list" do
-      assert L.length([1, 2, 3, 4]) == 4
+      assert L.count([1, 2, 3, 4]) == 4
     end
 
     @tag :pending
     @tag :slow
     test "huge list" do
-      assert L.length(Enum.to_list(1..1_000_000)) == 1_000_000
+      assert L.count(Enum.to_list(1..1_000_000)) == 1_000_000
     end
   end
 

--- a/exercises/practice/simple-linked-list/.meta/example.ex
+++ b/exercises/practice/simple-linked-list/.meta/example.ex
@@ -18,15 +18,15 @@ defmodule LinkedList do
   end
 
   @doc """
-  Calculate the length of a LinkedList
+  Counts the number of elements in a LinkedList
   """
-  @spec length(t) :: non_neg_integer()
-  def length(list) do
-    count_length(list, 0)
+  @spec count(t) :: non_neg_integer()
+  def count(list) do
+    do_count(list, 0)
   end
 
-  defp count_length({}, n), do: n
-  defp count_length({_, t}, n), do: count_length(t, n + 1)
+  defp do_count({}, n), do: n
+  defp do_count({_, t}, n), do: do_count(t, n + 1)
 
   @doc """
   Determine if a LinkedList is empty

--- a/exercises/practice/simple-linked-list/lib/linked_list.ex
+++ b/exercises/practice/simple-linked-list/lib/linked_list.ex
@@ -18,10 +18,10 @@ defmodule LinkedList do
   end
 
   @doc """
-  Calculate the length of a LinkedList
+  Counts the number of elements in a LinkedList
   """
-  @spec length(t) :: non_neg_integer()
-  def length(list) do
+  @spec count(t) :: non_neg_integer()
+  def count(list) do
     # Your implementation here...
   end
 

--- a/exercises/practice/simple-linked-list/test/linked_list_test.exs
+++ b/exercises/practice/simple-linked-list/test/linked_list_test.exs
@@ -1,9 +1,9 @@
 defmodule LinkedListTest do
   use ExUnit.Case
 
-  test "length/1 of new list" do
+  test "count/1 of new list" do
     list = LinkedList.new()
-    assert LinkedList.length(list) == 0
+    assert LinkedList.count(list) == 0
   end
 
   @tag :pending
@@ -13,9 +13,9 @@ defmodule LinkedListTest do
   end
 
   @tag :pending
-  test "length/1 of list of 1 datum" do
+  test "count/1 of list of 1 datum" do
     list = LinkedList.new() |> LinkedList.push(10)
-    assert LinkedList.length(list) == 1
+    assert LinkedList.count(list) == 1
   end
 
   @tag :pending
@@ -67,39 +67,39 @@ defmodule LinkedListTest do
   test "push 10 times" do
     list = Enum.reduce(1..10, LinkedList.new(), &LinkedList.push(&2, &1))
     assert LinkedList.peek(list) == {:ok, 10}
-    assert LinkedList.length(list) == 10
+    assert LinkedList.count(list) == 10
   end
 
   @tag :pending
   test "pop/1 of list of 1 datum" do
     list = LinkedList.new() |> LinkedList.push(:a)
     assert {:ok, :a, tail} = LinkedList.pop(list)
-    assert LinkedList.length(tail) == 0
+    assert LinkedList.count(tail) == 0
   end
 
   @tag :pending
   test "popping frenzy" do
     list = Enum.reduce(11..20, LinkedList.new(), &LinkedList.push(&2, &1))
-    assert LinkedList.length(list) == 10
+    assert LinkedList.count(list) == 10
     assert {:ok, 20, list} = LinkedList.pop(list)
     assert {:ok, 19, list} = LinkedList.pop(list)
     assert {:ok, 18, list} = LinkedList.pop(list)
     assert {:ok, 17, list} = LinkedList.pop(list)
     assert {:ok, 16, list} = LinkedList.pop(list)
     assert {:ok, 15} = LinkedList.peek(list)
-    assert LinkedList.length(list) == 5
+    assert LinkedList.count(list) == 5
   end
 
   @tag :pending
   test "from_list/1 of empty list" do
     list = LinkedList.from_list([])
-    assert LinkedList.length(list) == 0
+    assert LinkedList.count(list) == 0
   end
 
   @tag :pending
   test "from_list/1 of 2 element list, keeping order" do
     list = LinkedList.from_list([:a, :b])
-    assert LinkedList.length(list) == 2
+    assert LinkedList.count(list) == 2
     assert {:ok, :a, list} = LinkedList.pop(list)
     assert {:ok, :b, list} = LinkedList.pop(list)
     assert {:error, :empty_list} = LinkedList.pop(list)


### PR DESCRIPTION
At least one student has reported that defining length/1 warns that doing so conflicts with the automatically imported function Kernel.length/1, and it seems generally prudent not to shadow Kernel functions.