### PR TITLE
Go out of beta for all concept exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -42,7 +42,7 @@
           "basics"
         ],
         "prerequisites": [],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "pacman-rules",
@@ -54,7 +54,7 @@
         "prerequisites": [
           "basics"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "freelancer-rates",
@@ -67,7 +67,7 @@
         "prerequisites": [
           "basics"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "secrets",
@@ -80,7 +80,7 @@
         "prerequisites": [
           "basics"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "log-level",
@@ -93,7 +93,7 @@
         "prerequisites": [
           "booleans"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "language-list",
@@ -105,7 +105,7 @@
         "prerequisites": [
           "booleans"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "guessing-game",
@@ -119,7 +119,7 @@
         "prerequisites": [
           "cond"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "kitchen-calculator",
@@ -134,7 +134,7 @@
           "floating-point-numbers",
           "multiple-clause-functions"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "high-school-sweetheart",
@@ -148,7 +148,7 @@
           "lists",
           "pattern-matching"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "bird-count",
@@ -163,7 +163,7 @@
           "multiple-clause-functions",
           "guards"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "high-score",
@@ -179,7 +179,7 @@
           "anonymous-functions",
           "default-arguments"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "city-office",
@@ -197,7 +197,7 @@
           "maps",
           "multiple-clause-functions"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "german-sysadmin",
@@ -213,7 +213,7 @@
           "pattern-matching",
           "guards"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "date-parser",
@@ -225,7 +225,7 @@
         "prerequisites": [
           "strings"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "rpg-character-sheet",
@@ -239,7 +239,7 @@
           "maps",
           "atoms"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "name-badge",
@@ -253,7 +253,7 @@
           "strings",
           "booleans"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "take-a-number",
@@ -269,7 +269,7 @@
           "pattern-matching",
           "tuples"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "wine-cellar",
@@ -285,7 +285,7 @@
           "if",
           "default-arguments"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "dna-encoding",
@@ -300,7 +300,7 @@
           "recursion",
           "pattern-matching"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "library-fees",
@@ -316,7 +316,7 @@
           "atoms",
           "if"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "basketball-website",
@@ -331,7 +331,7 @@
           "recursion",
           "nil"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "boutique-inventory",
@@ -348,7 +348,7 @@
           "nil",
           "anonymous-functions"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "file-sniffer",
@@ -363,7 +363,7 @@
           "if",
           "bitstrings"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "newsletter",
@@ -379,7 +379,7 @@
           "processes",
           "pids"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "chessboard",
@@ -394,7 +394,7 @@
           "bitstrings",
           "charlists"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "remote-control-car",
@@ -412,7 +412,7 @@
           "default-arguments",
           "keyword-lists"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "boutique-suggestions",
@@ -428,7 +428,7 @@
           "keyword-lists",
           "tuples"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "community-garden",
@@ -442,7 +442,7 @@
           "maps",
           "structs"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "bread-and-potions",
@@ -455,7 +455,7 @@
           "structs",
           "nil"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "captains-log",
@@ -473,7 +473,7 @@
           "charlists",
           "atoms"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "need-for-speed",
@@ -491,7 +491,7 @@
           "structs",
           "io"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "rpn-calculator",
@@ -506,7 +506,7 @@
           "pattern-matching",
           "structs"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "stack-underflow",
@@ -519,7 +519,7 @@
           "access-behaviour",
           "errors"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "rpn-calculator-output",
@@ -550,7 +550,7 @@
           "errors",
           "maps"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "lucas-numbers",
@@ -567,7 +567,7 @@
           "anonymous-functions",
           "errors"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "mensch-aergere-dich-nicht",
@@ -595,7 +595,7 @@
           "errors",
           "dates-and-time"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "top-secret",
@@ -612,7 +612,7 @@
           "guards",
           "enum"
         ],
-        "status": "beta"
+        "status": "active"
       }
     ],
     "practice": [


### PR DESCRIPTION
This practically doesn't change anything, but I think all concept exercises have been around long enough to mark them as "active", not "beta".