### PR TITLE
Sync flatten-array

### DIFF
--- a/exercises/practice/flatten-array/.meta/tests.toml
+++ b/exercises/practice/flatten-array/.meta/tests.toml
@@ -1,9 +1,22 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[8c71dabd-da60-422d-a290-4a571471fb14]
+description = "empty"
 
 [d268b919-963c-442d-9f07-82b93f1b518c]
 description = "no nesting"
+
+[3f15bede-c856-479e-bb71-1684b20c6a30]
+description = "flattens a nested array"
 
 [c84440cc-bb3a-48a6-862c-94cf23f2815d]
 description = "flattens array with just integers present"
@@ -13,6 +26,9 @@ description = "5 level nesting"
 
 [d572bdba-c127-43ed-bdcd-6222ac83d9f7]
 description = "6 level nesting"
+
+[0705a8e5-dc86-4cec-8909-150c5e54fa9c]
+description = "null values are omitted from the final result"
 
 [ef1d4790-1b1e-4939-a179-51ace0829dbd]
 description = "6 level nest list with null values"

--- a/exercises/practice/flatten-array/test/flatten_array_test.exs
+++ b/exercises/practice/flatten-array/test/flatten_array_test.exs
@@ -2,14 +2,20 @@ defmodule FlattenArrayTest do
   use ExUnit.Case
 
   # @tag :pending
+  test "empty" do
+    assert FlattenArray.flatten([]) ==
+             []
+  end
+
+  @tag :pending
   test "no nesting" do
     assert FlattenArray.flatten([0, 1, 2]) ==
              [0, 1, 2]
   end
 
   @tag :pending
-  test "flattens an empty nested list" do
-    assert FlattenArray.flatten([[]]) ==
+  test "flattens a nested array" do
+    assert FlattenArray.flatten([[[]]]) ==
              []
   end
 
@@ -32,8 +38,8 @@ defmodule FlattenArrayTest do
   end
 
   @tag :pending
-  test "removes nil from list" do
-    assert FlattenArray.flatten([1, nil, 2]) ==
+  test "nil values values are omitted from the final result" do
+    assert FlattenArray.flatten([1, 2, nil]) ==
              [1, 2]
   end
 


### PR DESCRIPTION
Configlet added three tests to `test.toml`, but only the first one was actually new to the track. The other two already existed in a slightly different variant.