### PR TITLE
Tweak test exercises bash script to show test failures

### DIFF
--- a/bin/test_exercises.sh
+++ b/bin/test_exercises.sh
@@ -81,8 +81,10 @@ do
     fi
 
     # test compilation with --warnings-as-errors flag as the example and test should not raise any
+    set +e
     compiler_results=$(MIX_ENV=test mix compile --force --warnings-as-errors 2>&1)
     compile_exit_code="$?"
+    set -e
 
     if [ "${compile_exit_code}" -eq 0 ]
     then
@@ -95,8 +97,10 @@ do
       sed -i 's/use ExUnit.Case\(.*\)/use ExUnit.Case\1\n'" ${doctest_code}"'\n/g' "${test_file}"
 
       # perform unit tests
+      set +e
       test_results=$(mix test --color --no-elixir-version-check --include pending 2> /dev/null)
       test_exit_code="$?"
+      set -e
     else
       # use code 5 to indicate tests skipped
       test_exit_code=5


### PR DESCRIPTION
I thought we might as well update the script here too to show errors like [here](https://github.com/exercism/elixir-test-runner/pull/74).

I checked that compile errors or failing tests do appear and that the script ends with the report.