### PR TITLE
Fix [head | tail] list notation example

### DIFF
--- a/concepts/lists/introduction.md
+++ b/concepts/lists/introduction.md
@@ -16,7 +16,7 @@ Elixir implements lists as a linked list, where each node stores the reference t
 [1 | []]
 
 # [1, 2, 3] represented in [head | tail] notation
-[1 | [2 | 3 | []]]
+[1 | [2 | [3 | []]]]
 ```
 
 We can use _`[head | tail]`_ notation to prepend elements to a list:

--- a/exercises/concept/language-list/.docs/introduction.md
+++ b/exercises/concept/language-list/.docs/introduction.md
@@ -18,7 +18,7 @@ Elixir implements lists as a linked list, where each node stores the reference t
 [1 | []]
 
 # [1, 2, 3] represented in [head | tail] notation
-[1 | [2 | 3 | []]]
+[1 | [2 | [3 | []]]]
 ```
 
 We can use _`[head | tail]`_ notation to prepend elements to a list:


### PR DESCRIPTION
Before

```elixir
iex(1)> [1 | [2 | 3 | []]]
** (CompileError) iex:1: misplaced operator |/2

The | operator is typically used between brackets as the cons operator:

    [head | tail]

where head is a single element and the tail is the remaining of a list.
It is also used to update maps and structs, via the %{map | key: value} notation,
and in typespecs, such as @type and @spec, to express the union of two types
    (stdlib 3.16.1) lists.erl:1358: :lists.mapfoldl/3
    (stdlib 3.16.1) lists.erl:1359: :lists.mapfoldl/3
    (stdlib 3.16.1) lists.erl:1358: :lists.mapfoldl/3
```

After

```elixir
iex(1)> [1 | [2 | [3 | []]]]
[1, 2, 3]
```