### PR TITLE
Remove public functions to match the stubs

### DIFF
--- a/exercises/concept/dna-encoding/.meta/exemplar.ex
+++ b/exercises/concept/dna-encoding/.meta/exemplar.ex
@@ -39,8 +39,8 @@ defmodule DNA do
     do_decode(dna, [])
   end
 
-  def do_decode(<<>>, acc), do: acc |> reverse()
-  def do_decode(<<n::4, rest::bitstring>>, acc), do: do_decode(rest, [decode_nucleotide(n) | acc])
+  defp do_decode(<<>>, acc), do: acc |> reverse()
+  defp do_decode(<<n::4, rest::bitstring>>, acc), do: do_decode(rest, [decode_nucleotide(n) | acc])
 
   defp reverse(l), do: do_reverse(l, [])
   defp do_reverse([], acc), do: acc

--- a/exercises/concept/dna-encoding/.meta/exemplar.ex
+++ b/exercises/concept/dna-encoding/.meta/exemplar.ex
@@ -40,7 +40,9 @@ defmodule DNA do
   end
 
   defp do_decode(<<>>, acc), do: acc |> reverse()
-  defp do_decode(<<n::4, rest::bitstring>>, acc), do: do_decode(rest, [decode_nucleotide(n) | acc])
+
+  defp do_decode(<<n::4, rest::bitstring>>, acc),
+    do: do_decode(rest, [decode_nucleotide(n) | acc])
 
   defp reverse(l), do: do_reverse(l, [])
   defp do_reverse([], acc), do: acc

--- a/exercises/practice/affine-cipher/.meta/example.ex
+++ b/exercises/practice/affine-cipher/.meta/example.ex
@@ -55,15 +55,15 @@ defmodule AffineCipher do
     end
   end
 
-  def modular_multiplicative_inverse(a, m) do
+  defp modular_multiplicative_inverse(a, m) do
     modular_multiplicative_inverse(a, m, 1, 0)
     |> Integer.mod(m)
   end
 
-  def modular_multiplicative_inverse(0, r0, _t1, _t0) when r0 > 1, do: raise("Not invertible")
-  def modular_multiplicative_inverse(0, _r0, _t1, t0), do: t0
+  defp modular_multiplicative_inverse(0, r0, _t1, _t0) when r0 > 1, do: raise("Not invertible")
+  defp modular_multiplicative_inverse(0, _r0, _t1, t0), do: t0
 
-  def modular_multiplicative_inverse(r1, r0, t1, t0) do
+  defp modular_multiplicative_inverse(r1, r0, t1, t0) do
     q = div(r0, r1)
     modular_multiplicative_inverse(r0 - q * r1, r1, t0 - q * t1, t1)
   end

--- a/exercises/practice/bank-account/.meta/example.ex
+++ b/exercises/practice/bank-account/.meta/example.ex
@@ -7,18 +7,22 @@ defmodule BankAccount do
 
   ## Callbacks
 
+  @impl true
   def init(_args) do
     {:ok, 0}
   end
 
+  @impl true
   def handle_call(:balance, _from, balance) do
     {:reply, balance, balance}
   end
 
+  @impl true
   def handle_call({:update, amount}, _from, balance) do
     {:reply, :ok, balance + amount}
   end
 
+  @impl true
   def handle_call(:close, _from, balance) do
     # We stop normally and return :stopped to the caller.
     {:stop, :normal, :stopped, balance}

--- a/exercises/practice/binary-search-tree/.meta/example.ex
+++ b/exercises/practice/binary-search-tree/.meta/example.ex
@@ -17,11 +17,11 @@ defmodule BinarySearchTree do
     in_order(tree, []) |> Enum.reverse()
   end
 
-  def in_order(nil, accum) do
+  defp in_order(nil, accum) do
     accum
   end
 
-  def in_order(tree, accum) do
+  defp in_order(tree, accum) do
     left_side = in_order(tree.left, accum)
     middle = [tree.data | left_side]
     in_order(tree.right, middle)

--- a/exercises/practice/book-store/.meta/example.ex
+++ b/exercises/practice/book-store/.meta/example.ex
@@ -22,16 +22,16 @@ defmodule BookStore do
     |> Enum.min()
   end
 
-  def frequencies(list) do
+  defp frequencies(list) do
     list
     |> Enum.reduce(%{}, &Map.update(&2, &1, 1, fn count -> count + 1 end))
     |> Map.values()
   end
 
-  def discounts([]), do: [0]
-  def discounts([n]), do: [n * @base_price]
+  defp discounts([]), do: [0]
+  defp discounts([n]), do: [n * @base_price]
 
-  def discounts(frequencies) do
+  defp discounts(frequencies) do
     for num_books <- 2..5,
         {picked, left} <- pick_n_distinct_from(num_books, frequencies),
         remove_picked = picked |> Enum.map(&(&1 - 1)) |> Enum.reject(&(&1 == 0)),
@@ -39,11 +39,11 @@ defmodule BookStore do
         do: costs + num_books * @discount[num_books]
   end
 
-  def pick_n_distinct_from(n, list) when length(list) < n, do: %{}
-  def pick_n_distinct_from(0, list), do: %{[] => list}
-  def pick_n_distinct_from(n, list) when length(list) == n, do: %{list => []}
+  defp pick_n_distinct_from(n, list) when length(list) < n, do: %{}
+  defp pick_n_distinct_from(0, list), do: %{[] => list}
+  defp pick_n_distinct_from(n, list) when length(list) == n, do: %{list => []}
 
-  def pick_n_distinct_from(n, list) do
+  defp pick_n_distinct_from(n, list) do
     for pick <- Enum.uniq(list),
         {picked, left} <- pick_n_distinct_from(n - 1, list -- [pick]),
         into: %{},

--- a/exercises/practice/circular-buffer/.meta/example.ex
+++ b/exercises/practice/circular-buffer/.meta/example.ex
@@ -53,37 +53,37 @@ defmodule CircularBuffer do
 
   defstruct [:capacity, size: 0, input: [], output: []]
 
-  def new_buffer(capacity), do: {:ok, %CircularBuffer{capacity: capacity}}
+  defp new_buffer(capacity), do: {:ok, %CircularBuffer{capacity: capacity}}
 
-  def read_buffer(%CircularBuffer{size: 0} = buffer), do: {{:error, :empty}, buffer}
+  defp read_buffer(%CircularBuffer{size: 0} = buffer), do: {{:error, :empty}, buffer}
 
-  def read_buffer(%CircularBuffer{size: size, output: [out | output]} = buffer),
+  defp read_buffer(%CircularBuffer{size: size, output: [out | output]} = buffer),
     do: {{:ok, out}, %{buffer | size: size - 1, output: output}}
 
-  def read_buffer(%CircularBuffer{input: input} = buffer),
+  defp read_buffer(%CircularBuffer{input: input} = buffer),
     do: read_buffer(%{buffer | input: [], output: Enum.reverse(input)})
 
-  def write_buffer(%CircularBuffer{size: capacity, capacity: capacity} = buffer, _item),
+  defp write_buffer(%CircularBuffer{size: capacity, capacity: capacity} = buffer, _item),
     do: {{:error, :full}, buffer}
 
-  def write_buffer(%CircularBuffer{size: size, input: input} = buffer, item),
+  defp write_buffer(%CircularBuffer{size: size, input: input} = buffer, item),
     do: {:ok, %{buffer | size: size + 1, input: [item | input]}}
 
-  def overwrite_buffer(%CircularBuffer{size: capacity, capacity: capacity} = buffer, item) do
+  defp overwrite_buffer(%CircularBuffer{size: capacity, capacity: capacity} = buffer, item) do
     {_, smaller_buffer} = read_buffer(buffer)
     write_buffer(smaller_buffer, item)
   end
 
-  def overwrite_buffer(buffer, item), do: write_buffer(buffer, item)
+  defp overwrite_buffer(buffer, item), do: write_buffer(buffer, item)
 
-  def clear_buffer(%CircularBuffer{capacity: capacity}), do: %CircularBuffer{capacity: capacity}
+  defp clear_buffer(%CircularBuffer{capacity: capacity}), do: %CircularBuffer{capacity: capacity}
+
+  # SERVER API
 
   @impl true
   def init(capacity) do
     new_buffer(capacity)
   end
-
-  # SERVER API
 
   @impl true
   def handle_call(:read, _from, buffer) do

--- a/exercises/practice/dominoes/.meta/example.ex
+++ b/exercises/practice/dominoes/.meta/example.ex
@@ -5,13 +5,13 @@ defmodule Dominoes do
   chain?/1 takes a list of domino stones and returns boolean indicating if it's
   possible to make a full chain
   """
-  @spec chain?(dominoes :: [domino] | []) :: boolean
+  @spec chain?(dominoes :: [domino]) :: boolean
   def chain?([]), do: true
   def chain?([{a, a}]), do: true
   def chain?([{_a, _b}]), do: false
   def chain?(dominoes), do: [] !== chains(dominoes)
 
-  def chains([first | rest]) do
+  defp chains([first | rest]) do
     for combi <- permutations(rest),
         {:ok, result} <- chain(combi, [], first),
         do: result

--- a/exercises/practice/dominoes/lib/dominoes.ex
+++ b/exercises/practice/dominoes/lib/dominoes.ex
@@ -5,7 +5,7 @@ defmodule Dominoes do
   chain?/1 takes a list of domino stones and returns boolean indicating if it's
   possible to make a full chain
   """
-  @spec chain?(dominoes :: [domino] | []) :: boolean
+  @spec chain?(dominoes :: [domino]) :: boolean
   def chain?(dominoes) do
   end
 end

--- a/exercises/practice/food-chain/.meta/example.ex
+++ b/exercises/practice/food-chain/.meta/example.ex
@@ -16,19 +16,19 @@ defmodule FoodChain do
   @spec recite(start :: integer, stop :: integer) :: String.t()
   def recite(start, stop), do: Enum.map_join(start..stop, "\n", &verse/1)
 
-  def verse(1),
+  defp verse(1),
     do: """
     I know an old lady who swallowed a fly.
     I don't know why she swallowed the fly. Perhaps she'll die.
     """
 
-  def verse(8),
+  defp verse(8),
     do: """
     I know an old lady who swallowed a horse.
     She's dead, of course!
     """
 
-  def verse(number) do
+  defp verse(number) do
     [{animal, line} | _] =
       animals =
       Enum.take(@animals, number)

--- a/exercises/practice/forth/.meta/example.ex
+++ b/exercises/practice/forth/.meta/example.ex
@@ -1,26 +1,23 @@
 defmodule Forth do
-  defmodule Builtin do
-    def exec(word, st) when is_integer(word), do: [word | st]
-
-    def exec("+", [a, b | st]), do: [a + b | st]
-    def exec("+", _), do: raise(Forth.StackUnderflow)
-    def exec("-", [a, b | st]), do: [b - a | st]
-    def exec("-", _), do: raise(Forth.StackUnderflow)
-    def exec("*", [a, b | st]), do: [a * b | st]
-    def exec("*", _), do: raise(Forth.StackUnderflow)
-    def exec("/", [0, _ | _]), do: raise(Forth.DivisionByZero)
-    def exec("/", [a, b | st]), do: [div(b, a) | st]
-    def exec("/", _), do: raise(Forth.StackUnderflow)
-    def exec("DUP", [a | st]), do: [a, a | st]
-    def exec("DUP", _), do: raise(Forth.StackUnderflow)
-    def exec("DROP", [_ | st]), do: st
-    def exec("DROP", _), do: raise(Forth.StackUnderflow)
-    def exec("SWAP", [a, b | st]), do: [b, a | st]
-    def exec("SWAP", _), do: raise(Forth.StackUnderflow)
-    def exec("OVER", [a, b | st]), do: [b, a, b | st]
-    def exec("OVER", _), do: raise(Forth.StackUnderflow)
-    def exec(word, _), do: raise(Forth.UnknownWord, word: word)
-  end
+  defp exec(word, st) when is_integer(word), do: [word | st]
+  defp exec("+", [a, b | st]), do: [a + b | st]
+  defp exec("+", _), do: raise(Forth.StackUnderflow)
+  defp exec("-", [a, b | st]), do: [b - a | st]
+  defp exec("-", _), do: raise(Forth.StackUnderflow)
+  defp exec("*", [a, b | st]), do: [a * b | st]
+  defp exec("*", _), do: raise(Forth.StackUnderflow)
+  defp exec("/", [0, _ | _]), do: raise(Forth.DivisionByZero)
+  defp exec("/", [a, b | st]), do: [div(b, a) | st]
+  defp exec("/", _), do: raise(Forth.StackUnderflow)
+  defp exec("DUP", [a | st]), do: [a, a | st]
+  defp exec("DUP", _), do: raise(Forth.StackUnderflow)
+  defp exec("DROP", [_ | st]), do: st
+  defp exec("DROP", _), do: raise(Forth.StackUnderflow)
+  defp exec("SWAP", [a, b | st]), do: [b, a | st]
+  defp exec("SWAP", _), do: raise(Forth.StackUnderflow)
+  defp exec("OVER", [a, b | st]), do: [b, a, b | st]
+  defp exec("OVER", _), do: raise(Forth.StackUnderflow)
+  defp exec(word, _), do: raise(Forth.UnknownWord, word: word)
 
   defmodule Evaluator do
     defstruct state: :start, cmddef: [], stack: [], words: %{}
@@ -56,7 +53,7 @@ defmodule Forth do
 
   defp eval_word(word, %Evaluator{state: :start, stack: stack, words: words} = ev) do
     case Map.get(words, word) do
-      nil -> %{ev | stack: Builtin.exec(word, stack)}
+      nil -> %{ev | stack: exec(word, stack)}
       ts -> ts |> eval_words(ev)
     end
   end

--- a/exercises/practice/go-counting/.meta/example.ex
+++ b/exercises/practice/go-counting/.meta/example.ex
@@ -38,9 +38,9 @@ defmodule GoCounting do
     territories(graph, empties, %{white: [], black: [], none: []})
   end
 
-  def territories(_graph, [], territories), do: territories
+  defp territories(_graph, [], territories), do: territories
 
-  def territories(graph, [pos | positions], territories) do
+  defp territories(graph, [pos | positions], territories) do
     %{owner: owner, territory: territory} =
       graph
       |> expand_territory([pos])
@@ -52,11 +52,11 @@ defmodule GoCounting do
     territories(graph, positions, territories)
   end
 
-  def to_color(?W), do: :white
-  def to_color(?B), do: :black
-  def to_color(?_), do: :none
+  defp to_color(?W), do: :white
+  defp to_color(?B), do: :black
+  defp to_color(?_), do: :none
 
-  def make_graph(board) do
+  defp make_graph(board) do
     board =
       board
       |> String.split("\n", trim: true)
@@ -92,10 +92,10 @@ defmodule GoCounting do
     )
   end
 
-  def expand_territory(graph, positions, visited \\ MapSet.new())
-  def expand_territory(_graph, [], _visited), do: []
+  defp expand_territory(graph, positions, visited \\ MapSet.new())
+  defp expand_territory(_graph, [], _visited), do: []
 
-  def expand_territory(graph, [pos | positions], visited) do
+  defp expand_territory(graph, [pos | positions], visited) do
     {color, neighbors} =
       case graph[pos] do
         {:white, _neighbors} ->
@@ -111,7 +111,7 @@ defmodule GoCounting do
     [{pos, color} | expand_territory(graph, neighbors ++ positions, MapSet.put(visited, pos))]
   end
 
-  def get_owner(territory) do
+  defp get_owner(territory) do
     empties = for {pos, :none} <- territory, do: pos
     colors = for {_pos, color} when color != :none <- territory, do: color
 

--- a/exercises/practice/house/.meta/example.ex
+++ b/exercises/practice/house/.meta/example.ex
@@ -24,7 +24,7 @@ defmodule House do
     "the horse and the hound and the horn that belonged to"
   ]
 
-  def verse(n) do
+  defp verse(n) do
     stuff =
       @protagonists
       |> Enum.take(n)

--- a/exercises/practice/ocr-numbers/.meta/example.ex
+++ b/exercises/practice/ocr-numbers/.meta/example.ex
@@ -6,42 +6,43 @@ defmodule OcrNumbers do
   @spec convert([String.t()]) :: {:ok, String.t()} | {:error, charlist()}
   def convert(input) do
     Enum.chunk_every(input, 4)
-    |> Enum.map(fn row_set -> _convert(row_set, "") end)
+    |> Enum.map(fn row_set -> convert(row_set, "") end)
     |> format_output()
   end
 
-  def format_output([]), do: {:error, 'invalid line count'}
-  def format_output(rows), do: _format_output(Enum.any?(rows, &_error?/1), rows)
-  def _format_output(true, rows), do: Enum.find(rows, &_error?/1)
-  def _format_output(false, output), do: {:ok, Enum.join(output, ",")}
-  def _error?({:error, _}), do: true
-  def _error?(_), do: false
+  defp format_output([]), do: {:error, 'invalid line count'}
+  defp format_output(rows), do: format_output(Enum.any?(rows, &error?/1), rows)
+  defp format_output(true, rows), do: Enum.find(rows, &error?/1)
+  defp format_output(false, output), do: {:ok, Enum.join(output, ",")}
 
-  def _convert(_, {:error, _} = error), do: error
-  def _convert(input, _) when length(input) != 4, do: {:error, 'invalid line count'}
-  def _convert(["", "", "", ""], output), do: output
+  defp error?({:error, _}), do: true
+  defp error?(_), do: false
 
-  def _convert(input, output) do
+  defp convert(_, {:error, _} = error), do: error
+  defp convert(input, _) when length(input) != 4, do: {:error, 'invalid line count'}
+  defp convert(["", "", "", ""], output), do: output
+
+  defp convert(input, output) do
     split_strings = Enum.map(input, fn a -> String.split_at(a, 3) end)
     this_character = Enum.map(split_strings, fn {a, _} -> a end)
     other_characters = Enum.map(split_strings, fn {_, a} -> a end)
     lengths = Enum.map(this_character, fn a -> String.length(a) end)
 
-    _convert(other_characters, update_output(lengths, this_character, output))
+    convert(other_characters, update_output(lengths, this_character, output))
   end
 
-  def update_output([3, 3, 3, 3], chars, output), do: output <> recognize_character(chars)
-  def update_output(_, _, _), do: {:error, 'invalid column count'}
+  defp update_output([3, 3, 3, 3], chars, output), do: output <> recognize_character(chars)
+  defp update_output(_, _, _), do: {:error, 'invalid column count'}
 
-  def recognize_character([" _ ", "| |", "|_|", "   "]), do: "0"
-  def recognize_character(["   ", "  |", "  |", "   "]), do: "1"
-  def recognize_character([" _ ", " _|", "|_ ", "   "]), do: "2"
-  def recognize_character([" _ ", " _|", " _|", "   "]), do: "3"
-  def recognize_character(["   ", "|_|", "  |", "   "]), do: "4"
-  def recognize_character([" _ ", "|_ ", " _|", "   "]), do: "5"
-  def recognize_character([" _ ", "|_ ", "|_|", "   "]), do: "6"
-  def recognize_character([" _ ", "  |", "  |", "   "]), do: "7"
-  def recognize_character([" _ ", "|_|", "|_|", "   "]), do: "8"
-  def recognize_character([" _ ", "|_|", " _|", "   "]), do: "9"
-  def recognize_character(_), do: "?"
+  defp recognize_character([" _ ", "| |", "|_|", "   "]), do: "0"
+  defp recognize_character(["   ", "  |", "  |", "   "]), do: "1"
+  defp recognize_character([" _ ", " _|", "|_ ", "   "]), do: "2"
+  defp recognize_character([" _ ", " _|", " _|", "   "]), do: "3"
+  defp recognize_character(["   ", "|_|", "  |", "   "]), do: "4"
+  defp recognize_character([" _ ", "|_ ", " _|", "   "]), do: "5"
+  defp recognize_character([" _ ", "|_ ", "|_|", "   "]), do: "6"
+  defp recognize_character([" _ ", "  |", "  |", "   "]), do: "7"
+  defp recognize_character([" _ ", "|_|", "|_|", "   "]), do: "8"
+  defp recognize_character([" _ ", "|_|", " _|", "   "]), do: "9"
+  defp recognize_character(_), do: "?"
 end

--- a/exercises/practice/parallel-letter-frequency/.meta/example.ex
+++ b/exercises/practice/parallel-letter-frequency/.meta/example.ex
@@ -7,7 +7,7 @@ defmodule Frequency do
   def frequency(texts, workers) do
     groups = Enum.map(0..(workers - 1), &stripe(&1, texts, workers))
     # :rpc.pmap({Frequency, :count_texts}, [], groups)
-    Enum.map(groups, &Frequency.count_texts/1)
+    Enum.map(groups, &count_texts/1)
     |> merge_freqs()
   end
 
@@ -16,8 +16,8 @@ defmodule Frequency do
   end
 
   # Needs to be public because of how it's invoked by `:rpc.pmap/4`.
-  @doc false
-  def count_texts(texts) do
+  # @doc false
+  defp count_texts(texts) do
     Enum.map(texts, &count_text/1)
     |> merge_freqs()
   end

--- a/exercises/practice/pov/.meta/example.ex
+++ b/exercises/practice/pov/.meta/example.ex
@@ -46,81 +46,53 @@ defmodule Pov do
     end
   end
 
-  def search(%Zipper{focus: {node, _children}} = zipper, node), do: {:ok, zipper}
+  defp search(%Zipper{focus: {node, _children}} = zipper, node), do: {:ok, zipper}
 
-  def search(%Zipper{} = zipper, node) do
+  defp search(%Zipper{} = zipper, node) do
     case zipper |> down |> search(node) do
       {:ok, z} -> {:ok, z}
       _ -> zipper |> right |> search(node)
     end
   end
 
-  def search(nil, _node), do: nil
+  defp search(nil, _node), do: nil
 
-  def reparent(%Zipper{focus: tree, genealogy: []}), do: tree
+  defp reparent(%Zipper{focus: tree, genealogy: []}), do: tree
 
-  def reparent(%Zipper{
-        focus: {node, children},
-        genealogy: [
-          %Crumb{parent: parent, left_siblings: left, right_siblings: right} | grandparent
-        ]
-      }) do
+  defp reparent(%Zipper{
+         focus: {node, children},
+         genealogy: [
+           %Crumb{parent: parent, left_siblings: left, right_siblings: right} | grandparent
+         ]
+       }) do
     {node, [reparent(%Zipper{focus: {parent, left ++ right}, genealogy: grandparent}) | children]}
   end
 
-  def get_path(%Zipper{focus: {node, _children}, genealogy: genealogy}) do
+  defp get_path(%Zipper{focus: {node, _children}, genealogy: genealogy}) do
     parents = Enum.map(genealogy, fn %Crumb{parent: parent} -> parent end)
 
     Enum.reverse([node | parents])
   end
 
   # Zipper navigation
-  # up and left are not actually required for this problem
 
-  def zip(tree), do: %Zipper{focus: tree}
+  defp zip(tree), do: %Zipper{focus: tree}
 
-  def down(%Zipper{focus: {value, [child | children]}, genealogy: genealogy}) do
+  defp down(%Zipper{focus: {value, [child | children]}, genealogy: genealogy}) do
     %Zipper{
       focus: child,
       genealogy: [%Crumb{parent: value, right_siblings: children} | genealogy]
     }
   end
 
-  def down(_zipper), do: nil
+  defp down(_zipper), do: nil
 
-  def up(%Zipper{
-        focus: tree,
-        genealogy: [
-          %Crumb{parent: parent, left_siblings: left, right_siblings: right} | grandparents
-        ]
-      }) do
-    %Zipper{focus: {parent, left ++ [tree | right]}, genealogy: grandparents}
-  end
-
-  def up(_zipper), do: nil
-
-  def left(%Zipper{
-        focus: tree,
-        genealogy: [
-          %Crumb{left_siblings: [left | lefties], right_siblings: right} = crumb | grandparents
-        ]
-      }) do
-    %Zipper{
-      focus: left,
-      genealogy: [
-        %Crumb{crumb | left_siblings: lefties, right_siblings: [tree | right]} | grandparents
-      ]
-    }
-  end
-
-  def left(_zipper), do: nil
-
-  def right(%Zipper{
-        focus: tree,
-        genealogy: [
-          %Crumb{left_siblings: left, right_siblings: [right | righties]} = crumb | grandparents
-        ]
-      }) do
+  defp right(%Zipper{
+         focus: tree,
+         genealogy: [
+           %Crumb{left_siblings: left, right_siblings: [right | righties]} = crumb | grandparents
+         ]
+       }) do
     %Zipper{
       focus: right,
       genealogy: [
@@ -129,5 +101,5 @@ defmodule Pov do
     }
   end
 
-  def right(_zipper), do: nil
+  defp right(_zipper), do: nil
 end

--- a/exercises/practice/pythagorean-triplet/.meta/example.ex
+++ b/exercises/practice/pythagorean-triplet/.meta/example.ex
@@ -34,9 +34,9 @@ defmodule Triplet do
     |> Enum.sort()
   end
 
-  def generate([], _sum), do: []
+  defp generate([], _sum), do: []
 
-  def generate([[a, b, c] = triple | triplets], sum) do
+  defp generate([[a, b, c] = triple | triplets], sum) do
     next =
       triple
       |> next_triplets
@@ -49,11 +49,9 @@ defmodule Triplet do
     multiples ++ generate(next ++ triplets, sum)
   end
 
-  @doc """
-  Given a primitive Pythagorean triple, generate three more.
-  [All primitive Pythagorean triples can be generated this way without duplication][https://en.wikipedia.org/wiki/Tree_of_primitive_Pythagorean_triples].
-  """
-  def next_triplets([a, b, c]),
+  # Given a primitive Pythagorean triple, generate three more.
+  # [All primitive Pythagorean triples can be generated this way without duplication][https://en.wikipedia.org/wiki/Tree_of_primitive_Pythagorean_triples].
+  defp next_triplets([a, b, c]),
     do: [
       [a - 2 * b + 2 * c, 2 * a - b + 2 * c, 2 * a - 2 * b + 3 * c],
       [a + 2 * b + 2 * c, 2 * a + b + 2 * c, 2 * a + 2 * b + 3 * c],

--- a/exercises/practice/rectangles/.meta/example.ex
+++ b/exercises/practice/rectangles/.meta/example.ex
@@ -31,7 +31,7 @@ defmodule Rectangles do
     |> length
   end
 
-  def connected?(coord, {r1, c1}, {r2, c2}) do
+  defp connected?(coord, {r1, c1}, {r2, c2}) do
     Enum.all?([
       connected?(coord, r1, r2, column: c1),
       connected?(coord, r1, r2, column: c2),
@@ -40,9 +40,9 @@ defmodule Rectangles do
     ])
   end
 
-  def connected?(coord, r1, r2, column: c),
+  defp connected?(coord, r1, r2, column: c),
     do: Enum.all?(r1..r2, fn r -> coord[{r, c}] in '+|' end)
 
-  def connected?(coord, c1, c2, row: r),
+  defp connected?(coord, c1, c2, row: r),
     do: Enum.all?(c1..c2, fn c -> coord[{r, c}] in '+-' end)
 end

--- a/exercises/practice/rotational-cipher/.meta/example.ex
+++ b/exercises/practice/rotational-cipher/.meta/example.ex
@@ -13,15 +13,15 @@ defmodule RotationalCipher do
       |> Enum.take(@alphabet_size)
 
     for {p, c} <- Enum.zip(plain, cipher) do
-      def translate(unquote(p), unquote(shift)), do: unquote(c)
+      defp translate(unquote(p), unquote(shift)), do: unquote(c)
 
-      def translate(unquote(p |> String.upcase()), unquote(shift)),
+      defp translate(unquote(p |> String.upcase()), unquote(shift)),
         do: unquote(c |> String.upcase())
     end
   end
 
   # Non a-zA-Z just returns the original character
-  def translate(plaintext, _), do: plaintext
+  defp translate(plaintext, _), do: plaintext
 
   @doc """
   Given a plaintext and amount to shift by, return a rotated string.

--- a/exercises/practice/satellite/.meta/example.ex
+++ b/exercises/practice/satellite/.meta/example.ex
@@ -19,16 +19,16 @@ defmodule Satellite do
       p_length != i_length -> {:error, "traversals must have the same length"}
       p_set != i_set -> {:error, "traversals must have the same elements"}
       p_length != MapSet.size(p_set) -> {:error, "traversals must contain unique items"}
-      true -> {:ok, build_tree(preorder, inorder, :safe)}
+      true -> {:ok, do_build_tree(preorder, inorder)}
     end
   end
 
-  def build_tree([], [], :safe), do: {}
+  defp do_build_tree([], []), do: {}
 
-  def build_tree([root | preorder], inorder, :safe) do
+  defp do_build_tree([root | preorder], inorder) do
     {in_left, in_right, pre_left, pre_right} = split(root, inorder, preorder)
 
-    {build_tree(pre_left, in_left, :safe), root, build_tree(pre_right, in_right, :safe)}
+    {do_build_tree(pre_left, in_left), root, do_build_tree(pre_right, in_right)}
   end
 
   defp split(root, [root | inorder], preorder), do: {[], inorder, [], preorder}

--- a/exercises/practice/simple-linked-list/.meta/example.ex
+++ b/exercises/practice/simple-linked-list/.meta/example.ex
@@ -83,6 +83,6 @@ defmodule LinkedList do
     do_reverse(list, new())
   end
 
-  def do_reverse({}, acc), do: acc
-  def do_reverse({h, t}, acc), do: do_reverse(t, push(acc, h))
+  defp do_reverse({}, acc), do: acc
+  defp do_reverse({h, t}, acc), do: do_reverse(t, push(acc, h))
 end

--- a/exercises/practice/square-root/.meta/example.ex
+++ b/exercises/practice/square-root/.meta/example.ex
@@ -10,7 +10,7 @@ defmodule SquareRoot do
     calculate(radicand, guess)
   end
 
-  def calculate(radicand, guess) do
+  defp calculate(radicand, guess) do
     new_guess = div(guess + div(radicand, guess), 2)
 
     if new_guess == guess do

--- a/exercises/practice/two-bucket/.meta/example.ex
+++ b/exercises/practice/two-bucket/.meta/example.ex
@@ -21,12 +21,12 @@ defmodule TwoBucket do
     pour([{{0, 0}, 0}], forbidden_states, next_moves, goal)
   end
 
-  def pour([], _, _, _), do: {:error, :impossible}
+  defp pour([], _, _, _), do: {:error, :impossible}
 
-  def pour([{{a, b}, moves} | _], _, _, goal) when a == goal or b == goal,
+  defp pour([{{a, b}, moves} | _], _, _, goal) when a == goal or b == goal,
     do: {:ok, %TwoBucket{bucket_one: a, bucket_two: b, moves: moves}}
 
-  def pour([{state, moves} | states], forbidden_states, next_moves, goal) do
+  defp pour([{state, moves} | states], forbidden_states, next_moves, goal) do
     next =
       next_moves.(state)
       |> Enum.reject(&MapSet.member?(forbidden_states, &1))
@@ -35,7 +35,7 @@ defmodule TwoBucket do
     pour(states ++ next, MapSet.put(forbidden_states, state), next_moves, goal)
   end
 
-  def next_moves({fill_one, fill_two}, size_one, size_two) do
+  defp next_moves({fill_one, fill_two}, size_one, size_two) do
     [
       # Empty a bucket
       {0, fill_two},

--- a/exercises/practice/variable-length-quantity/.meta/example.ex
+++ b/exercises/practice/variable-length-quantity/.meta/example.ex
@@ -7,37 +7,39 @@ defmodule VariableLengthQuantity do
   @spec encode(integers :: [integer]) :: binary
   def encode(integers) when is_list(integers) do
     integers
-    |> Enum.map(&encode/1)
+    |> Enum.map(&do_encode/1)
     |> Enum.map(&String.reverse/1)
     |> Enum.join(<<>>)
   end
 
-  def encode(0), do: <<0>>
+  defp do_encode(0), do: <<0>>
 
-  def encode(int, leading \\ 0)
-  def encode(0, _), do: <<>>
+  defp do_encode(int, leading \\ 0)
+  defp do_encode(0, _), do: <<>>
 
-  def encode(int, leading) do
+  defp do_encode(int, leading) do
     rest = int >>> 7
-    <<leading::1, int::7, encode(rest, 1)::binary>>
+    <<leading::1, int::7, do_encode(rest, 1)::binary>>
   end
 
   @doc """
   Decode a bitstring of VLQ encoded bytes into a series of integers
   """
   @spec decode(bytes :: binary) :: {:ok, [integer]} | {:error, String.t()}
-  def decode(bytes, _status \\ :complete, acc \\ 0)
-  def decode(<<>>, :complete, _), do: {:ok, []}
-  def decode(<<>>, :incomplete, _), do: {:error, "incomplete sequence"}
+  def decode(bytes), do: do_decode(bytes)
+  defp do_decode(bytes, _status \\ :complete, acc \\ 0)
+  defp do_decode(<<>>, :complete, _), do: {:ok, []}
+  defp do_decode(<<>>, :incomplete, _), do: {:error, "incomplete sequence"}
 
-  def decode(<<lead::1, byte::7, bytes::binary>>, _status, acc) do
+  defp do_decode(<<lead::1, byte::7, bytes::binary>>, _status, acc) do
     acc = (acc <<< 7) + byte
 
     if lead == 1 do
-      decode(bytes, :incomplete, acc)
+      do_decode(bytes, :incomplete, acc)
     else
-      with {:ok, result} <- decode(bytes, :complete),
-           do: {:ok, [acc | result]}
+      with {:ok, result} <- do_decode(bytes, :complete) do
+        {:ok, [acc | result]}
+      end
     end
   end
 end

--- a/exercises/practice/word-search/.meta/example.ex
+++ b/exercises/practice/word-search/.meta/example.ex
@@ -32,9 +32,9 @@ defmodule WordSearch do
     end)
   end
 
-  def search(_word, nil, _coord), do: nil
+  defp search(_word, nil, _coord), do: nil
 
-  def search(word, starting_points, coord) do
+  defp search(word, starting_points, coord) do
     word_length = String.length(word)
     word = to_charlist(word)
 
@@ -46,7 +46,7 @@ defmodule WordSearch do
     |> Enum.reduce(nil, &||/2)
   end
 
-  def make_paths(%{row: r, column: c}, delta) do
+  defp make_paths(%{row: r, column: c}, delta) do
     [
       for(i <- 0..delta, do: %{row: r + i, column: c}),
       for(i <- 0..delta, do: %{row: r - i, column: c}),

--- a/exercises/practice/zebra-puzzle/.meta/example.ex
+++ b/exercises/practice/zebra-puzzle/.meta/example.ex
@@ -29,7 +29,7 @@ defmodule ZebraPuzzle do
     nationality
   end
 
-  def solve_puzzle() do
+  defp solve_puzzle() do
     #
     # Step 0: Consider all possible combinations of values
     #
@@ -90,7 +90,7 @@ defmodule ZebraPuzzle do
     |> filter_by_unique_relations
   end
 
-  def filter_direct(list, field_1, value_1, field_2, value_2) do
+  defp filter_direct(list, field_1, value_1, field_2, value_2) do
     Enum.filter(list, fn element ->
       cond do
         element[field_1] == value_1 and element[field_2] == value_2 -> true
@@ -101,7 +101,7 @@ defmodule ZebraPuzzle do
     end)
   end
 
-  def filter_by_neighbors(list) do
+  defp filter_by_neighbors(list) do
     next_to = fn n -> [n - 1, n + 1] end
 
     filtered_list =
@@ -123,7 +123,7 @@ defmodule ZebraPuzzle do
     end
   end
 
-  def filter_indirect(list, field_1, value_1, order_1_to_2, field_2, value_2, order_2_to_1) do
+  defp filter_indirect(list, field_1, value_1, order_1_to_2, field_2, value_2, order_2_to_1) do
     # Get all possible neighbor houses of possibilities with field_1: value_1
     # Ex: find all possible house numbers that neighbor a green house
     orders_2 = get_orders(list, field_1, value_1, order_1_to_2)
@@ -135,7 +135,7 @@ defmodule ZebraPuzzle do
     filter_neighbors(list2, field_1, value_1, orders_1)
   end
 
-  def get_orders(list, field, value, to_other_order) do
+  defp get_orders(list, field, value, to_other_order) do
     list
     |> Enum.filter(&(&1[field] == value))
     |> Enum.map(fn %{order: order} -> to_other_order.(order) end)
@@ -144,7 +144,7 @@ defmodule ZebraPuzzle do
     |> Enum.filter(fn order -> 1 <= order and order <= 5 end)
   end
 
-  def filter_neighbors(list, field, value, orders) do
+  defp filter_neighbors(list, field, value, orders) do
     Enum.filter(list, fn element ->
       cond do
         element[field] == value and element.order in orders -> true
@@ -155,7 +155,7 @@ defmodule ZebraPuzzle do
     end)
   end
 
-  def filter_by_unique_relations(list) do
+  defp filter_by_unique_relations(list) do
     # Some values happen to exist only in one particular house number
     filter_parameters =
       list
@@ -186,7 +186,7 @@ defmodule ZebraPuzzle do
     end
   end
 
-  def values_to_set(map) do
+  defp values_to_set(map) do
     Map.new(map, fn {field, value} -> {field, MapSet.new([value])} end)
   end
 end


### PR DESCRIPTION
Related to [this analyzer check](https://github.com/exercism/elixir-analyzer/pull/207).

I have compared all the exemploids to the stubs and listed all the functions that were public in the exemploid but not in the stubs. Then I basically added a whole bunch of `p` until the problem went away. Some notes:

- Concept exercises: 3 functions have empty stubs, nothing we can do there except change the analyzer comment
- `circular-buffer`, `bank-account` and `react` have some GenServer `@impl true` functions that are not in the stubs but cannot be private. This is fine because students are expected to write those and their solution will be compared to the examples that have them too.
- `clock` implements its own `to_string` that is not in the stub, but required by the tests. Once again, this is fine for the same reason than above.
- `parallel-letter-frequency` is strange, I think it used to use `:rpc.pmap` but then it was commented and I don't think it's doing anything in parallel anymore. [My solution does](https://exercism.org/tracks/elixir/exercises/parallel-letter-frequency/solutions/jiegillet) if we want to replace it.
- I couldn't help but change some implementations a tiny little bit, sometimes using the notation `do_thing` because otherwise `thing` ends up with several arities. I also had to remove some unused functions.