### PR TITLE
Small fixes to `basics` intro

### DIFF
--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -23,25 +23,46 @@ end
 
 ## Named functions
 
-_Named Functions_ must be defined in a module. Each function can have zero or more arguments. All arguments are dynamically-typed, and the return type is not explicitly declared, it is the type of the value returned. An _access modifier_ can be specified for functions, making only desired functions available for use external to the module. In a function, the value of the last expression is _implicitly returned_ to the calling function.
+_Named Functions_ must be defined in a module. The `def` keyword is used to define a _public_ named function.
 
-Invoking a function is done by specifying its module and function name and passing arguments for each of the function's arguments. The module name may be omitted if the function is invoked inside of the module.
-
-You may also write short functions using a one-line syntax (note the comma `,` and the colon `:` around the keyword `do`).
+Each function can have zero or more arguments. The value of the last expression in a function is always _implicitly returned_.
 
 ```elixir
 defmodule Calculator do
   def add(x, y) do
     x + y
   end
-
-  def short_add(x, y), do: x + y
 end
+ ```
 
+Invoking a function is done by specifying its module and function name and passing arguments for each of the function's arguments.
+
+```elixir
 sum = Calculator.add(1, 2)
 # => 3
-sum = Calculator.short_add(2, 2)
-# => 4
+```
+
+The `defp` keyword can be used instead of `def` to define a _private_ function. Private functions can only be used from within the same module that defined them.
+
+When invoking a function inside the same module where it's defined, the module name can be omitted.
+
+You may also write short functions using a one-line syntax (note the comma `,` and the colon `:` around the keyword `do`).
+
+```elixir
+defmodule Calculator do
+  def subtract(x, y) do
+    private_subtract(x, y)
+  end
+
+  defp private_subtract(x, y), do: x - y
+end
+
+difference = Calculator.subtract(7, 2)
+# => 5
+
+difference = Calculator.private_subtract(7, 2)
+# => ** (UndefinedFunctionError) function Calculator.private_subtract/2 is undefined or private
+#       Calculator.private_subtract(7, 2)
 ```
 
 ## Arity of functions

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -27,25 +27,46 @@ end
 
 ### Named functions
 
-_Named Functions_ must be defined in a module. Each function can have zero or more arguments. All arguments are dynamically-typed, and the return type is not explicitly declared, it is the type of the value returned. An _access modifier_ can be specified for functions, making only desired functions available for use external to the module. In a function, the value of the last line is _implicitly returned_ to the calling function.
+_Named Functions_ must be defined in a module. The `def` keyword is used to define a _public_ named function.
 
-Invoking a function is done by specifying its module and function name and passing arguments for each of the function's arguments. The module name may be omitted if the function is invoked inside of the module.
-
-You may also write short functions using a one-line syntax (note the comma `,` and the colon `:` around the keyword `do`).
+Each function can have zero or more arguments. The value of the last expression in a function is always _implicitly returned_.
 
 ```elixir
 defmodule Calculator do
   def add(x, y) do
     x + y
   end
-
-  def short_add(x, y), do: x + y
 end
+ ```
 
+Invoking a function is done by specifying its module and function name and passing arguments for each of the function's arguments.
+
+```elixir
 sum = Calculator.add(1, 2)
 # => 3
-sum = Calculator.short_add(2, 2)
-# => 4
+```
+
+The `defp` keyword can be used instead of `def` to define a _private_ function. Private functions can only be used from within the same module that defined them.
+
+When invoking a function inside the same module where it's defined, the module name can be omitted.
+
+You may also write short functions using a one-line syntax (note the comma `,` and the colon `:` around the keyword `do`).
+
+```elixir
+defmodule Calculator do
+  def subtract(x, y) do
+    private_subtract(x, y)
+  end
+
+  defp private_subtract(x, y), do: x - y
+end
+
+difference = Calculator.subtract(7, 2)
+# => 5
+
+difference = Calculator.private_subtract(7, 2)
+# => ** (UndefinedFunctionError) function Calculator.private_subtract/2 is undefined or private
+#       Calculator.private_subtract(7, 2)
 ```
 
 ### Arity of functions

--- a/exercises/concept/lasagna/.meta/design.md
+++ b/exercises/concept/lasagna/.meta/design.md
@@ -25,13 +25,11 @@
 - Anonymous functions.
 - Default arguments.
 - Organizing functions in namespaces.
-- Visibility (`defp`).
-- Single-line functions
 - `@moduledoc` and `@doc` multi-line comments
 
 ## Concepts
 
-- `basics`: know what a variable is; know how to define a variable; know how to update a variable; know how to use type inference for variables; know how to define a function; know how to return a value from a function; know how to call a function; know that functions must be defined in classes; know about the `public` access modifier; know how to define an integer; know how to define a string; know how to use mathematical operators on integers; know how to define single-line comments.
+- `basics`: know what a variable is; know how to define a variable; know how to update a variable; know how to use type inference for variables; know how to define a function; know how to return a value from a function; know how to call a function; know that functions must be defined in modules; know how to define an integer; know how to define a string; know how to use mathematical operators on integers; know how to define single-line comments.
 
 ## Prerequisites
 


### PR DESCRIPTION
Prompted by @SleeplessByte's comment https://github.com/exercism/elixir-analyzer/issues/267#issuecomment-1066008048, I reviewed the basics intro to check if it mentions that module names can be skipped in local calls. It did, but in a way that was very easy to miss.

I rewrote the basics intro a bit so that:
- There is a code example of calling a function without a module name.
- Both `def` and `defp` are clearly mentioned by name and shown in code examples. The design document claimed `depf` is out of scope, but that's wrong, no other concept mentions `defp` later and we are using it in other exercises.
- Remove the phrase "access modifier" because it doesn't apply in Elixir like it does in other languages where "public" or "private" are stand-alone keywords.