### PR TITLE
Clarify what should happen in new passport for "unhappy path"

### DIFF
--- a/exercises/concept/new-passport/.docs/instructions.md
+++ b/exercises/concept/new-passport/.docs/instructions.md
@@ -6,13 +6,13 @@ You print out the form you need to get your new passport, fill it out, jump into
 
 All the following tasks will require implementing and extending `get_new_passport/3`.
 
-`get_new_passport/3` uses some already defined functions (you shouldn't change these). For the most part, these functions can return a tuple with `:ok` or `:error` as the first item. If the retuned value is the `:error` tuple, `get_new_passport/3` should return it.
-
 ## 1. Get into the building
 
 It turns out that the building is only open in the afternoon, and not at the same time everyday.
 
 Call the function `enter_building/1` with the current time (given to you as first argument of `get_new_passport/3`). If the building is open, the function will return a tuple with `:ok` and a timestamp that you will need later, otherwise a tuple with `:error` and a message. For now, the happy path can return the `:ok` tuple.
+
+If you get an `:error` tuple, use the `else` block to return it.
 
 ## 2. Go to the information desk and find which counter you should go to
 
@@ -20,13 +20,13 @@ The information desk is notorious for taking long coffee breaks. If you are luck
 
 Call the function `find_counter_information/1` with the current time. You will get either a tuple with `:ok` and a manual, represented by an anonymous function, or a tuple with `:coffee_break` and more instructions. In your happy path where you receive the manual, apply it to you birthday (second argument of `get_new_passport/3`) and learn which counter to go to. Return an `:ok` tuple with the counter.
 
-If you get a `:coffee_break` message, return a tuple with `:retry` and a `NaiveDateTime` pointing to 15 minutes after the current time.
+If you get a `:coffee_break` message, return a tuple with `:retry` and a `NaiveDateTime` pointing to 15 minutes after the current time. As before, if you get an `:error` tuple, return it.
 
 ## 3. Go to the counter and get your form stamped
 
 For some reason, different counters require forms of different colors. Of course, you printed the first one you found on the website, so you focus on your happy path and hope for the best.
 
-Call the function `stamp_form/3` with the timestamp you received at the entrance, the counter and the form you brought (last argument of `get_new_passport/3`). You will get either a tuple with `:ok` and a checksum that will be used to verify your passport number or a tuple with `:error` and a message. Have your happy path return an `:ok` tuple with the checksum.
+Call the function `stamp_form/3` with the timestamp you received at the entrance, the counter and the form you brought (last argument of `get_new_passport/3`). You will get either a tuple with `:ok` and a checksum that will be used to verify your passport number or a tuple with `:error` and a message. Have your happy path return an `:ok` tuple with the checksum. If you get an `:error` tuple, return it.
 
 ## 4. Receive your new passport
 


### PR DESCRIPTION
close #974 

As mentioned in [this issue](https://github.com/exercism/elixir/issues/974), I think that the description of the exercise would be improved with some guidance as to what `get_new_passport/3` should return if pattern matching fails. So I added a paragraph instructing the user to return the `:error` tuple in said case.