### PR TITLE
Fix error name in stack-underflow instructions

### DIFF
--- a/exercises/concept/stack-underflow/.docs/instructions.md
+++ b/exercises/concept/stack-underflow/.docs/instructions.md
@@ -38,7 +38,7 @@ RPNCalculator.Exception.divide([])
 # => ** (StackUnderflowError) stack underflow occurred, context: when dividing
 
 RPNCalculator.Exception.divide([0, 100])
-# => ** (DivisionByZero) division by zero occurred
+# => ** (DivisionByZeroError) division by zero occurred
 
 RPNCalculator.Exception.divide([4, 16])
 # => 4


### PR DESCRIPTION
In part 1. we have to "Implement the `DivisionByZeroError` module".
The name used in part 3. should be the same `DivisionByZeroError`, not `DivisionByZero`.