### PR TITLE
Update instructions for resistor-color

### DIFF
--- a/exercises/practice/resistor-color/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color/.docs/instructions.append.md
@@ -1,0 +1,3 @@
+# Instructions append
+
+For this exercise, returning the list of colors is not required.


### PR DESCRIPTION
This exercise previously had a test to get the list of all colors, but it was removed later to simplify the exercise. It's still referenced in the instructions, so better remove it.