### PR TITLE
Remove moduledoc from dna-encoding exemplar

### DIFF
--- a/exercises/concept/dna-encoding/.meta/exemplar.ex
+++ b/exercises/concept/dna-encoding/.meta/exemplar.ex
@@ -1,18 +1,4 @@
 defmodule DNA do
-  @moduledoc """
-  Example solution for the `bitstrings` exercise.
-
-  Written by Tim Austin, tim@neenjaw.com, June 2020.
-
-   | NucleicAcid | Bits |
-   | ----------- | ---- |
-   |    ' '      | 0000 |
-   |     A       | 0001 |
-   |     C       | 0010 |
-   |     G       | 0100 |
-   |     T       | 1000 |
-  """
-
   def encode_nucleotide(?\s), do: 0b0000
   def encode_nucleotide(?A), do: 0b0001
   def encode_nucleotide(?C), do: 0b0010


### PR DESCRIPTION
Reasons:
- None of the other concept exercises have it.
- With that moduledoc, it's impossible for a student to have an identical solution to this one in the way the analyzer compares them.