### PR TITLE
Bring rational-numbers up to date with canonical-data

### DIFF
--- a/exercises/practice/rational-numbers/.meta/tests.toml
+++ b/exercises/practice/rational-numbers/.meta/tests.toml
@@ -1,117 +1,127 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [0ba4d988-044c-4ed5-9215-4d0bb8d0ae9f]
-description = "Add two positive rational numbers"
+description = "Arithmetic -> Addition -> Add two positive rational numbers"
 
 [88ebc342-a2ac-4812-a656-7b664f718b6a]
-description = "Add a positive rational number and a negative rational number"
+description = "Arithmetic -> Addition -> Add a positive rational number and a negative rational number"
 
 [92ed09c2-991e-4082-a602-13557080205c]
-description = "Add two negative rational numbers"
+description = "Arithmetic -> Addition -> Add two negative rational numbers"
 
 [6e58999e-3350-45fb-a104-aac7f4a9dd11]
-description = "Add a rational number to its additive inverse"
+description = "Arithmetic -> Addition -> Add a rational number to its additive inverse"
 
 [47bba350-9db1-4ab9-b412-4a7e1f72a66e]
-description = "Subtract two positive rational numbers"
+description = "Arithmetic -> Subtraction -> Subtract two positive rational numbers"
 
 [93926e2a-3e82-4aee-98a7-fc33fb328e87]
-description = "Subtract a positive rational number and a negative rational number"
+description = "Arithmetic -> Subtraction -> Subtract a positive rational number and a negative rational number"
 
 [a965ba45-9b26-442b-bdc7-7728e4b8d4cc]
-description = "Subtract two negative rational numbers"
+description = "Arithmetic -> Subtraction -> Subtract two negative rational numbers"
 
 [0df0e003-f68e-4209-8c6e-6a4e76af5058]
-description = "Subtract a rational number from itself"
+description = "Arithmetic -> Subtraction -> Subtract a rational number from itself"
 
 [34fde77a-75f4-4204-8050-8d3a937958d3]
-description = "Multiply two positive rational numbers"
+description = "Arithmetic -> Multiplication -> Multiply two positive rational numbers"
 
 [6d015cf0-0ea3-41f1-93de-0b8e38e88bae]
-description = "Multiply a negative rational number by a positive rational number"
+description = "Arithmetic -> Multiplication -> Multiply a negative rational number by a positive rational number"
 
 [d1bf1b55-954e-41b1-8c92-9fc6beeb76fa]
-description = "Multiply two negative rational numbers"
+description = "Arithmetic -> Multiplication -> Multiply two negative rational numbers"
 
 [a9b8f529-9ec7-4c79-a517-19365d779040]
-description = "Multiply a rational number by its reciprocal"
+description = "Arithmetic -> Multiplication -> Multiply a rational number by its reciprocal"
 
 [d89d6429-22fa-4368-ab04-9e01a44d3b48]
-description = "Multiply a rational number by 1"
+description = "Arithmetic -> Multiplication -> Multiply a rational number by 1"
 
 [0d95c8b9-1482-4ed7-bac9-b8694fa90145]
-description = "Multiply a rational number by 0"
+description = "Arithmetic -> Multiplication -> Multiply a rational number by 0"
 
 [1de088f4-64be-4e6e-93fd-5997ae7c9798]
-description = "Divide two positive rational numbers"
+description = "Arithmetic -> Division -> Divide two positive rational numbers"
 
 [7d7983db-652a-4e66-981a-e921fb38d9a9]
-description = "Divide a positive rational number by a negative rational number"
+description = "Arithmetic -> Division -> Divide a positive rational number by a negative rational number"
 
 [1b434d1b-5b38-4cee-aaf5-b9495c399e34]
-description = "Divide two negative rational numbers"
+description = "Arithmetic -> Division -> Divide two negative rational numbers"
 
 [d81c2ebf-3612-45a6-b4e0-f0d47812bd59]
-description = "Divide a rational number by 1"
+description = "Arithmetic -> Division -> Divide a rational number by 1"
 
 [5fee0d8e-5955-4324-acbe-54cdca94ddaa]
-description = "Absolute value of a positive rational number"
+description = "Absolute value -> Absolute value of a positive rational number"
 
 [3cb570b6-c36a-4963-a380-c0834321bcaa]
-description = "Absolute value of a positive rational number with negative numerator and denominator"
+description = "Absolute value -> Absolute value of a positive rational number with negative numerator and denominator"
 
 [6a05f9a0-1f6b-470b-8ff7-41af81773f25]
-description = "Absolute value of a negative rational number"
+description = "Absolute value -> Absolute value of a negative rational number"
 
 [5d0f2336-3694-464f-8df9-f5852fda99dd]
-description = "Absolute value of a negative rational number with negative denominator"
+description = "Absolute value -> Absolute value of a negative rational number with negative denominator"
 
 [f8e1ed4b-9dca-47fb-a01e-5311457b3118]
-description = "Absolute value of zero"
+description = "Absolute value -> Absolute value of zero"
 
 [ea2ad2af-3dab-41e7-bb9f-bd6819668a84]
-description = "Raise a positive rational number to a positive integer power"
+description = "Exponentiation of a rational number -> Raise a positive rational number to a positive integer power"
 
 [8168edd2-0af3-45b1-b03f-72c01332e10a]
-description = "Raise a negative rational number to a positive integer power"
+description = "Exponentiation of a rational number -> Raise a negative rational number to a positive integer power"
 
 [e2f25b1d-e4de-4102-abc3-c2bb7c4591e4]
-description = "Raise zero to an integer power"
+description = "Exponentiation of a rational number -> Raise zero to an integer power"
 
 [431cac50-ab8b-4d58-8e73-319d5404b762]
-description = "Raise one to an integer power"
+description = "Exponentiation of a rational number -> Raise one to an integer power"
 
 [7d164739-d68a-4a9c-b99f-dd77ce5d55e6]
-description = "Raise a positive rational number to the power of zero"
+description = "Exponentiation of a rational number -> Raise a positive rational number to the power of zero"
 
 [eb6bd5f5-f880-4bcd-8103-e736cb6e41d1]
-description = "Raise a negative rational number to the power of zero"
+description = "Exponentiation of a rational number -> Raise a negative rational number to the power of zero"
 
 [30b467dd-c158-46f5-9ffb-c106de2fd6fa]
-description = "Raise a real number to a positive rational number"
+description = "Exponentiation of a real number to a rational number -> Raise a real number to a positive rational number"
 
 [6e026bcc-be40-4b7b-ae22-eeaafc5a1789]
-description = "Raise a real number to a negative rational number"
+description = "Exponentiation of a real number to a rational number -> Raise a real number to a negative rational number"
 
 [9f866da7-e893-407f-8cd2-ee85d496eec5]
-description = "Raise a real number to a zero rational number"
+description = "Exponentiation of a real number to a rational number -> Raise a real number to a zero rational number"
 
 [0a63fbde-b59c-4c26-8237-1e0c73354d0a]
-description = "Reduce a positive rational number to lowest terms"
+description = "Reduction to lowest terms -> Reduce a positive rational number to lowest terms"
+
+[5ed6f248-ad8d-4d4e-a545-9146c6727f33]
+description = "Reduction to lowest terms -> Reduce places the minus sign on the numerator"
 
 [f87c2a4e-d29c-496e-a193-318c503e4402]
-description = "Reduce a negative rational number to lowest terms"
+description = "Reduction to lowest terms -> Reduce a negative rational number to lowest terms"
 
 [3b92ffc0-5b70-4a43-8885-8acee79cdaaf]
-description = "Reduce a rational number with a negative denominator to lowest terms"
+description = "Reduction to lowest terms -> Reduce a rational number with a negative denominator to lowest terms"
 
 [c9dbd2e6-5ac0-4a41-84c1-48b645b4f663]
-description = "Reduce zero to lowest terms"
+description = "Reduction to lowest terms -> Reduce zero to lowest terms"
 
 [297b45ad-2054-4874-84d4-0358dc1b8887]
-description = "Reduce an integer to lowest terms"
+description = "Reduction to lowest terms -> Reduce an integer to lowest terms"
 
 [a73a17fe-fe8c-4a1c-a63b-e7579e333d9e]
-description = "Reduce one to lowest terms"
+description = "Reduction to lowest terms -> Reduce one to lowest terms"

--- a/exercises/practice/rational-numbers/test/rational_numbers_test.exs
+++ b/exercises/practice/rational-numbers/test/rational_numbers_test.exs
@@ -275,6 +275,13 @@ defmodule RationalNumbersTest do
     end
 
     @tag :pending
+    test "Reduce places the minus sign on the numerator" do
+      r = {3, -4}
+      result = {-3, 4}
+      assert RationalNumbers.reduce(r) == result
+    end
+
+    @tag :pending
     test "Reduce a negative rational number to lowest terms" do
       r = {-4, 6}
       result = {-2, 3}
@@ -306,13 +313,6 @@ defmodule RationalNumbersTest do
     test "Reduce one to lowest terms" do
       r = {13, 13}
       result = {1, 1}
-      assert RationalNumbers.reduce(r) == result
-    end
-
-    @tag :pending
-    test "Reduce places the minus sign on the numerator" do
-      r = {3, -4}
-      result = {-3, 4}
       assert RationalNumbers.reduce(r) == result
     end
   end


### PR DESCRIPTION
There was one "new" test (and the whole tests toml got reformatted) but the test actually came from us, so I am merely reordering it to match canonical data.