### PR TITLE
Update `boutique-inventory` exercise to use `Enum.into` instead of `Enum.map`

### DIFF
--- a/exercises/concept/boutique-inventory/.docs/hints.md
+++ b/exercises/concept/boutique-inventory/.docs/hints.md
@@ -17,8 +17,7 @@
 
 - Maps implement the enumerable protocol.
 - `Enum` functions convert maps to a list of `{key, value}` tuples.
-- There is a [built-in function][enum-map] for replacing every element in an enumerable with another element.
-- There is a [built-in function][enum-into] that can transform a list of `{key, value}` tuples back into a map.
+- There is a [built-in function][enum-into] that can transform a list of `{key, value}` tuples back into a map using a transformation function.
 
 ## 4. Calculate the item's total quantity
 
@@ -31,6 +30,5 @@
 [enum-functions]: https://hexdocs.pm/elixir/Enum.html#functions
 [enum-sort-by]: https://hexdocs.pm/elixir/Enum.html#sort_by/3
 [enum-filter]: https://hexdocs.pm/elixir/Enum.html#filter/2
-[enum-map]: https://hexdocs.pm/elixir/Enum.html#map/2
-[enum-into]: https://hexdocs.pm/elixir/Enum.html#into/2
+[enum-into]: https://hexdocs.pm/elixir/Enum.html#into/3
 [enum-reduce]: https://hexdocs.pm/elixir/Enum.html#reduce/3

--- a/exercises/concept/boutique-inventory/.docs/introduction.md
+++ b/exercises/concept/boutique-inventory/.docs/introduction.md
@@ -15,10 +15,6 @@ Enum.all?([1, 2, 3, 4, 5], fn x -> x > 3 end)
 
 The most common `Enum` functions are `map` and `reduce`.
 
-### `map/2`
-
-`Enum.map/2` allows you to replace every element in an enumerable with another element. The second argument to `Enum.map/2` is a function that accepts the original element and returns its replacement.
-
 ### `reduce/3`
 
 `Enum.reduce/3` allows you to _reduce_ the whole enumerable to a single value. To achieve this, a special variable called the _accumulator_ is used. The accumulator carries the intermediate state of the reduction between iterations.
@@ -30,3 +26,5 @@ The second argument to `Enum.reduce/3` is the initial value of the accumulator. 
 When using maps with `Enum` functions, the map gets automatically converted to a list of 2 `{key, value}` tuples.
 
 To transform it back to a map, use `Enum.into/2`. `Enum.into/2` is a function that transforms an enumerable into a collectable - any data structure implementing the `Collectable` protocol. It can be thought of as the opposite of `Enum.reduce/3`.
+
+`Enum` also have `Enum.into/3`. `Enum.into/3` is a variation of `Enum.into/2` that accepts a transformation function to be applied while transforming the enumerable into a collectable.

--- a/exercises/concept/boutique-inventory/.meta/config.json
+++ b/exercises/concept/boutique-inventory/.meta/config.json
@@ -4,7 +4,8 @@
     "angelikatyborska"
   ],
   "contributors": [
-    "neenjaw"
+    "neenjaw",
+    "fmmatheus"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/boutique-inventory/.meta/design.md
+++ b/exercises/concept/boutique-inventory/.meta/design.md
@@ -3,10 +3,9 @@
 ## Learning objectives
 
 - Know about the `Enum` module.
-- Know how to use `Enum.map` and `Enum.reduce`.
+- Know how to use `Enum.into` and `Enum.reduce`.
 - Know about the `Enumerable` protocol.
 - Know that maps and lists implement the `Enumerable` protocol.
-- Know how to map a map (sic) to another map.
 - Know how to pass an existing function as an argument.
 
 ## Out of scope
@@ -32,5 +31,5 @@
 
 - The function `sort_by_price/1` should use `Enum.sort_by`.
 - The function `with_missing_price/1` should use `Enum.filter` or `Enum.reject`.
-- The function `increase_quantity/2` should use `Enum.map`.
+- The function `increase_quantity/2` should use `Enum.into`.
 - The function `total_quantity/1` should use `Enum.reduce`.

--- a/exercises/concept/boutique-inventory/.meta/exemplar.ex
+++ b/exercises/concept/boutique-inventory/.meta/exemplar.ex
@@ -9,9 +9,7 @@ defmodule BoutiqueInventory do
 
   def increase_quantity(item, count) do
     Map.update(item, :quantity_by_size, %{}, fn quantity_by_size ->
-      quantity_by_size
-      |> Enum.map(fn {size, quantity} -> {size, quantity + count} end)
-      |> Enum.into(%{})
+      Enum.into(quantity_by_size, %{}, fn {size, quantity} -> {size, quantity + count} end)
     end)
   end
 


### PR DESCRIPTION
Issue: #199 

### Description

Change `boutique-inventory` docs by:

- Remove misleading `Enum.map` hints/intros
- Add `Enum.into/3` introduction
- Edit exemplar and Design to require `Enum.into/3` usage instead of `Enum.into/2` + `Enum.map`

This PR is based on a suggestion made by @jiegillet here: [thread](https://github.com/exercism/elixir-analyzer/pull/194#issuecomment-942835845)

### Related PRs:

- Elixir-Analyzer: https://github.com/exercism/elixir-analyzer/pull/203
- Website-copy: https://github.com/exercism/website-copy/pull/2104