### PR TITLE
Ensure value is integer in tests for resistor-color-trio

### DIFF
--- a/exercises/practice/resistor-color-trio/.meta/example.ex
+++ b/exercises/practice/resistor-color-trio/.meta/example.ex
@@ -15,7 +15,7 @@ defmodule ResistorColorTrio do
   @doc """
   Calculate the resistance value in ohm or kiloohm from resistor colors
   """
-  @spec label(colors :: [atom]) :: {integer, atom}
+  @spec label(colors :: [atom]) :: {number, :ohms | :kiloohms}
   def label([a, b, c]) do
     value = (10 * @colors[a] + @colors[b]) * round(:math.pow(10, @colors[c]))
 

--- a/exercises/practice/resistor-color-trio/lib/resistor_color_trio.ex
+++ b/exercises/practice/resistor-color-trio/lib/resistor_color_trio.ex
@@ -2,7 +2,7 @@ defmodule ResistorColorTrio do
   @doc """
   Calculate the resistance value in ohm or kiloohm from resistor colors
   """
-  @spec label(colors :: [atom]) :: {integer, :ohms | :kiloohms}
+  @spec label(colors :: [atom]) :: {number, :ohms | :kiloohms}
   def label(colors) do
   end
 end


### PR DESCRIPTION
I've seen some students use float division instead of integer division when converting to kiloohms, so we better use `===` for the assertion so we can catch this.