### PR TITLE
`rational-numbers` test: Small cleanup

### DIFF
--- a/exercises/practice/rational-numbers/test/rational_numbers_test.exs
+++ b/exercises/practice/rational-numbers/test/rational_numbers_test.exs
@@ -4,239 +4,157 @@ defmodule RationalNumbersTest do
   describe "Addition" do
     # @tag :pending
     test "Add two positive rational numbers" do
-      r1 = {1, 2}
-      r2 = {2, 3}
-      result = {7, 6}
-      assert RationalNumbers.add(r1, r2) == result
+      assert RationalNumbers.add({1, 2}, {2, 3}) == {7, 6}
     end
 
     @tag :pending
     test "Add a positive rational number and a negative rational number" do
-      r1 = {1, 2}
-      r2 = {-2, 3}
-      result = {-1, 6}
-      assert RationalNumbers.add(r1, r2) == result
+      assert RationalNumbers.add({1, 2}, {-2, 3}) == {-1, 6}
     end
 
     @tag :pending
     test "Add two negative rational numbers" do
-      r1 = {-1, 2}
-      r2 = {-2, 3}
-      result = {-7, 6}
-      assert RationalNumbers.add(r1, r2) == result
+      assert RationalNumbers.add({-1, 2}, {-2, 3}) == {-7, 6}
     end
 
     @tag :pending
     test "Add a rational number to its additive inverse" do
-      r1 = {1, 2}
-      r2 = {-1, 2}
-      result = {0, 1}
-      assert RationalNumbers.add(r1, r2) == result
+      assert RationalNumbers.add({1, 2}, {-1, 2}) == {0, 1}
     end
   end
 
   describe "Subtraction" do
     @tag :pending
     test "Subtract two positive rational numbers" do
-      r1 = {1, 2}
-      r2 = {2, 3}
-      result = {-1, 6}
-      assert RationalNumbers.subtract(r1, r2) == result
+      assert RationalNumbers.subtract({1, 2}, {2, 3}) == {-1, 6}
     end
 
     @tag :pending
     test "Subtract a positive rational number and a negative rational number" do
-      r1 = {1, 2}
-      r2 = {-2, 3}
-      result = {7, 6}
-      assert RationalNumbers.subtract(r1, r2) == result
+      assert RationalNumbers.subtract({1, 2}, {-2, 3}) == {7, 6}
     end
 
     @tag :pending
     test "Subtract two negative rational numbers" do
-      r1 = {-1, 2}
-      r2 = {-2, 3}
-      result = {1, 6}
-      assert RationalNumbers.subtract(r1, r2) == result
+      assert RationalNumbers.subtract({-1, 2}, {-2, 3}) == {1, 6}
     end
 
     @tag :pending
     test "Subtract a rational number from itself" do
-      r1 = {1, 2}
-      r2 = {1, 2}
-      result = {0, 1}
-      assert RationalNumbers.subtract(r1, r2) == result
+      assert RationalNumbers.subtract({1, 2}, {1, 2}) == {0, 1}
     end
   end
 
   describe "Multiplication" do
     @tag :pending
     test "Multiply two positive rational numbers" do
-      r1 = {1, 2}
-      r2 = {2, 3}
-      result = {1, 3}
-      assert RationalNumbers.multiply(r1, r2) == result
+      assert RationalNumbers.multiply({1, 2}, {2, 3}) == {1, 3}
     end
 
     @tag :pending
     test "Multiply a negative rational number by a positive rational number" do
-      r1 = {-1, 2}
-      r2 = {2, 3}
-      result = {-1, 3}
-      assert RationalNumbers.multiply(r1, r2) == result
+      assert RationalNumbers.multiply({-1, 2}, {2, 3}) == {-1, 3}
     end
 
     @tag :pending
     test "Multiply two negative rational numbers" do
-      r1 = {-1, 2}
-      r2 = {-2, 3}
-      result = {1, 3}
-      assert RationalNumbers.multiply(r1, r2) == result
+      assert RationalNumbers.multiply({-1, 2}, {-2, 3}) == {1, 3}
     end
 
     @tag :pending
     test "Multiply a rational number by its reciprocal" do
-      r1 = {1, 2}
-      r2 = {2, 1}
-      result = {1, 1}
-      assert RationalNumbers.multiply(r1, r2) == result
+      assert RationalNumbers.multiply({1, 2}, {2, 1}) == {1, 1}
     end
 
     @tag :pending
     test "Multiply a rational number by 1" do
-      r1 = {1, 2}
-      r2 = {1, 1}
-      result = {1, 2}
-      assert RationalNumbers.multiply(r1, r2) == result
+      assert RationalNumbers.multiply({1, 2}, {1, 1}) == {1, 2}
     end
 
     @tag :pending
     test "Multiply a rational number by 0" do
-      r1 = {1, 2}
-      r2 = {0, 1}
-      result = {0, 1}
-      assert RationalNumbers.multiply(r1, r2) == result
+      assert RationalNumbers.multiply({1, 2}, {0, 1}) == {0, 1}
     end
   end
 
   describe "Division" do
     @tag :pending
     test "Divide two positive rational numbers" do
-      r1 = {1, 2}
-      r2 = {2, 3}
-      result = {3, 4}
-      assert RationalNumbers.divide_by(r1, r2) == result
+      assert RationalNumbers.divide_by({1, 2}, {2, 3}) == {3, 4}
     end
 
     @tag :pending
     test "Divide a positive rational number by a negative rational number" do
-      r1 = {1, 2}
-      r2 = {-2, 3}
-      result = {-3, 4}
-      assert RationalNumbers.divide_by(r1, r2) == result
+      assert RationalNumbers.divide_by({1, 2}, {-2, 3}) == {-3, 4}
     end
 
     @tag :pending
     test "Divide two negative rational numbers" do
-      r1 = {-1, 2}
-      r2 = {-2, 3}
-      result = {3, 4}
-      assert RationalNumbers.divide_by(r1, r2) == result
+      assert RationalNumbers.divide_by({-1, 2}, {-2, 3}) == {3, 4}
     end
 
     @tag :pending
     test "Divide a rational number by 1" do
-      r1 = {1, 2}
-      r2 = {1, 1}
-      result = {1, 2}
-      assert RationalNumbers.divide_by(r1, r2) == result
+      assert RationalNumbers.divide_by({1, 2}, {1, 1}) == {1, 2}
     end
   end
 
   describe "Absolute value" do
     @tag :pending
     test "Absolute value of a positive rational number" do
-      r = {1, 2}
-      result = {1, 2}
-      assert RationalNumbers.abs(r) == result
+      assert RationalNumbers.abs({1, 2}) == {1, 2}
     end
 
     @tag :pending
     test "Absolute value of a positive rational number with negative numerator and denominator" do
-      r = {-1, -2}
-      result = {1, 2}
-      assert RationalNumbers.abs(r) == result
+      assert RationalNumbers.abs({-1, -2}) == {1, 2}
     end
 
     @tag :pending
     test "Absolute value of a negative rational number" do
-      r = {-1, 2}
-      result = {1, 2}
-      assert RationalNumbers.abs(r) == result
+      assert RationalNumbers.abs({-1, 2}) == {1, 2}
     end
 
     @tag :pending
     test "Absolute value of a negative rational number with negative denominator" do
-      r = {1, -2}
-      result = {1, 2}
-      assert RationalNumbers.abs(r) == result
+      assert RationalNumbers.abs({1, -2}) == {1, 2}
     end
 
     @tag :pending
     test "Absolute value of zero" do
-      r = {0, 1}
-      result = {0, 1}
-      assert RationalNumbers.abs(r) == result
+      assert RationalNumbers.abs({0, 1}) == {0, 1}
     end
   end
 
   describe "Exponentiation of a rational number" do
     @tag :pending
     test "Raise a positive rational number to a positive integer power" do
-      r = {1, 2}
-      n = 3
-      result = {1, 8}
-      assert RationalNumbers.pow_rational(r, n) == result
+      assert RationalNumbers.pow_rational({1, 2}, 3) == {1, 8}
     end
 
     @tag :pending
     test "Raise a negative rational number to a positive integer power" do
-      r = {-1, 2}
-      n = 3
-      result = {-1, 8}
-      assert RationalNumbers.pow_rational(r, n) == result
+      assert RationalNumbers.pow_rational({-1, 2}, 3) == {-1, 8}
     end
 
     @tag :pending
     test "Raise zero to an integer power" do
-      r = {0, 1}
-      n = 5
-      result = {0, 1}
-      assert RationalNumbers.pow_rational(r, n) == result
+      assert RationalNumbers.pow_rational({0, 1}, 5) == {0, 1}
     end
 
     @tag :pending
     test "Raise one to an integer power" do
-      r = {1, 1}
-      n = 4
-      result = {1, 1}
-      assert RationalNumbers.pow_rational(r, n) == result
+      assert RationalNumbers.pow_rational({1, 1}, 4) == {1, 1}
     end
 
     @tag :pending
     test "Raise a positive rational number to the power of zero" do
-      r = {1, 2}
-      n = 0
-      result = {1, 1}
-      assert RationalNumbers.pow_rational(r, n) == result
+      assert RationalNumbers.pow_rational({1, 2}, 0) == {1, 1}
     end
 
     @tag :pending
     test "Raise a negative rational number to the power of zero" do
-      r = {-1, 2}
-      n = 0
-      result = {1, 1}
-      assert RationalNumbers.pow_rational(r, n) == result
+      assert RationalNumbers.pow_rational({-1, 2}, 0) == {1, 1}
     end
   end
 
@@ -269,51 +187,37 @@ defmodule RationalNumbersTest do
   describe "Reduction to lowest terms" do
     @tag :pending
     test "Reduce a positive rational number to lowest terms" do
-      r = {2, 4}
-      result = {1, 2}
-      assert RationalNumbers.reduce(r) == result
+      assert RationalNumbers.reduce({2, 4}) == {1, 2}
     end
 
     @tag :pending
     test "Reduce places the minus sign on the numerator" do
-      r = {3, -4}
-      result = {-3, 4}
-      assert RationalNumbers.reduce(r) == result
+      assert RationalNumbers.reduce({3, -4}) == {-3, 4}
     end
 
     @tag :pending
     test "Reduce a negative rational number to lowest terms" do
-      r = {-4, 6}
-      result = {-2, 3}
-      assert RationalNumbers.reduce(r) == result
+      assert RationalNumbers.reduce({-4, 6}) == {-2, 3}
     end
 
     @tag :pending
     test "Reduce a rational number with a negative denominator to lowest terms" do
-      r = {3, -9}
-      result = {-1, 3}
-      assert RationalNumbers.reduce(r) == result
+      assert RationalNumbers.reduce({3, -9}) == {-1, 3}
     end
 
     @tag :pending
     test "Reduce zero to lowest terms" do
-      r = {0, 6}
-      result = {0, 1}
-      assert RationalNumbers.reduce(r) == result
+      assert RationalNumbers.reduce({0, 6}) == {0, 1}
     end
 
     @tag :pending
     test "Reduce an integer to lowest terms" do
-      r = {-14, 7}
-      result = {-2, 1}
-      assert RationalNumbers.reduce(r) == result
+      assert RationalNumbers.reduce({-14, 7}) == {-2, 1}
     end
 
     @tag :pending
     test "Reduce one to lowest terms" do
-      r = {13, 13}
-      result = {1, 1}
-      assert RationalNumbers.reduce(r) == result
+      assert RationalNumbers.reduce({13, 13}) == {1, 1}
     end
   end
 end


### PR DESCRIPTION
Did a simple search and replace to make the tests more readable.  The regexes (in vim) used were:
```
%s#      r1 = \(.*\)\n      r2 = \(.*\)\n      result = \(.*\)\n      assert RationalNumbers\.\(.*\)(.*#      assert RationalNumbers.\4(\1, \2) == \3
%s#      r = \(.*\)\n      result = \(.*\)\n      assert RationalNumbers\.\(.*\)(.*#      assert RationalNumbers.\3(\1) == \2
%s#      r = \(.*\)\n      n = \(.*\)\n      result = \(.*\)\n      assert RationalNumbers\.\(.*\)(.*#      assert RationalNumbers.\4(\1, \2) == \3
```

I only ran the `test_exercises.sh` script.  Let me know if I should run anything else to check the PR:
```
./bin/test_exercises.sh rational-numbers                                       
Testing: rational-numbers Pass                                                                          
--------------------------------------------------------------------------------                        
1/1 tests passed.                                                                                       
```

CC @jiegillet , as discussed on slack :slightly_smiling_face: 