### PR TITLE
Fix configlet warnings

### DIFF
--- a/config.json
+++ b/config.json
@@ -1953,7 +1953,6 @@
           "protocols"
         ],
         "practices": [
-          "integers",
           "structs",
           "protocols"
         ],
@@ -2136,13 +2135,13 @@
         "prerequisites": [
           "if",
           "cond",
-          "integer",
+          "integers",
           "multiple-clause-functions",
           "pattern-matching",
           "recursion"
         ],
         "practices": [
-          "integer"
+          "integers"
         ],
         "difficulty": 5
       },
@@ -2627,12 +2626,10 @@
           "errors",
           "exceptions",
           "keyword-lists",
-          "nil",
-          "macros"
+          "nil"
         ],
         "practices": [
-          "keyword-lists",
-          "macros"
+          "keyword-lists"
         ],
         "difficulty": 8
       },


### PR DESCRIPTION
Those were the exercises that practiced integers. One of them had to have "integers" removed:
```
integers ⨯
  Too many exercises practice this concept.
  Practiced by (11): [all-your-base, armstrong-numbers, change, clock, collatz-conjecture, largest-series-product, leap, luhn, nth-prime, resistor-color-trio, square-root]
```