### PR TITLE
nil concept is missing a link target

### DIFF
--- a/concepts/nil/introduction.md
+++ b/concepts/nil/introduction.md
@@ -8,3 +8,5 @@ favorite_color = nil
 ```
 
 In other programming languages, `null` or `none` values might play a similar role.
+
+[nil-dictionary]: https://www.merriam-webster.com/dictionary/nil


### PR DESCRIPTION
I brought `[nil-dictionary]` over from the "about" document.

https://exercism.org/tracks/elixir/concepts/nil

![image](https://user-images.githubusercontent.com/122470/152213613-1b34c2d1-c368-4ac0-a6ab-f4d8e30c52f8.png)
