### PR TITLE
Support 1.13; drop 1.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: [1.12]
-        otp: [24.0]
+        elixir: [1.13]
+        otp: [24.1]
 
     steps:
       - name: Checkout code
@@ -75,8 +75,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: '1.7.0'
-            otp: '20.0'
           - elixir: '1.8.0'
             otp: '20.0'
           - elixir: '1.9.0'
@@ -89,6 +87,8 @@ jobs:
             otp: '23.2'
           - elixir: '1.12.0'
             otp: '24.0'
+          - elixir: '1.13.0'
+            otp: '24.1'
 
     steps:
       - uses: actions/checkout@v2.4.0

--- a/.github/workflows/pr.ci.yml
+++ b/.github/workflows/pr.ci.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: [1.12]
-        otp: [24.0]
+        elixir: [1.13]
+        otp: [24.1]
 
     steps:
       - name: Checkout PR
@@ -72,8 +72,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: '1.7.0'
-            otp: '20.0'
           - elixir: '1.8.0'
             otp: '20.0'
           - elixir: '1.9.0'
@@ -86,6 +84,8 @@ jobs:
             otp: '23.2'
           - elixir: '1.12.0'
             otp: '24.0'
+          - elixir: '1.13.0'
+            otp: '24.1'
 
     steps:
       - uses: actions/checkout@v2.4.0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Setup
 
-The exercises currently target Elixir versions from 1.7 to 1.12 and Erlang/OTP versions from 20 to 24. Detailed installation instructions can be found at
+The exercises currently target Elixir versions from 1.8 to 1.13 and Erlang/OTP versions from 20 to 24. Detailed installation instructions can be found at
 [http://elixir-lang.org/install.html](http://elixir-lang.org/install.html). We recommend using the [asdf version manager](https://github.com/asdf-vm/asdf) to manage multiple Elixir versions.
 
 ## Testing

--- a/exercises/practice/variable-length-quantity/.meta/example.ex
+++ b/exercises/practice/variable-length-quantity/.meta/example.ex
@@ -8,7 +8,7 @@ defmodule VariableLengthQuantity do
   def encode(integers) when is_list(integers) do
     integers
     |> Enum.map(&do_encode/1)
-    |> Enum.map(&String.reverse/1)
+    |> Enum.map(&reverse/1)
     |> Enum.join(<<>>)
   end
 
@@ -41,5 +41,10 @@ defmodule VariableLengthQuantity do
         {:ok, [acc | result]}
       end
     end
+  end
+
+  defp reverse(bitstring) do
+    list = for <<x <- bitstring>>, into: [], do: x
+    for bit <- Enum.reverse(list), into: <<>>, do: <<bit>>
   end
 end

--- a/exercises/practice/yacht/.meta/example.ex
+++ b/exercises/practice/yacht/.meta/example.ex
@@ -25,16 +25,12 @@ defmodule Yacht do
   @spec score(category :: category(), dice :: [integer]) :: integer
   def score(category, dice)
 
-  def score(:ones, dice), do: score(1, dice)
-  def score(:twos, dice), do: score(2, dice)
-  def score(:threes, dice), do: score(3, dice)
-  def score(:fours, dice), do: score(4, dice)
-  def score(:fives, dice), do: score(5, dice)
-  def score(:sixes, dice), do: score(6, dice)
-
-  def score(number, dice) when is_integer(number) do
-    Enum.count(dice, &(&1 == number)) * number
-  end
+  def score(:ones, dice), do: score_number(1, dice)
+  def score(:twos, dice), do: score_number(2, dice)
+  def score(:threes, dice), do: score_number(3, dice)
+  def score(:fours, dice), do: score_number(4, dice)
+  def score(:fives, dice), do: score_number(5, dice)
+  def score(:sixes, dice), do: score_number(6, dice)
 
   def score(:full_house, dice) do
     full_house =
@@ -91,5 +87,9 @@ defmodule Yacht do
       1 -> 50
       _ -> 0
     end
+  end
+
+  defp score_number(number, dice) when is_integer(number) do
+    Enum.count(dice, &(&1 == number)) * number
   end
 end


### PR DESCRIPTION
There were two problems in example solutions:
- in `yacht`, `score/2` is a public function with a defined contract (the first argument should be an atom) but the same function was defined to also accept an integer.
- in `variable-length-quantity`, reversing a bitstring no longer works with `String.reverse` if the bitstring is not a valid string.