### PR TITLE
Update boutique-inventory test cases

### DIFF
--- a/exercises/concept/boutique-inventory/test/boutique_inventory_test.exs
+++ b/exercises/concept/boutique-inventory/test/boutique_inventory_test.exs
@@ -75,7 +75,7 @@ defmodule BoutiqueInventoryTest do
     end
 
     @tag task_id: 3
-    test "increases quantity of an item" do
+    test "works for an item with an existing quantity map" do
       assert BoutiqueInventory.increase_quantity(
                %{
                  name: "Green Swimming Shorts",

--- a/exercises/concept/boutique-inventory/test/boutique_inventory_test.exs
+++ b/exercises/concept/boutique-inventory/test/boutique_inventory_test.exs
@@ -70,7 +70,7 @@ defmodule BoutiqueInventoryTest do
              ) == %{
                name: "Long Black Evening Dress",
                price: 105,
-               quantity_by_size: %{}
+               quantity_by_size: %{s: 1, m: 1, l: 1, xl: 1}
              }
     end
 


### PR DESCRIPTION
Quick disclaimer: My first PR for this repo, so all feedback is very welcome.

### Description

This PR addresses two small things for the `boutique-inventory` exercise.
- Updates the test case for the first test `works for an empty quantity map` for `task_id: 3` to be more aligned with what in the exercise description. See exercise quote below.
- Updates a test description to be more aligned with the former test with the same `task_id: 3`

> Implement the `increase_quantity/2` function. It should take a single item and a number `n`, and return that item with the quantity for each size increased by `n`.

This PR came about as I was doing the exercise and didn't fully comprehend the test. I believe this is what the test was originally meant to assert. I haven't gone about the practicalities of adding myself to any contribution lists etc.