### PR TITLE
Fix key name for inventory items

### DIFF
--- a/exercises/concept/boutique-inventory/test/boutique_inventory_test.exs
+++ b/exercises/concept/boutique-inventory/test/boutique_inventory_test.exs
@@ -45,14 +45,14 @@ defmodule BoutiqueInventoryTest do
     @tag task_id: 2
     test "filters out items that do have a price" do
       assert BoutiqueInventory.with_missing_price([
-               %{name: "Red Flowery Top", price: 50, quantity_per_size: %{}},
-               %{name: "Purple Flowery Top", price: nil, quantity_per_size: %{}},
-               %{name: "Bamboo Socks Avocado", price: 10, quantity_per_size: %{}},
-               %{name: "Bamboo Socks Palm Trees", price: 10, quantity_per_size: %{}},
-               %{name: "Bamboo Socks Kittens", price: nil, quantity_per_size: %{}}
+               %{name: "Red Flowery Top", price: 50, quantity_by_size: %{}},
+               %{name: "Purple Flowery Top", price: nil, quantity_by_size: %{}},
+               %{name: "Bamboo Socks Avocado", price: 10, quantity_by_size: %{}},
+               %{name: "Bamboo Socks Palm Trees", price: 10, quantity_by_size: %{}},
+               %{name: "Bamboo Socks Kittens", price: nil, quantity_by_size: %{}}
              ]) == [
-               %{name: "Purple Flowery Top", price: nil, quantity_per_size: %{}},
-               %{name: "Bamboo Socks Kittens", price: nil, quantity_per_size: %{}}
+               %{name: "Purple Flowery Top", price: nil, quantity_by_size: %{}},
+               %{name: "Bamboo Socks Kittens", price: nil, quantity_by_size: %{}}
              ]
     end
   end


### PR DESCRIPTION
The key for inventory items should be `quantity_by_size` instead of `quantity_per_size`