### PR TITLE
Fix flakiness test from take-a-number

### DIFF
--- a/exercises/concept/take-a-number/test/take_a_number_test.exs
+++ b/exercises/concept/take-a-number/test/take_a_number_test.exs
@@ -84,30 +84,13 @@ defmodule TakeANumberTest do
     send(pid, {:report_state, self()})
     assert_receive 1
 
-    # wait_until/3 is a custom helper function that tries to
-    # evaluate the given expression a few times until it returns true.
     # This is necessary because `Process.info/1` is not guaranteed to return up-to-date info immediately.
+    dirty_hacky_delay_to_ensure_up_to_date_process_info = 200
+    :timer.sleep(dirty_hacky_delay_to_ensure_up_to_date_process_info)
 
     # Do not use `Process.info/1` in your own code.
     # It's meant for debugging purposes only.
     # We use it here for didactic purposes because there is no alternative that would achieve the same result.
-    assert wait_until(fn ->
-             Keyword.get(Process.info(pid), :message_queue_len) == 0
-           end)
-  end
-
-  defp wait_until(condition_fn, max_retries \\ 5, current_try \\ 1) do
-    condition_fn_return = condition_fn.()
-
-    cond do
-      condition_fn_return == true ->
-        true
-
-      max_retries > current_try ->
-        :timer.sleep(100) && wait_until(condition_fn, max_retries, current_try + 1)
-
-      max_retries <= current_try ->
-        condition_fn_return
-    end
+    assert Keyword.get(Process.info(pid), :message_queue_len) == 0
   end
 end

--- a/exercises/concept/take-a-number/test/take_a_number_test.exs
+++ b/exercises/concept/take-a-number/test/take_a_number_test.exs
@@ -84,6 +84,30 @@ defmodule TakeANumberTest do
     send(pid, {:report_state, self()})
     assert_receive 1
 
-    assert Keyword.get(Process.info(pid), :message_queue_len) == 0
+    # wait_until/3 is a custom helper function that tries to
+    # evaluate the given expression a few times until it returns true.
+    # This is necessary because `Process.info/1` is not guaranteed to return up-to-date info immediately.
+
+    # Do not use `Process.info/1` in your own code.
+    # It's meant for debugging purposes only.
+    # We use it here for didactic purposes because there is no alternative that would achieve the same result.
+    assert wait_until(fn ->
+             Keyword.get(Process.info(pid), :message_queue_len) == 0
+           end)
+  end
+
+  defp wait_until(condition_fn, max_retries \\ 5, current_try \\ 1) do
+    condition_fn_return = condition_fn.()
+
+    cond do
+      condition_fn_return == true ->
+        true
+
+      max_retries > current_try ->
+        :timer.sleep(100) && wait_until(condition_fn, max_retries, current_try + 1)
+
+      max_retries <= current_try ->
+        condition_fn_return
+    end
   end
 end


### PR DESCRIPTION
Resolves #1021

I was just about to open a PR that just removes this test and then checks in the analyzer if a catch-all was used, but i realized it would be terrible student-experience. The last test, and the only test for the last 5th task, would pass without the student having to do any work. They might not even notice that the 5th task was there if they do it task by task and rely on the test runner output to know when they're done, and then they would be hit with an analyzer warning...

I decided to do a dirty tricky and add a retry mechanism to the assertion to fight the flakiness. I know that the students on the web won't see the content of this new private function, so I tried to describe it.