### PR TITLE
Add cross-concept linking to intros and abouts

### DIFF
--- a/concepts/agent/introduction.md
+++ b/concepts/agent/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-The `Agent` module facilitates an abstraction for spawning processes and the _receive-send_ loop. From here, we will call processes started using the `Agent` module _'agent processes'_. An _agent process_ might be chosen to represent a central shared state.
+The `Agent` module facilitates an abstraction for spawning [processes and the _receive-send_ loop][exercism-processes]. From here, we will call processes started using the `Agent` module _'agent processes'_. An _agent process_ might be chosen to represent a central shared state.
 
 To start an _agent process_, `Agent` provides the `start/2` function. The supplied function when `start`_-ing_ the _agent process_ returns the initial state of the process:
 
@@ -12,3 +12,5 @@ To start an _agent process_, `Agent` provides the `start/2` function. The suppli
 Just like `Map` or `List`, `Agent` provides many functions for working with _agent processes_.
 
 It is customary to organize and encapsulate all `Agent`-related functionality into a module for the domain being modeled.
+
+[exercism-processes]: https://exercism.org/tracks/elixir/concepts/processes

--- a/concepts/binaries/introduction.md
+++ b/concepts/binaries/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Elixir provides an elegant syntax for working with binary data as we have seen with the `<<>>` special form provided for working with _bitstrings_.
+Elixir provides an elegant syntax for working with binary data as we have seen with the `<<>>` special form provided for working with [bitstrings][exercism-bitstrings].
 
 The binary type is a specialization on the bitstring type. Where bitstrings could be of any length (any number of [bits][wiki-bit]), binaries are where the number of bits can be evenly divided by 8. That is, when working with binaries, we often think of things in terms of [bytes][wiki-byte] (8 bits). A byte can represent integer numbers from `0` to `255`. It is common to work with byte values in [hexadecimal][wiki-hexadecimal], `0x00 - 0xFF`.
 
@@ -16,7 +16,7 @@ A _null-byte_ is another name for `<<0>>`.
 
 ## Pattern matching on binary data
 
-Pattern matching is even extended to binaries, and we can pattern match on a portion of binary data much like we could for a list.
+[Pattern matching][exercism-pattern-matching] is even extended to binaries, and we can pattern match on a portion of binary data much like we could for a list.
 
 ```elixir
 # Ignore the first 8 bytes, match and bind the remaining to `body`
@@ -28,3 +28,5 @@ Like with other types of pattern matching, we can use this in function signature
 [wiki-bit]: https://en.wikipedia.org/wiki/Bit
 [wiki-byte]: https://en.wikipedia.org/wiki/Byte
 [wiki-hexadecimal]: https://en.wikipedia.org/wiki/Hexadecimal
+[exercism-bitstrings]: https://exercism.org/tracks/elixir/concepts/bitstrings
+[exercism-pattern-matching]: https://exercism.org/tracks/elixir/concepts/pattern-matching

--- a/concepts/case/about.md
+++ b/concepts/case/about.md
@@ -2,7 +2,7 @@
 
 [`case`][case] is a control flow structure that allows us to compare a given value against many patterns. Clauses in a `case` expression are evaluated from top to bottom, until a match is found.
 
-In many cases, using `case` is interchangeable with defining multiple function clauses. Pattern matching and guards can be used in `case` clauses.
+In many cases, using `case` is interchangeable with defining [multiple function clauses][exercism-multiple-clause-functions]. [Pattern matching][exercism-pattern-matching] and [guards][exercism-guards] can be used in `case` clauses.
 
 ```elixir
 # one function clause, multiple case clauses
@@ -27,3 +27,6 @@ def age_group(_), do: 'adult'
 There are no strict rules for choosing one over the other. It's a matter of personal preference that usually depends on context.
 
 [case]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#case/2
+[exercism-multiple-clause-functions]: https://exercism.org/tracks/elixir/concepts/multiple-clause-functions
+[exercism-pattern-matching]: https://exercism.org/tracks/elixir/concepts/pattern-matching
+[exercism-guards]: https://exercism.org/tracks/elixir/concepts/guards

--- a/concepts/enum/about.md
+++ b/concepts/enum/about.md
@@ -14,7 +14,7 @@ And much more! Refer to the [`Enum` module documentation][enum-functions] for a 
 
 ## Enumerable
 
-In general, an _enumerable_ is any data that can be iterated over, a collection. In Elixir, an enumerable is any data type that implements the `Enumerable` protocol. Those are:
+In general, an _enumerable_ is any data that can be iterated over, a collection. In Elixir, an enumerable is any data type that implements the `Enumerable` [protocol][exercism-protocols]. Those are:
 
 - [`List`][list]
 - [`Map`][map]
@@ -80,3 +80,4 @@ Enum.reduce([1, 2, 3, 4, 5], [], fn x, acc -> [x + 10 | acc] end)
 [date-range]: https://hexdocs.pm/elixir/Date.Range.html
 [io-stream]: https://hexdocs.pm/elixir/IO.Stream.html
 [file-stream]: https://hexdocs.pm/elixir/File.Stream.html
+[exercism-protocols]: https://exercism.org/tracks/elixir/concepts/protocols

--- a/concepts/enum/introduction.md
+++ b/concepts/enum/introduction.md
@@ -30,3 +30,5 @@ When using maps with `Enum` functions, the map gets automatically converted to a
 To transform it back to a map, use `Enum.into/2`. `Enum.into/2` is a function that transforms an enumerable into a collectable - any data structure implementing the `Collectable` protocol. It can be thought of as the opposite of `Enum.reduce/3`.
 
 [exercism-protocols]: https://exercism.org/tracks/elixir/concepts/protocols
+[exercism-lists]: https://exercism.org/tracks/elixir/concepts/lists
+[exercism-maps]: https://exercism.org/tracks/elixir/concepts/maps

--- a/concepts/enum/introduction.md
+++ b/concepts/enum/introduction.md
@@ -2,7 +2,7 @@
 
 `Enum` is a very useful module that provides a set of algorithms for working with enumerables. It offers sorting, filtering, grouping, counting, searching, finding min/max values, and much more.
 
-In general, an _enumerable_ is any data that can be iterated over, a collection. In Elixir, an enumerable is any data type that implements the `Enumerable` protocol. The most common of those are lists and maps.
+In general, an _enumerable_ is any data that can be iterated over, a collection. In Elixir, an enumerable is any data type that implements the `Enumerable` [protocol][exercism-protocols]. The most common of those are [lists][exercism-lists] and [maps][exercism-maps].
 
 Many `Enum` functions accept a function as an argument.
 
@@ -28,3 +28,5 @@ The second argument to `Enum.reduce/3` is the initial value of the accumulator. 
 When using maps with `Enum` functions, the map gets automatically converted to a list of 2 `{key, value}` tuples.
 
 To transform it back to a map, use `Enum.into/2`. `Enum.into/2` is a function that transforms an enumerable into a collectable - any data structure implementing the `Collectable` protocol. It can be thought of as the opposite of `Enum.reduce/3`.
+
+[exercism-protocols]: https://exercism.org/tracks/elixir/concepts/protocols

--- a/concepts/file/about.md
+++ b/concepts/file/about.md
@@ -25,7 +25,7 @@ File.read!("does_not_exist")
 
 ## Files and processes
 
-Every time a file is written to with [`File.write/2`][file-write], a file descriptor is opened and a new Elixir process is spawned. For this reason, writing to a file in a loop using [`File.write/2`][file-write] should be avoided.
+Every time a file is written to with [`File.write/2`][file-write], a file descriptor is opened and a new Elixir [process][exercism-processes] is spawned. For this reason, writing to a file in a loop using [`File.write/2`][file-write] should be avoided.
 
 Instead, a file can be opened using [`File.open/2`][file-open]. The second argument to [`File.open/2`][file-open] is a list of modes, which allows you to specify if you want to open the file for reading or for writing.
 
@@ -92,3 +92,4 @@ Path.expand(Path.join(["~", "documents", "important.txt"]))
 [collectable]: https://hexdocs.pm/elixir/Collectable.html
 [path]: https://hexdocs.pm/elixir/Path.html
 [path-join]: https://hexdocs.pm/elixir/Path.html#join/1
+[exercism-processes]: https://exercism.org/tracks/elixir/concepts/processes

--- a/concepts/file/introduction.md
+++ b/concepts/file/introduction.md
@@ -4,7 +4,7 @@ Functions for working with files are provided by the `File` module.
 
 To read a whole file, use `File.read/1`. To write to a file, use `File.write/2`.
 
-Every time a file is written to with `File.write/2`, a file descriptor is opened and a new Elixir process is spawned. For this reason, writing to a file in a loop using `File.write/2` should be avoided.
+Every time a file is written to with `File.write/2`, a file descriptor is opened and a new Elixir [process][exercism-processes] is spawned. For this reason, writing to a file in a loop using `File.write/2` should be avoided.
 
 Instead, a file can be opened using `File.open/2`. The second argument to `File.open/2` is a list of modes, which allows you to specify if you want to open the file for reading or for writing.
 
@@ -13,3 +13,5 @@ Instead, a file can be opened using `File.open/2`. The second argument to `File.
 When you're finished working with the file, close it with `File.close/1`.
 
 All the mentioned functions from the `File` module also have a `!` variant that raises an error instead of returning an error tuple (e.g. `File.read!/1`). Use that variant if you don't intend to handle errors such as missing files or lack of permissions.
+
+[exercism-processes]: https://exercism.org/tracks/elixir/concepts/processes

--- a/concepts/guards/about.md
+++ b/concepts/guards/about.md
@@ -1,6 +1,6 @@
 # About
 
-[Guards][guards] are used as a complement to pattern matching. They allow for more complex checks. They can be used in [some, but not all situations][where-guards-can-be-used] where pattern matching can be used, for example in function clauses or case clauses.
+[Guards][guards] are used as a complement to [pattern matching][exercism-pattern-matching]. They allow for more complex checks. They can be used in [some, but not all situations][where-guards-can-be-used] where pattern matching can be used, for example in function clauses or case clauses.
 
 ```elixir
 def empty?(list) when is_list(list) and length(list) == 0 do
@@ -50,3 +50,4 @@ end
 [defguard]: https://hexdocs.pm/elixir/Kernel.html#defguard/1
 [naming]: https://hexdocs.pm/elixir/naming-conventions.html#is_-prefix-is_foo
 [where-guards-can-be-used]: https://hexdocs.pm/elixir/master/patterns-and-guards.html#where-patterns-and-guards-can-be-used
+[exercism-pattern-matching]: https://exercism.org/tracks/elixir/concepts/pattern-matching

--- a/concepts/keyword-lists/about.md
+++ b/concepts/keyword-lists/about.md
@@ -1,6 +1,6 @@
 # About
 
-A keyword list is a list of `{key, value}` tuples. There are two way to write a keyword list:
+A keyword list is a list of `{key, value}` [tuples][exercism-tuples]. There are two way to write a keyword list:
 
 ```elixir
 # concise
@@ -105,3 +105,4 @@ Use keyword lists when you don't have a lot of data, but need duplicate keys or 
 [keyword]: https://hexdocs.pm/elixir/Keyword.html
 [access-behaviour]: https://hexdocs.pm/elixir/Access.html
 [keyword-call-syntax]: https://hexdocs.pm/elixir/Keyword.html#module-call-syntax
+[exercism-tuples]: https://exercism.org/tracks/elixir/concepts/tuples

--- a/concepts/keyword-lists/introduction.md
+++ b/concepts/keyword-lists/introduction.md
@@ -6,13 +6,16 @@ Keyword lists are a key-value data structure.
 [month: "April", year: 2018]
 ```
 
-Keyword lists are lists of `{key, value}` tuples, and can also be written as such, but the shorter syntax is more widely used.
+Keyword lists are lists of `{key, value}` [tuples][exercism-tuples], and can also be written as such, but the shorter syntax is more widely used.
 
 ```elixir
 [month: "April"] == [{:month, "April"}]
 # => true
 ```
 
-Keys in a keyword list must be atoms, but the values can be anything. Each key can be used more than once. The key-value pairs in a keyword list are ordered.
+Keys in a keyword list must be [atoms][exercism-atoms], but the values can be anything. Each key can be used more than once. The key-value pairs in a keyword list are ordered.
 
 You can work with keyword lists using the same approaches as for lists, or you can use the `Keyword` module.
+
+[exercism-tuples]: https://exercism.org/tracks/elixir/concepts/tuples
+[exercism-atoms]: https://exercism.org/tracks/elixir/concepts/atoms

--- a/concepts/links/introduction.md
+++ b/concepts/links/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Elixir processes are isolated and don't share anything by default. When an unlinked child process crashes, its parent process is not affected.
+Elixir [processes][exercism-processes] are isolated and don't share anything by default. When an unlinked child process crashes, its parent process is not affected.
 
 This behavior can be changed by _linking_ processes to one another. If two processes are linked, a failure in one process will be propagated to the other process. Links are **bidirectional**.
 
@@ -15,3 +15,5 @@ Linking can also be used for _supervising_ processes. If a process _traps exits_
 A process can be configured to trap exits by calling `Process.flag(:trap_exit, true)`. Note that `Process.flag/2` returns the _old_ value of the flag, not the new one.
 
 The message that will be sent to the process in case a linked process crashes will match the pattern `{:EXIT, from, reason}`, where `from` is a PID. If `reason` is anything other than the atom `:normal`, that means that the process crashed or was forcefully killed.
+
+[exercism-processes]: https://exercism.org/tracks/elixir/concepts/processes

--- a/concepts/processes/introduction.md
+++ b/concepts/processes/introduction.md
@@ -23,7 +23,7 @@ A message can be of any type. Often it consists of atoms and tuples. If you want
 
 `send/2` does not check if the message was received by the recipient, nor if the recipient is still alive. The message ends up in the recipient's _mailbox_ and it will only be read if and when the recipient explicitly asks to _receive messages_.
 
-A message can be read from a mailbox using the `receive/1` macro. It accepts a `do` block that can pattern match on the messages.
+A message can be read from a mailbox using the `receive/1` macro. It accepts a `do` block that can [pattern match][exercism-pattern-matching] on the messages.
 
 ```elixir
 receive do
@@ -37,3 +37,5 @@ end
 ## Receive loop
 
 If you want to receive more than one message, you need to call `receive/1` recursively. It is a common pattern to implement a recursive function, for example named `loop`, that calls `receive/1`, does something with the message, and then calls itself to wait for more messages. If you need to carry some state from one `receive/1` call to another, you can do it by passing an argument to that `loop` function.
+
+[exercism-pattern-matching]: https://exercism.org/tracks/elixir/concepts/pattern-matching

--- a/concepts/streams/introduction.md
+++ b/concepts/streams/introduction.md
@@ -1,7 +1,10 @@
 # Introduction
 
-All functions in the `Enum` module are _eager_. When performing multiple operations on enumerables with the `Enum` module, each operation is going to generate an intermediate result.
+All functions in the [`Enum` module][exercism-enum] are _eager_. When performing multiple operations on enumerables with the `Enum` module, each operation is going to generate an intermediate result.
 
 The `Stream` module is a _lazy_ alternative to the _eager_ `Enum` module. It offers many of the same functions as `Enum`, but instead of generating intermediate results, it builds a series of computations that are only executed once the stream is passed to a function from the `Enum` module.
 
-Streams implement the _Enumerable protocol_ and are composable.
+Streams implement the _Enumerable [protocol][exercism-protocols]_ and are composable -- you can chain them together to create more complex functionality.
+
+[exercism-enum]: https://exercism.org/tracks/elixir/concepts/enum
+[exercism-protocols]: https://exercism.org/tracks/elixir/concepts/protocols

--- a/concepts/structs/introduction.md
+++ b/concepts/structs/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Structs are an extension built on top of maps which provide compile-time checks and default values. A struct is named after the module it is defined in. To define a struct use the `defstruct` construct. The construct usually immediately follows after the module definition. `defstruct` accepts either a list of atoms (for `nil` default values) or a keyword list (for specified default values). The fields without defaults must precede the fields with default values.
+Structs are an extension built on top of [maps][exercism-maps] which provide compile-time checks and default values. A struct is named after the module it is defined in. To define a struct use the `defstruct` construct. The construct usually immediately follows after the module definition. `defstruct` accepts either a list of atoms (for `nil` default values) or a keyword list (for specified default values). The fields without defaults must precede the fields with default values.
 
 ```elixir
 defmodule Plane do
@@ -46,3 +46,5 @@ end
 %User{}
 # => (ArgumentError) the following keys must also be given when building struct User: [:username]
 ```
+
+[exercism-maps]: https://exercism.org/tracks/elixir/concepts/maps

--- a/concepts/tail-call-recursion/introduction.md
+++ b/concepts/tail-call-recursion/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-When recursing through enumerables (lists, bitstrings, strings), there are often two concerns:
+When [recursing][exercism-recursion] through enumerables (lists, bitstrings, strings), there are often two concerns:
 
 - how much memory is required to store the trail of recursive function calls
 - how to build the solution efficiently
@@ -24,3 +24,5 @@ defp do_count([_head | tail], count), do: do_count(tail, count + 1)
 ```
 
 The usage of an accumulator allows us to turn recursive functions into _tail-recursive_ functions. A function is tail-recursive if the _last_ thing executed by the function is a call to itself.
+
+[exercism-recursion]: https://exercism.org/tracks/elixir/concepts/recursion

--- a/concepts/tasks/introduction.md
+++ b/concepts/tasks/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Tasks are processes meant to execute one specific operation.
+Tasks are [processes][exercism-processes] meant to execute one specific operation.
 They usually don't communicate with other processes, but they can return a result to the process that started the task.
 
 Tasks are commonly used to parallelize work.
@@ -18,3 +18,5 @@ Any task started with `Task.async/1` should be awaited because it will send a me
 ## `start`/`start_link`
 
 If you want to start a task for side-effects only, use `Task.start/1` or `Task.start_link/1`. `Task.start/1` will start a task that is not linked to the calling process, and `Task.start_link/1` will start a task that is linked to the calling process. Both functions return a `{:ok, pid}` tuple.
+
+[exercism-processes]: https://exercism.org/tracks/elixir/concepts/processes

--- a/concepts/try-rescue/about.md
+++ b/concepts/try-rescue/about.md
@@ -40,7 +40,7 @@ Rescuing errors in Elixir is done very rarely.
 Usually the rescued error is logged or sent to an external monitoring service, and then reraised.
 This means we usually don't care about the internal structure of the specific error struct.
 
-The [Exceptions concept]( /tracks/elixir/concepts/exceptions) describes how to define custom error structs.
+The [Exceptions concept][exercism-exceptions] describes how to define custom error structs.
 
 ## Avoid anti-patterns
 
@@ -74,3 +74,4 @@ As it's written in [Elixir's getting started guide][getting-started]:
 [errors]: https://elixir-lang.org/getting-started/try-catch-and-rescue.html#errors
 [docs-try]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#try/1
 [argument-error]: https://hexdocs.pm/elixir/ArgumentError.html#content
+[exercism-exceptions]: https://exercism.org/tracks/elixir/concepts/exceptions

--- a/concepts/try-rescue/introduction.md
+++ b/concepts/try-rescue/introduction.md
@@ -30,4 +30,6 @@ Rescuing errors in Elixir is done very rarely.
 Usually the rescued error is logged or sent to an external monitoring service, and then reraised.
 This means we usually don't care about the internal structure of the specific error struct.
 
-In the [Exceptions concept](/tracks/elixir/concepts/exceptions) you will learn more about error structs, including how to define your own custom error.
+In the [Exceptions concept][exercism-exceptions] you will learn more about error structs, including how to define your own custom error.
+
+[exercism-exceptions]: https://exercism.org/tracks/elixir/concepts/exceptions

--- a/exercises/concept/boutique-inventory/.docs/introduction.md
+++ b/exercises/concept/boutique-inventory/.docs/introduction.md
@@ -4,7 +4,7 @@
 
 `Enum` is a very useful module that provides a set of algorithms for working with enumerables. It offers sorting, filtering, grouping, counting, searching, finding min/max values, and much more.
 
-In general, an _enumerable_ is any data that can be iterated over, a collection. In Elixir, an enumerable is any data type that implements the `Enumerable` protocol. The most common of those are lists and maps.
+In general, an _enumerable_ is any data that can be iterated over, a collection. In Elixir, an enumerable is any data type that implements the `Enumerable` [protocol][exercism-protocols]. The most common of those are [lists][exercism-lists] and [maps][exercism-maps].
 
 Many `Enum` functions accept a function as an argument.
 
@@ -30,3 +30,7 @@ The second argument to `Enum.reduce/3` is the initial value of the accumulator. 
 When using maps with `Enum` functions, the map gets automatically converted to a list of 2 `{key, value}` tuples.
 
 To transform it back to a map, use `Enum.into/2`. `Enum.into/2` is a function that transforms an enumerable into a collectable - any data structure implementing the `Collectable` protocol. It can be thought of as the opposite of `Enum.reduce/3`.
+
+[exercism-protocols]: https://exercism.org/tracks/elixir/concepts/protocols
+[exercism-lists]: https://exercism.org/tracks/elixir/concepts/lists
+[exercism-maps]: https://exercism.org/tracks/elixir/concepts/maps

--- a/exercises/concept/community-garden/.docs/introduction.md
+++ b/exercises/concept/community-garden/.docs/introduction.md
@@ -2,7 +2,7 @@
 
 ## Agent
 
-The `Agent` module facilitates an abstraction for spawning processes and the _receive-send_ loop. From here, we will call processes started using the `Agent` module _'agent processes'_. An _agent process_ might be chosen to represent a central shared state.
+The `Agent` module facilitates an abstraction for spawning [processes and the _receive-send_ loop][exercism-processes]. From here, we will call processes started using the `Agent` module _'agent processes'_. An _agent process_ might be chosen to represent a central shared state.
 
 To start an _agent process_, `Agent` provides the `start/2` function. The supplied function when `start`_-ing_ the _agent process_ returns the initial state of the process:
 
@@ -14,3 +14,5 @@ To start an _agent process_, `Agent` provides the `start/2` function. The suppli
 Just like `Map` or `List`, `Agent` provides many functions for working with _agent processes_.
 
 It is customary to organize and encapsulate all `Agent`-related functionality into a module for the domain being modeled.
+
+[exercism-processes]: https://exercism.org/tracks/elixir/concepts/processes

--- a/exercises/concept/dna-encoding/.docs/introduction.md
+++ b/exercises/concept/dna-encoding/.docs/introduction.md
@@ -54,7 +54,7 @@ value == 0b0110
 
 ## Tail Call Recursion
 
-When recursing through enumerables (lists, bitstrings, strings), there are often two concerns:
+When [recursing][exercism-recursion] through enumerables (lists, bitstrings, strings), there are often two concerns:
 
 - how much memory is required to store the trail of recursive function calls
 - how to build the solution efficiently
@@ -78,3 +78,5 @@ defp do_count([_head | tail], count), do: do_count(tail, count + 1)
 ```
 
 The usage of an accumulator allows us to turn recursive functions into _tail-recursive_ functions. A function is tail-recursive if the _last_ thing executed by the function is a call to itself.
+
+[exercism-recursion]: https://exercism.org/tracks/elixir/concepts/recursion

--- a/exercises/concept/file-sniffer/.docs/introduction.md
+++ b/exercises/concept/file-sniffer/.docs/introduction.md
@@ -2,7 +2,7 @@
 
 ## Binaries
 
-Elixir provides an elegant syntax for working with binary data as we have seen with the `<<>>` special form provided for working with _bitstrings_.
+Elixir provides an elegant syntax for working with binary data as we have seen with the `<<>>` special form provided for working with [bitstrings][exercism-bitstrings].
 
 The binary type is a specialization on the bitstring type. Where bitstrings could be of any length (any number of [bits][wiki-bit]), binaries are where the number of bits can be evenly divided by 8. That is, when working with binaries, we often think of things in terms of [bytes][wiki-byte] (8 bits). A byte can represent integer numbers from `0` to `255`. It is common to work with byte values in [hexadecimal][wiki-hexadecimal], `0x00 - 0xFF`.
 
@@ -18,7 +18,7 @@ A _null-byte_ is another name for `<<0>>`.
 
 ### Pattern matching on binary data
 
-Pattern matching is even extended to binaries, and we can pattern match on a portion of binary data much like we could for a list.
+[Pattern matching][exercism-pattern-matching] is even extended to binaries, and we can pattern match on a portion of binary data much like we could for a list.
 
 ```elixir
 # Ignore the first 8 bytes, match and bind the remaining to `body`
@@ -30,3 +30,5 @@ Like with other types of pattern matching, we can use this in function signature
 [wiki-bit]: https://en.wikipedia.org/wiki/Bit
 [wiki-byte]: https://en.wikipedia.org/wiki/Byte
 [wiki-hexadecimal]: https://en.wikipedia.org/wiki/Hexadecimal
+[exercism-bitstrings]: https://exercism.org/tracks/elixir/concepts/bitstrings
+[exercism-pattern-matching]: https://exercism.org/tracks/elixir/concepts/pattern-matching

--- a/exercises/concept/guessing-game/.meta/design.md
+++ b/exercises/concept/guessing-game/.meta/design.md
@@ -31,7 +31,7 @@ A student upon completion will:
 
 ## Narrative
 
-This exercise is a fork from [F#'s Number Guessing Game](https://github.com/exercism/v3/blob/master/languages/fsharp/exercises/concept/pattern-matching/.docs/instructions.md)
+This exercise is a fork from [F#'s Number Guessing Game](https://github.com/exercism/fsharp/tree/main/exercises/concept/guessing-game)
 
 ## Resources to refer to
 

--- a/exercises/concept/lucas-numbers/.docs/introduction.md
+++ b/exercises/concept/lucas-numbers/.docs/introduction.md
@@ -2,8 +2,11 @@
 
 ## Streams
 
-All functions in the `Enum` module are _eager_. When performing multiple operations on enumerables with the `Enum` module, each operation is going to generate an intermediate result.
+All functions in the [`Enum` module][exercism-enum] are _eager_. When performing multiple operations on enumerables with the `Enum` module, each operation is going to generate an intermediate result.
 
 The `Stream` module is a _lazy_ alternative to the _eager_ `Enum` module. It offers many of the same functions as `Enum`, but instead of generating intermediate results, it builds a series of computations that are only executed once the stream is passed to a function from the `Enum` module.
 
-Streams implement the _Enumerable protocol_ and are composable -- you can chain them together to create more complex functionality.
+Streams implement the _Enumerable [protocol][exercism-protocols]_ and are composable -- you can chain them together to create more complex functionality.
+
+[exercism-enum]: https://exercism.org/tracks/elixir/concepts/enum
+[exercism-protocols]: https://exercism.org/tracks/elixir/concepts/protocols

--- a/exercises/concept/newsletter/.docs/introduction.md
+++ b/exercises/concept/newsletter/.docs/introduction.md
@@ -6,7 +6,7 @@ Functions for working with files are provided by the `File` module.
 
 To read a whole file, use `File.read/1`. To write to a file, use `File.write/2`.
 
-Every time a file is written to with `File.write/2`, a file descriptor is opened and a new Elixir process is spawned. For this reason, writing to a file in a loop using `File.write/2` should be avoided.
+Every time a file is written to with `File.write/2`, a file descriptor is opened and a new Elixir [process][exercism-processes] is spawned. For this reason, writing to a file in a loop using `File.write/2` should be avoided.
 
 Instead, a file can be opened using `File.open/2`. The second argument to `File.open/2` is a list of modes, which allows you to specify if you want to open the file for reading or for writing.
 
@@ -15,3 +15,5 @@ Instead, a file can be opened using `File.open/2`. The second argument to `File.
 When you're finished working with the file, close it with `File.close/1`.
 
 All the mentioned functions from the `File` module also have a `!` variant that raises an error instead of returning an error tuple (e.g. `File.read!/1`). Use that variant if you don't intend to handle errors such as missing files or lack of permissions.
+
+[exercism-processes]: https://exercism.org/tracks/elixir/concepts/processes

--- a/exercises/concept/remote-control-car/.docs/introduction.md
+++ b/exercises/concept/remote-control-car/.docs/introduction.md
@@ -2,7 +2,7 @@
 
 ## Structs
 
-Structs are an extension built on top of maps which provide compile-time checks and default values. A struct is named after the module it is defined in. To define a struct use the `defstruct` construct. The construct usually immediately follows after the module definition. `defstruct` accepts either a list of atoms (for `nil` default values) or key-value tuples (for specified default values). The fields without defaults must precede the fields with default values.
+Structs are an extension built on top of [maps][exercism-maps] which provide compile-time checks and default values. A struct is named after the module it is defined in. To define a struct use the `defstruct` construct. The construct usually immediately follows after the module definition. `defstruct` accepts either a list of atoms (for `nil` default values) or a keyword list (for specified default values). The fields without defaults must precede the fields with default values.
 
 ```elixir
 defmodule Plane do
@@ -48,3 +48,5 @@ end
 %User{}
 # => (ArgumentError) the following keys must also be given when building struct User: [:username]
 ```
+
+[exercism-maps]: https://exercism.org/tracks/elixir/concepts/maps

--- a/exercises/concept/rpn-calculator-inspection/.docs/introduction.md
+++ b/exercises/concept/rpn-calculator-inspection/.docs/introduction.md
@@ -2,7 +2,7 @@
 
 ## Links
 
-Elixir processes are isolated and don't share anything by default. When an unlinked child process crashes, its parent process is not affected.
+Elixir [processes][exercism-processes] are isolated and don't share anything by default. When an unlinked child process crashes, its parent process is not affected.
 
 This behavior can be changed by _linking_ processes to one another. If two processes are linked, a failure in one process will be propagated to the other process. Links are **bidirectional**.
 
@@ -20,7 +20,7 @@ The message that will be sent to the process in case a linked process crashes wi
 
 ## Tasks
 
-Tasks are processes meant to execute one specific operation.
+Tasks are [processes][exercism-processes] meant to execute one specific operation.
 They usually don't communicate with other processes, but they can return a result to the process that started the task.
 
 Tasks are commonly used to parallelize work.
@@ -39,3 +39,4 @@ Any task started with `Task.async/1` should be awaited because it will send a me
 
 If you want to start a task for side-effects only, use `Task.start/1` or `Task.start_link/1`. `Task.start/1` will start a task that is not linked to the calling process, and `Task.start_link/1` will start a task that is linked to the calling process. Both functions return a `{:ok, pid}` tuple.
 
+[exercism-processes]: https://exercism.org/tracks/elixir/concepts/processes

--- a/exercises/concept/rpn-calculator/.docs/introduction.md
+++ b/exercises/concept/rpn-calculator/.docs/introduction.md
@@ -43,4 +43,6 @@ Rescuing errors in Elixir is done very rarely.
 Usually the rescued error is logged or sent to an external monitoring service, and then reraised.
 This means we usually don't care about the internal structure of the specific error struct.
 
-In the [Exceptions concept](/tracks/elixir/concepts/exceptions) you will learn more about error structs, including how to define your own custom error.
+In the [Exceptions concept][exercism-exceptions] you will learn more about error structs, including how to define your own custom error.
+
+[exercism-exceptions]: https://exercism.org/tracks/elixir/concepts/exceptions

--- a/exercises/concept/take-a-number/.docs/introduction.md
+++ b/exercises/concept/take-a-number/.docs/introduction.md
@@ -25,7 +25,7 @@ A message can be of any type. Often it consists of atoms and tuples. If you want
 
 `send/2` does not check if the message was received by the recipient, nor if the recipient is still alive. The message ends up in the recipient's _mailbox_ and it will only be read if and when the recipient explicitly asks to _receive messages_.
 
-A message can be read from a mailbox using the `receive/1` macro. It accepts a `do` block that can pattern match on the messages.
+A message can be read from a mailbox using the `receive/1` macro. It accepts a `do` block that can [pattern match][exercism-pattern-matching] on the messages.
 
 ```elixir
 receive do
@@ -43,3 +43,5 @@ If you want to receive more than one message, you need to call `receive/1` recur
 ## PIDs
 
 Process identifiers are their own data type. They function as _mailbox addresses_ - if you have a process's PID, you can send a message to that process. PIDs are usually created indirectly, as a return value of functions that create new processes, like `spawn`.
+
+[exercism-pattern-matching]: https://exercism.org/tracks/elixir/concepts/pattern-matching

--- a/exercises/concept/wine-cellar/.docs/introduction.md
+++ b/exercises/concept/wine-cellar/.docs/introduction.md
@@ -8,13 +8,16 @@ Keyword lists are a key-value data structure.
 [month: "April", year: 2018]
 ```
 
-Keyword lists are lists of `{key, value}` tuples, and can also be written as such, but the shorter syntax is more widely used.
+Keyword lists are lists of `{key, value}` [tuples][exercism-tuples], and can also be written as such, but the shorter syntax is more widely used.
 
 ```elixir
 [month: "April"] == [{:month, "April"}]
 # => true
 ```
 
-Keys in a keyword list must be atoms, but the values can be anything. Each key can be used more than once. The key-value pairs in a keyword list are ordered.
+Keys in a keyword list must be [atoms][exercism-atoms], but the values can be anything. Each key can be used more than once. The key-value pairs in a keyword list are ordered.
 
 You can work with keyword lists using the same approaches as for lists, or you can use the `Keyword` module.
+
+[exercism-tuples]: https://exercism.org/tracks/elixir/concepts/tuples
+[exercism-atoms]: https://exercism.org/tracks/elixir/concepts/atoms

--- a/exercises/practice/pythagorean-triplet/.docs/hints.md
+++ b/exercises/practice/pythagorean-triplet/.docs/hints.md
@@ -1,5 +1,5 @@
 ## General
 
-- If checking through all sorts of triangles is too slow, consider that [right triangles grow on trees](triples).
+- If checking through all sorts of triangles is too slow, consider that [right triangles grow on trees][triples].
 
 [triples]: https://en.wikipedia.org/wiki/Tree_of_primitive_Pythagorean_triples

--- a/reference/exercise-concepts/robot-simulator.md
+++ b/reference/exercise-concepts/robot-simulator.md
@@ -94,7 +94,7 @@ defmodule RobotSimulator do
 end
 ```
 
-[Canonical](https://github.com/exercism/elixir/blob/master/exercises/robot-simulator/example.exs)
+[Canonical](https://github.com/exercism/elixir/blob/main/exercises/practice/robot-simulator/.meta/example.ex)
 
 ```elixir
 defmodule RobotSimulator do

--- a/reference/implementing-a-concept-exercise.md
+++ b/reference/implementing-a-concept-exercise.md
@@ -94,8 +94,8 @@ If you have any questions regarding implementing the exercise, please post them 
 [how-to-implement-a-concept-exercise]: https://github.com/exercism/v3/blob/main/docs/maintainers/generic-how-to-implement-a-concept-exercise.md
 [docs-rationale-for-v3]: https://github.com/exercism/v3/blob/main/docs/rationale-for-v3.md
 [docs-features-of-v3]: https://github.com/exercism/v3/blob/main/docs/features-of-v3.md
-[anatomy-of-a-concept]: https://github.com/exercism/docs/blob/main/anatomy/tracks/concepts.md
-[anatomy-of-a-concept-exercise]: https://github.com/exercism/docs/blob/main/anatomy/tracks/concept-exercises.md
+[anatomy-of-a-concept]: https://github.com/exercism/docs/blob/main/building/tracks/concepts.md
+[anatomy-of-a-concept-exercise]: https://github.com/exercism/docs/blob/main/building/tracks/concept-exercises.md
 [anatomy-of-a-concept-exercise-video]: https://www.youtube.com/watch?v=gkbBqd7hPrA
 [reference]: https://github.com/exercism/v3/blob/main/reference/README.md
 [config-json]: https://github.com/exercism/docs/blob/main/anatomy/tracks/config-json.md


### PR DESCRIPTION
Resolves #580

I tried to avoid linking between concepts that are taught by the same exercise, e.g. multiple clause functions and guards, processes and pids.
