### PR TITLE
Fix practice exercise hints

### DIFF
--- a/exercises/practice/darts/.docs/hints.md
+++ b/exercises/practice/darts/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - The distance of a point `(x, y)` from the center of the target `(0, 0)` can be calculated with `sqrt(x*x + y *y)`

--- a/exercises/practice/diffie-hellman/.docs/hints.md
+++ b/exercises/practice/diffie-hellman/.docs/hints.md
@@ -1,4 +1,6 @@
-# General
+# Hints
+
+## General
 
 - For generating random numbers, Erlang's `:rand.uniform` or `Enum.random` are
 good places to start.

--- a/exercises/practice/pythagorean-triplet/.docs/hints.md
+++ b/exercises/practice/pythagorean-triplet/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - If checking through all sorts of triangles is too slow, consider that [right triangles grow on trees][triples].

--- a/exercises/practice/secret-handshake/.docs/hints.md
+++ b/exercises/practice/secret-handshake/.docs/hints.md
@@ -1,4 +1,6 @@
-# General
+# Hints
+
+## General
 
 - Use `Bitwise` (or div/rem).
 - If you use `Bitwise`, an easy way to see if a particular bit is set is to compare

--- a/exercises/practice/strain/.docs/hints.md
+++ b/exercises/practice/strain/.docs/hints.md
@@ -1,3 +1,5 @@
-# General
+# Hints
+
+## General
 
 - `apply` will let you pass arguments to a function, as will `fun.(args)`.

--- a/exercises/practice/tournament/.docs/hints.md
+++ b/exercises/practice/tournament/.docs/hints.md
@@ -1,4 +1,6 @@
-# General
+# Hints
+
+## General
 
 - Formatting the output is easy with `String`'s padding functions. All number
 columns can be left-padded with spaces to a width of 2 characters, while the


### PR DESCRIPTION
To have the hints show up for a practice exercise, the `hints.md` file has to have an `## General` heading.
Some of the existing `hints.md` file only contained a `# General` heading, which caused the hints to not be displayed.
This PR fixes this, whilst also adding a top-level `# Hints` heading, which is required for the documents markdown to lint correctly (we might add this to configlet sometime).
