### PR TITLE
allow await_many as well as await when expecting timeout message

### DIFF
--- a/exercises/concept/rpn-calculator-inspection/test/rpn_calculator_inspection_test.exs
+++ b/exercises/concept/rpn-calculator-inspection/test/rpn_calculator_inspection_test.exs
@@ -343,7 +343,11 @@ defmodule RPNCalculatorInspectionTest do
 
       Process.flag(:trap_exit, true)
       pid = spawn_link(fn -> RPNCalculatorInspection.correctness_check(calculator, inputs) end)
-      assert_receive {:EXIT, ^pid, {:timeout, {Task, task_fn, [_task, 100]}}} when task_fn in [:await, :await_many], 150
+
+      assert_receive {:EXIT, ^pid, {:timeout, {Task, task_fn, [_task, 100]}}}
+                     when task_fn in [:await, :await_many],
+                     150
+
       Process.flag(:trap_exit, false)
     end
   end

--- a/exercises/concept/rpn-calculator-inspection/test/rpn_calculator_inspection_test.exs
+++ b/exercises/concept/rpn-calculator-inspection/test/rpn_calculator_inspection_test.exs
@@ -346,7 +346,8 @@ defmodule RPNCalculatorInspectionTest do
 
       assert_receive {:EXIT, ^pid, {:timeout, {Task, task_fn, [_task, 100]}}}
                      when task_fn in [:await, :await_many],
-                     150
+                     150,
+                     "expected to receive a timemout message from Task.await/2 or Task.await_many/2"
 
       Process.flag(:trap_exit, false)
     end

--- a/exercises/concept/rpn-calculator-inspection/test/rpn_calculator_inspection_test.exs
+++ b/exercises/concept/rpn-calculator-inspection/test/rpn_calculator_inspection_test.exs
@@ -343,7 +343,7 @@ defmodule RPNCalculatorInspectionTest do
 
       Process.flag(:trap_exit, true)
       pid = spawn_link(fn -> RPNCalculatorInspection.correctness_check(calculator, inputs) end)
-      assert_receive {:EXIT, ^pid, {:timeout, {Task, :await, [_task, 100]}}}, 150
+      assert_receive {:EXIT, ^pid, {:timeout, {Task, task_fn, [_task, 100]}}} when task_fn in [:await, :await_many], 150
       Process.flag(:trap_exit, false)
     end
   end


### PR DESCRIPTION
Update to `assert_receive` expectation on timeout in "RPN Calculator Inspection" exercise to allow a timeout message with `:await_many` as the MFA tuple function (as well as allowing current `:await`)

My solution for that exercise that causes the test to incorrectly fail was:

```elixir
  def correctness_check(calculator, inputs) do
    inputs
    |> Enum.map(& fn -> calculator.(&1) end)
    |> Enum.map(&Task.async/1)
    |> Task.await_many(100)
  end
```

Where as the exemplar is:

```elixir
  def correctness_check(calculator, inputs) do
    inputs
    |> Enum.map(fn input -> Task.async(fn -> calculator.(input) end) end)
    |> Enum.map(fn task -> Task.await(task, 100) end)
  end
```

The changes in the test allow both to pass.