### PR TITLE
Remove call to update_score/3

### DIFF
--- a/exercises/concept/high-score/test/high_score_test.exs
+++ b/exercises/concept/high-score/test/high_score_test.exs
@@ -104,8 +104,7 @@ defmodule HighScoreTest do
     test "resetting score for existing player sets previous player score to 0" do
       scores =
         HighScore.new()
-        |> HighScore.add_player("José Valim")
-        |> HighScore.update_score("José Valim", 486_373)
+        |> HighScore.add_player("José Valim", 486_373)
         |> HighScore.reset_score("José Valim")
 
       assert scores == %{"José Valim" => 0}


### PR DESCRIPTION
Resolve #960

`update_score/3` will be implemented by the student at step 5, that's why we can't call it during step 4 tests.