### PR TITLE
Add new test to Community Garden test suite

### DIFF
--- a/exercises/concept/community-garden/.meta/config.json
+++ b/exercises/concept/community-garden/.meta/config.json
@@ -7,7 +7,8 @@
     "angelikatyborska",
     "jrr",
     "efx",
-    "justin-m-morgan"
+    "justin-m-morgan",
+    "cr0t"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/community-garden/test/community_garden_test.exs
+++ b/exercises/concept/community-garden/test/community_garden_test.exs
@@ -46,6 +46,26 @@ defmodule CommunityGardenTest do
     assert [] == CommunityGarden.list_registrations(pid)
   end
 
+  @tag task_id: 4
+  test "do not re-use id of released plots" do
+    assert {:ok, pid} = CommunityGarden.start()
+
+    plot_1 = CommunityGarden.register(pid, "Keanu Reeves")
+    plot_2 = CommunityGarden.register(pid, "Thomas A. Anderson")
+
+    ids = CommunityGarden.list_registrations(pid) |> Enum.map(& &1.plot_id)
+
+    CommunityGarden.release(pid, plot_1.plot_id)
+    CommunityGarden.release(pid, plot_2.plot_id)
+
+    CommunityGarden.register(pid, "John Doe")
+    CommunityGarden.register(pid, "Jane Doe")
+
+    new_ids = CommunityGarden.list_registrations(pid) |> Enum.map(& &1.plot_id)
+
+    refute Enum.sort(ids) == Enum.sort(new_ids)
+  end
+
   @tag task_id: 5
   test "can get registration of a registered plot" do
     assert {:ok, pid} = CommunityGarden.start()


### PR DESCRIPTION
We have an additional condition stated in the Instructions file (in section #4):

> ...when a plot is released, the id is not re-used, it is used as a unique identifier only.

But the test suite lack of the test for it.

In this PR we introduce a test to check that CommunityGarden do not re-use IDs which were assigned previously to the released plots.

Here is an example implementation (using a list as container for the Agent's state), that passes all previous tests, but fails with the new one:

```elixir
# ...
defmodule CommunityGarden do
  def start(opts \\ []),
    do: Agent.start(fn -> [] end, opts)

  def list_registrations(pid),
    do: Agent.get(pid, fn plots -> plots end)

  def register(pid, register_to) do
    Agent.get_and_update(pid, fn plots ->
      next_id = length(plots) + 1
      new_plot = %Plot{plot_id: next_id, registered_to: register_to}

      {new_plot, [new_plot | plots]}
    end)
  end

  def release(pid, plot_id) do
    Agent.update(pid, fn plots ->
      Enum.reject(plots, fn
        %{plot_id: ^plot_id} -> true
        _ -> false
      end)
    end)
  end


  def get_registration(pid, plot_id) do
    Agent.get(pid, fn plots ->
      Enum.find(plots, {:not_found, "plot is unregistered"}, fn %{plot_id: ^plot_id} = plot ->
        plot
      end)
    end)
  end
end
```

P.S. This PR is made after conversation happened in this previous PR: https://github.com/exercism/elixir/pull/976