### PR TITLE
Sync protein-translation

### DIFF
--- a/exercises/practice/protein-translation/.meta/tests.toml
+++ b/exercises/practice/protein-translation/.meta/tests.toml
@@ -1,6 +1,16 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[2c44f7bf-ba20-43f7-a3bf-f2219c0c3f98]
+description = "Empty RNA sequence results in no proteins"
 
 [96d3d44f-34a2-4db4-84cd-fff523e069be]
 description = "Methionine RNA sequence"
@@ -53,6 +63,12 @@ description = "STOP codon RNA sequence 2"
 [9c2ad527-ebc9-4ace-808b-2b6447cb54cb]
 description = "STOP codon RNA sequence 3"
 
+[f4d9d8ee-00a8-47bf-a1e3-1641d4428e54]
+description = "Sequence of two protein codons translates into proteins"
+
+[dd22eef3-b4f1-4ad6-bb0b-27093c090a9d]
+description = "Sequence of two different protein codons translates into proteins"
+
 [d0f295df-fb70-425c-946c-ec2ec185388e]
 description = "Translate RNA strand into correct protein list"
 
@@ -70,3 +86,15 @@ description = "Translation stops if STOP codon in middle of three-codon sequence
 
 [2c2a2a60-401f-4a80-b977-e0715b23b93d]
 description = "Translation stops if STOP codon in middle of six-codon sequence"
+
+[1e75ea2a-f907-4994-ae5c-118632a1cb0f]
+description = "Non-existing codon can't translate"
+
+[9eac93f3-627a-4c90-8653-6d0a0595bc6f]
+description = "Unknown amino acids, not part of a codon, can't translate"
+
+[9d73899f-e68e-4291-b1e2-7bf87c00f024]
+description = "Incomplete RNA sequence can't translate"
+
+[43945cf7-9968-402d-ab9f-b8a28750b050]
+description = "Incomplete RNA sequence can translate if valid until a STOP codon"

--- a/exercises/practice/protein-translation/test/protein_translation_test.exs
+++ b/exercises/practice/protein-translation/test/protein_translation_test.exs
@@ -52,16 +52,49 @@ defmodule ProteinTranslationTest do
     end
 
     @tag :pending
-    test "invalid codon" do
-      assert ProteinTranslation.of_codon("INVALID") == {:error, "invalid codon"}
+    test "incomplete codon" do
+      assert ProteinTranslation.of_codon("UG") == {:error, "invalid codon"}
+    end
+
+    @tag :pending
+    test "too long, invalid codon" do
+      assert ProteinTranslation.of_codon("UGGG") == {:error, "invalid codon"}
+    end
+
+    @tag :pending
+    test "known amino acids, but invalid codon" do
+      assert ProteinTranslation.of_codon("AAA") == {:error, "invalid codon"}
+    end
+
+    @tag :pending
+    test "unknown amino acids, not part of a codon" do
+      assert ProteinTranslation.of_codon("XYZ") == {:error, "invalid codon"}
     end
   end
 
   describe "of_rna" do
     @tag :pending
+    test "empty RNA sequence results in no proteins" do
+      strand = ""
+      assert ProteinTranslation.of_rna(strand) == {:ok, []}
+    end
+
+    @tag :pending
     test "translates rna strand into correct protein" do
       strand = "AUGUUUUGG"
       assert ProteinTranslation.of_rna(strand) == {:ok, ~w(Methionine Phenylalanine Tryptophan)}
+    end
+
+    @tag :pending
+    test "sequence of two identical protein codons translates into two identical proteins" do
+      strand = "UUUUUU"
+      assert ProteinTranslation.of_rna(strand) == {:ok, ~w(Phenylalanine Phenylalanine)}
+    end
+
+    @tag :pending
+    test "sequence of two different protein codons translates into two identical proteins" do
+      strand = "UUAUUG"
+      assert ProteinTranslation.of_rna(strand) == {:ok, ~w(Leucine Leucine)}
     end
 
     @tag :pending
@@ -95,13 +128,39 @@ defmodule ProteinTranslationTest do
     end
 
     @tag :pending
-    test "invalid RNA" do
-      assert ProteinTranslation.of_rna("CARROT") == {:error, "invalid RNA"}
+    test "incomplete codon, invalid RNA" do
+      strand = "UG"
+      assert ProteinTranslation.of_rna(strand) == {:error, "invalid RNA"}
+    end
+
+    @tag :pending
+    test "known amino acids, but invalid codon, invalid RNA" do
+      strand = "AAA"
+      assert ProteinTranslation.of_rna(strand) == {:error, "invalid RNA"}
+    end
+
+    @tag :pending
+    test "unknown amino acids, not part of a codon, invalid RNA" do
+      strand = "XYZ"
+      assert ProteinTranslation.of_rna("XYZ") == {:error, "invalid RNA"}
     end
 
     @tag :pending
     test "invalid codon at end of RNA" do
-      assert ProteinTranslation.of_rna("UUUROT") == {:error, "invalid RNA"}
+      strand = "UUUROT"
+      assert ProteinTranslation.of_rna(strand) == {:error, "invalid RNA"}
+    end
+
+    @tag :pending
+    test "incomplete RNA" do
+      strand = "AUGU"
+      assert ProteinTranslation.of_rna(strand) == {:error, "invalid RNA"}
+    end
+
+    @tag :pending
+    test "incomplete RNA valid until a STOP codon" do
+      strand = "UUCUUCUAAUGGU"
+      assert ProteinTranslation.of_rna(strand) == {:ok, ~w(Phenylalanine Phenylalanine)}
     end
   end
 end


### PR DESCRIPTION
This one was a bit more challenging because Elixir's implementation has two separate functions, `of_codon` and `of_rna`, but problem specs only define a single function. For this reason I took some liberties by duplicating some test cases and changing their order.

The 7 new cases can be split into 3 categories:
- 1 test for empty input: https://github.com/exercism/problem-specifications/blob/main/exercises/protein-translation/canonical-data.json#L3-L16
- 2 tests for two cases where two identical proteins are returned: https://github.com/exercism/problem-specifications/blob/main/exercises/protein-translation/canonical-data.json#L170-L190
- 4 tests for input validation: https://github.com/exercism/problem-specifications/blob/main/exercises/protein-translation/canonical-data.json#L245-L312

Before that, there was no input validation defined in problem specs, but we already had some.