### PR TITLE
Fix spelling issue that prevents linking to `guards` documentation

### DIFF
--- a/exercises/concept/lucas-numbers/.docs/hints.md
+++ b/exercises/concept/lucas-numbers/.docs/hints.md
@@ -18,7 +18,7 @@
 
 ## 3. Catch bad arguments
 
-- Use a [guard][guard] to catch the cases when an integer isn't passed as an argument to `generate/1`.
+- Use a [guard][guards] to catch the cases when an integer isn't passed as an argument to `generate/1`.
 
 [enum]: https://hexdocs.pm/elixir/Enum.html#content
 [guards]: https://hexdocs.pm/elixir/master/patterns-and-guards.html#guards


### PR DESCRIPTION
I was working through this exercise when I noticed a very minor issue with the link on the third hint.