### PR TITLE
Sync: small updates to 5 exercises

### DIFF
--- a/exercises/practice/accumulate/.meta/tests.toml
+++ b/exercises/practice/accumulate/.meta/tests.toml
@@ -8,6 +8,7 @@
 #
 # As user-added comments (using the # character) will be removed when this file
 # is regenerated, comments can be added via a `comment` key.
+
 [64d97c14-36dd-44a8-9621-2cecebd6ed23]
 description = "accumulate empty"
 
@@ -22,3 +23,8 @@ description = "accumulate reversed strings"
 
 [bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb]
 description = "accumulate recursively"
+include = false
+
+[0b357334-4cad-49e1-a741-425202edfc7c]
+description = "accumulate recursively"
+reimplements = "bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb"

--- a/exercises/practice/forth/.meta/tests.toml
+++ b/exercises/practice/forth/.meta/tests.toml
@@ -8,8 +8,12 @@
 #
 # As user-added comments (using the # character) will be removed when this file
 # is regenerated, comments can be added via a `comment` key.
+
 [9962203f-f00a-4a85-b404-8a8ecbcec09d]
 description = "parsing and numbers -> numbers just get pushed onto the stack"
+
+[fd7a8da2-6818-4203-a866-fed0714e7aa0]
+description = "parsing and numbers -> pushes negative numbers onto the stack"
 
 [9e69588e-a3d8-41a3-a371-ea02206c1e6e]
 description = "addition -> can add two numbers"
@@ -130,6 +134,9 @@ description = "user-defined words -> cannot redefine negative numbers"
 
 [5180f261-89dd-491e-b230-62737e09806f]
 description = "user-defined words -> errors if executing a non-existent word"
+
+[3c8bfef3-edbb-49c1-9993-21d4030043cb]
+description = "user-defined words -> only defines locally"
 
 [7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6]
 description = "case-insensitivity -> DUP is case-insensitive"

--- a/exercises/practice/forth/test/forth_test.exs
+++ b/exercises/practice/forth/test/forth_test.exs
@@ -9,6 +9,16 @@ defmodule ForthTest do
     end
 
     @tag :pending
+    test "pushes negative numbers onto the stack" do
+      s =
+        Forth.new()
+        |> Forth.eval("-1 -2 -3 -4 -5")
+        |> Forth.format_stack()
+
+      assert s == "-1 -2 -3 -4 -5"
+    end
+
+    @tag :pending
     test "numbers just get pushed onto the stack" do
       s =
         Forth.new()
@@ -414,6 +424,24 @@ defmodule ForthTest do
       assert_raise Forth.UnknownWord, fn ->
         Forth.new() |> Forth.eval("foo")
       end
+    end
+
+    @tag :pending
+    test "only defines locally" do
+      s =
+        Forth.new()
+        |> Forth.eval(": + - ;")
+        |> Forth.eval("1 1 +")
+        |> Forth.format_stack()
+
+      assert s == "0"
+
+      s =
+        Forth.new()
+        |> Forth.eval("1 1 +")
+        |> Forth.format_stack()
+
+      assert s == "2"
     end
   end
 

--- a/exercises/practice/hello-world/.docs/instructions.md
+++ b/exercises/practice/hello-world/.docs/instructions.md
@@ -8,7 +8,7 @@ or environment.
 
 The objectives are simple:
 
-- Write a function that returns the string "Hello, World!".
+- Modify the provided code so that it produces the string "Hello, World!".
 - Run the test suite and make sure that it succeeds.
 - Submit your solution and check it at the website.
 

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [64f61791-508e-4f5c-83ab-05de042b0149]
 description = "empty sentence"
@@ -31,3 +38,8 @@ description = "mixed case and punctuation"
 
 [2577bf54-83c8-402d-a64b-a2c0f7bb213a]
 description = "case insensitive"
+include = false
+
+[7138e389-83e4-4c6e-8413-1e40a0076951]
+description = "a-m and A-M are 26 different characters but not a pangram"
+reimplements = "2577bf54-83c8-402d-a64b-a2c0f7bb213a"

--- a/exercises/practice/pangram/test/pangram_test.exs
+++ b/exercises/practice/pangram/test/pangram_test.exs
@@ -54,7 +54,11 @@ defmodule PangramTest do
   @tag :pending
   test "case insensitive" do
     assert Pangram.pangram?("the quick brown fox jumps over the lazy DOG")
-    refute Pangram.pangram?("the quick brown fox jumps over with lazy FX")
+  end
+
+  @tag :pending
+  test "a-m and A-M are 26 different characters but not a pangram" do
+    refute Pangram.pangram?("abcdefghijklm ABCDEFGHIJKLM")
   end
 
   @tag :pending

--- a/exercises/practice/zipper/.meta/tests.toml
+++ b/exercises/practice/zipper/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [771c652e-0754-4ef0-945c-0675d12ef1f5]
 description = "data is retained"
@@ -19,6 +26,9 @@ description = "traversing up from top"
 
 [b8505f6a-aed4-4c2e-824f-a0ed8570d74b]
 description = "left, right, and up"
+
+[b9aa8d54-07b7-4bfd-ab6b-7ff7f35930b6]
+description = "test ability to descend multiple levels and return"
 
 [47df1a27-b709-496e-b381-63a03b82ea5f]
 description = "set_value"

--- a/exercises/practice/zipper/test/zipper_test.exs
+++ b/exercises/practice/zipper/test/zipper_test.exs
@@ -45,6 +45,12 @@ defmodule ZipperTest do
   end
 
   @tag :pending
+  test "test ability to descend multiple levels and return" do
+    zipper = t1() |> from_tree() |> left() |> right() |> up() |> up()
+    assert value(zipper) == 1
+  end
+
+  @tag :pending
   test "set_value" do
     assert t1() |> from_tree() |> left() |> set_value(5) |> to_tree() == t2()
   end


### PR DESCRIPTION
I decided to pool some more small updates.

- `hello-world`: doc update
- `accumulate`: typo in test description upstream, nothing to change here
- `zipper`: add one test case
- `pangram`: re-implement one test case
- `forth`: add 2 test cases