### PR TITLE
Removing dynamic-dispatch from the list of prerequisites for forth

### DIFF
--- a/config.json
+++ b/config.json
@@ -2815,8 +2815,7 @@
           "case",
           "structs",
           "errors",
-          "exceptions",
-          "dynamic-dispatch"
+          "exceptions"
         ],
         "practices": [
           "regular-expressions",


### PR DESCRIPTION
Fixes #951 

The dynamic dispatch exercise is still a WIP, so we can make it a prerequisite for the forth exercise.