### PR TITLE
Change BoutiqueSuggestions.get_combinations output

### DIFF
--- a/exercises/concept/boutique-suggestions/.docs/instructions.md
+++ b/exercises/concept/boutique-suggestions/.docs/instructions.md
@@ -27,9 +27,9 @@ bottoms = [
 ]
 BoutiqueSuggestions.get_combinations(tops, bottoms)
 # => [
-#      {%{item_name: "Dress shirt"}, %{item_name: "Jeans"}}
-#      {%{item_name: "Dress shirt"}, %{item_name: "Dress trousers"}}
-#      {%{item_name: "Casual shirt"}, %{item_name: "Jeans"}}
+#      {%{item_name: "Dress shirt"}, %{item_name: "Jeans"}},
+#      {%{item_name: "Dress shirt"}, %{item_name: "Dress trousers"}},
+#      {%{item_name: "Casual shirt"}, %{item_name: "Jeans"}},
 #      {%{item_name: "Casual shirt"}, %{item_name: "Dress trousers"}}
 #    ]
 ```
@@ -49,8 +49,10 @@ bottoms = [
 ]
 BoutiqueSuggestions.get_combinations(tops, bottoms)
 # => [
-#      {%{item_name: "Dress shirt"}, %{item_name: "Dress trousers"}}
-#      {%{item_name: "Casual shirt"}, %{item_name: "Jeans"}}
+#      {%{item_name: "Dress shirt", base_color: "blue"},
+#       %{item_name: "Casual shirt", base_color: "black"}},
+#      {%{item_name: "Jeans", base_color: "blue"},
+#       %{item_name: "Dress trousers", base_color: "black"}}
 #    ]
 ```
 
@@ -71,6 +73,7 @@ bottoms = [
 ]
 BoutiqueSuggestions.get_combinations(tops, bottoms, maximum_price: 50)
 # => [
-#      {%{item_name: "Casual shirt"}, %{item_name: "Jeans"}}
+#      {%{item_name: "Casual shirt", base_color: "black", price: 20},
+#       %{item_name: "Jeans", base_color: "blue", price: 30}}
 #    ]
 ```

--- a/exercises/concept/boutique-suggestions/.docs/instructions.md
+++ b/exercises/concept/boutique-suggestions/.docs/instructions.md
@@ -50,9 +50,9 @@ bottoms = [
 BoutiqueSuggestions.get_combinations(tops, bottoms)
 # => [
 #      {%{item_name: "Dress shirt", base_color: "blue"},
-#       %{item_name: "Casual shirt", base_color: "black"}},
-#      {%{item_name: "Jeans", base_color: "blue"},
-#       %{item_name: "Dress trousers", base_color: "black"}}
+#       %{item_name: "Dress trousers", base_color: "black"}},
+#      {%{item_name: "Casual shirt", base_color: "black"},
+#       %{item_name: "Jeans", base_color: "blue"}}
 #    ]
 ```
 


### PR DESCRIPTION
When I was doing this exercise, I noticed that on the examples, the output would only show the item name. So when I was solving the exercise, initially I did it in a way where the function would only output the name of each item. But then that made tests fail. So I think it would be clearer to show the actual output expected on the examples, even if the output gets a little long.