### PR TITLE
Set 5 seconds time limit for test to pass.

### DIFF
--- a/exercises/concept/rpn-calculator-inspection/test/rpn_calculator_inspection_test.exs
+++ b/exercises/concept/rpn-calculator-inspection/test/rpn_calculator_inspection_test.exs
@@ -344,7 +344,7 @@ defmodule RPNCalculatorInspectionTest do
       assert_receive(
         {:outputs, ^expected},
         5000,
-        "This test shouldn't take this long to complete. Make sure to start all tasks first before awaiting them"
+        "This test shouldn't take this long to complete. Make sure to start all tasks first before awaiting them."
       )
     end
 

--- a/exercises/concept/rpn-calculator-inspection/test/rpn_calculator_inspection_test.exs
+++ b/exercises/concept/rpn-calculator-inspection/test/rpn_calculator_inspection_test.exs
@@ -344,7 +344,7 @@ defmodule RPNCalculatorInspectionTest do
       assert_receive(
         {:outputs, ^expected},
         5000,
-        "This test shouldn't take this long complete. Make sure to start all tasks first before awaiting them"
+        "This test shouldn't take this long to complete. Make sure to start all tasks first before awaiting them"
       )
     end
 


### PR DESCRIPTION
Allow test to timeout and fail when exercise solution is taking too much time to finish. This improves user experience and to fix the issue that the tests pass on local but not on-site.