### PR TITLE
Sync: Add error handling to `space-age`

### DIFF
--- a/config.json
+++ b/config.json
@@ -1059,6 +1059,7 @@
         "prerequisites": [
           "floating-point-numbers",
           "atoms",
+          "tuples",
           "multiple-clause-functions",
           "pattern-matching",
           "maps",

--- a/exercises/practice/space-age/.meta/example.ex
+++ b/exercises/practice/space-age/.meta/example.ex
@@ -1,12 +1,19 @@
 defmodule SpaceAge do
-  def age_on(:earth, seconds), do: seconds / 31_557_600.0
-  def age_on(planet, seconds), do: age_on(:earth, seconds) / planet_rel_years(planet)
+  def age_on(:earth, seconds), do: {:ok, seconds / 31_557_600.0}
 
-  defp planet_rel_years(:mercury), do: 0.2408467
-  defp planet_rel_years(:venus), do: 0.61519726
-  defp planet_rel_years(:mars), do: 1.8808158
-  defp planet_rel_years(:jupiter), do: 11.862615
-  defp planet_rel_years(:saturn), do: 29.447498
-  defp planet_rel_years(:uranus), do: 84.016846
-  defp planet_rel_years(:neptune), do: 164.79132
+  def age_on(planet, seconds) do
+    with {:ok, rel} <- planet_rel_years(planet),
+         {:ok, earth} <- age_on(:earth, seconds) do
+      {:ok, earth / rel}
+    end
+  end
+
+  defp planet_rel_years(:mercury), do: {:ok, 0.2408467}
+  defp planet_rel_years(:venus), do: {:ok, 0.61519726}
+  defp planet_rel_years(:mars), do: {:ok, 1.8808158}
+  defp planet_rel_years(:jupiter), do: {:ok, 11.862615}
+  defp planet_rel_years(:saturn), do: {:ok, 29.447498}
+  defp planet_rel_years(:uranus), do: {:ok, 84.016846}
+  defp planet_rel_years(:neptune), do: {:ok, 164.79132}
+  defp planet_rel_years(_), do: {:error, "not a planet"}
 end

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [84f609af-5a91-4d68-90a3-9e32d8a5cd34]
 description = "age on Earth"

--- a/exercises/practice/space-age/lib/space_age.ex
+++ b/exercises/practice/space-age/lib/space_age.ex
@@ -11,9 +11,9 @@ defmodule SpaceAge do
 
   @doc """
   Return the number of years a person that has lived for 'seconds' seconds is
-  aged on 'planet'.
+  aged on 'planet', or an error if 'planet' is not a planet.
   """
-  @spec age_on(planet, pos_integer) :: float
+  @spec age_on(planet, pos_integer) :: {:ok, float} | {:error, String.t()}
   def age_on(planet, seconds) do
   end
 end

--- a/exercises/practice/space-age/test/space_age_test.exs
+++ b/exercises/practice/space-age/test/space_age_test.exs
@@ -4,55 +4,76 @@ defmodule SpaceAgeTest do
   # @tag :pending
   test "age on Earth" do
     input = 1_000_000_000
-    assert_in_delta 31.69, SpaceAge.age_on(:earth, input), 0.005
+    {:ok, age} = SpaceAge.age_on(:earth, input)
+    assert_in_delta 31.69, age, 0.005
   end
 
   @tag :pending
   test "age on Mercury" do
     input = 2_134_835_688
-    assert_in_delta 67.65, SpaceAge.age_on(:earth, input), 0.005
-    assert_in_delta 280.88, SpaceAge.age_on(:mercury, input), 0.005
+    {:ok, age} = SpaceAge.age_on(:earth, input)
+    assert_in_delta 67.65, age, 0.005
+    {:ok, age} = SpaceAge.age_on(:mercury, input)
+    assert_in_delta 280.88, age, 0.005
   end
 
   @tag :pending
   test "age on Venus" do
     input = 189_839_836
-    assert_in_delta 6.02, SpaceAge.age_on(:earth, input), 0.005
-    assert_in_delta 9.78, SpaceAge.age_on(:venus, input), 0.005
+    {:ok, age} = SpaceAge.age_on(:earth, input)
+    assert_in_delta 6.02, age, 0.005
+    {:ok, age} = SpaceAge.age_on(:venus, input)
+    assert_in_delta 9.78, age, 0.005
   end
 
   @tag :pending
   test "age on Mars" do
     input = 2_129_871_239
-    assert_in_delta 67.49, SpaceAge.age_on(:earth, input), 0.005
-    assert_in_delta 35.88, SpaceAge.age_on(:mars, input), 0.005
+    {:ok, age} = SpaceAge.age_on(:earth, input)
+    assert_in_delta 67.49, age, 0.005
+    {:ok, age} = SpaceAge.age_on(:mars, input)
+    assert_in_delta 35.88, age, 0.005
   end
 
   @tag :pending
   test "age on Jupiter" do
     input = 901_876_382
-    assert_in_delta 28.58, SpaceAge.age_on(:earth, input), 0.005
-    assert_in_delta 2.41, SpaceAge.age_on(:jupiter, input), 0.005
+    {:ok, age} = SpaceAge.age_on(:earth, input)
+    assert_in_delta 28.58, age, 0.005
+    {:ok, age} = SpaceAge.age_on(:jupiter, input)
+    assert_in_delta 2.41, age, 0.005
   end
 
   @tag :pending
   test "age on Saturn" do
     input = 2_000_000_000
-    assert_in_delta 63.38, SpaceAge.age_on(:earth, input), 0.005
-    assert_in_delta 2.15, SpaceAge.age_on(:saturn, input), 0.005
+    {:ok, age} = SpaceAge.age_on(:earth, input)
+    assert_in_delta 63.38, age, 0.005
+    {:ok, age} = SpaceAge.age_on(:saturn, input)
+    assert_in_delta 2.15, age, 0.005
   end
 
   @tag :pending
   test "age on Uranus" do
     input = 1_210_123_456
-    assert_in_delta 38.35, SpaceAge.age_on(:earth, input), 0.005
-    assert_in_delta 0.46, SpaceAge.age_on(:uranus, input), 0.005
+    {:ok, age} = SpaceAge.age_on(:earth, input)
+    assert_in_delta 38.35, age, 0.005
+    {:ok, age} = SpaceAge.age_on(:uranus, input)
+    assert_in_delta 0.46, age, 0.005
   end
 
   @tag :pending
   test "age on Neptune" do
     input = 1_821_023_456
-    assert_in_delta 57.70, SpaceAge.age_on(:earth, input), 0.005
-    assert_in_delta 0.35, SpaceAge.age_on(:neptune, input), 0.005
+    {:ok, age} = SpaceAge.age_on(:earth, input)
+    assert_in_delta 57.70, age, 0.005
+    {:ok, age} = SpaceAge.age_on(:neptune, input)
+    assert_in_delta 0.35, age, 0.005
+  end
+
+  @tag :pending
+  test "invalid planet causes error" do
+    input = 680_804_807
+    assert SpaceAge.age_on(:sun, input) == {:error, "not a planet"}
   end
 end


### PR DESCRIPTION
This one is a breaking change, because the new test required an error message, so I changed the output to `{:ok, answer} | {:error, message}`.