### PR TITLE
Add doc tests to the doc concept and corresponding city-office exercise

### DIFF
--- a/bin/test_exercises.sh
+++ b/bin/test_exercises.sh
@@ -93,8 +93,14 @@ do
       module_name=$(cat "${test_file}" | sed -rn 's/^defmodule (.*)Test do$/\1 /p')
       doctest_code="doctest ${module_name}"
 
-      # .bak and rm part left here to simplify GNU/BSD sed options compatibility
-      sed -i.bak 's/use ExUnit.Case\(.*\)/use ExUnit.Case\1\n'" ${doctest_code}"'\n/g' "${test_file}" && rm -f "${test_file}.bak"
+      if [ ${module_name} != "Form" ]
+      then
+        # This module is skipped because it contains tests *for* doc tests.
+        # It already *has* a `doctest ...` line, and mix really doesn't like seeing that in a module twice.
+
+        # .bak and rm part left here to simplify GNU/BSD sed options compatibility
+        sed -i.bak 's/use ExUnit.Case\(.*\)/use ExUnit.Case\1\n'" ${doctest_code}"'\n/g' "${test_file}" && rm -f "${test_file}.bak"
+      fi
 
       # perform unit tests
       set +e

--- a/bin/test_exercises.sh
+++ b/bin/test_exercises.sh
@@ -93,14 +93,8 @@ do
       module_name=$(cat "${test_file}" | sed -rn 's/^defmodule (.*)Test do$/\1 /p')
       doctest_code="doctest ${module_name}"
 
-      if [ ${module_name} != "Form" ]
-      then
-        # This module is skipped because it contains tests *for* doc tests.
-        # It already *has* a `doctest ...` line, and mix really doesn't like seeing that in a module twice.
-
-        # .bak and rm part left here to simplify GNU/BSD sed options compatibility
-        sed -i.bak 's/use ExUnit.Case\(.*\)/use ExUnit.Case\1\n'" ${doctest_code}"'\n/g' "${test_file}" && rm -f "${test_file}.bak"
-      fi
+      # .bak and rm part left here to simplify GNU/BSD sed options compatibility
+      sed -i.bak 's/^  use ExUnit.Case\(.*\)/  use ExUnit.Case\1\n'" ${doctest_code}"'\n/' "${test_file}" && rm -f "${test_file}.bak"
 
       # perform unit tests
       set +e
@@ -141,7 +135,7 @@ do
 done
 
 # clean up
-rm -rf tmp-exercises
+#rm -rf tmp-exercises
 
 # report
 printf -- '-%.0s' {1..80}; echo ""

--- a/bin/test_exercises.sh
+++ b/bin/test_exercises.sh
@@ -135,7 +135,7 @@ do
 done
 
 # clean up
-#rm -rf tmp-exercises
+rm -rf tmp-exercises
 
 # report
 printf -- '-%.0s' {1..80}; echo ""

--- a/concepts/docs/about.md
+++ b/concepts/docs/about.md
@@ -6,6 +6,7 @@ Elixir documentation:
 - Written in [**Markdown**][markdown].
 - Added by using special module attributes.
 - Typically uses the heredoc syntax for multiline strings.
+- Can include unit tests.
 
 Module attributes used for documentation:
 
@@ -91,6 +92,10 @@ Many modern IDEs that support Elixir can parse and display documentation and typ
 ## Internal modules and function
 
 If a module or a function is intended for internal usage only, you can mark it with `@moduledoc false` or `@doc false`. Those modules and functions will not be included in the generated documentation. Note that that doesn't make them private. They can still be invoked and/or imported. Check the [official documentation about hiding internal modules and functions][hiding-internal-modules-and-functions] to learn about potential solutions to this problem.
+
+## Doc tests
+
+You can attach unit tests directly to functions by including them in the `@doc` attribute. These are offset by indenting them 4 spaces. They start with a `iex>` prompt, just like in an `iex` shell. The output from the test is on a new line, indented the same 4 spaces. A blank space goes between each test. See the example at the top of the page.
 
 [markdown]: https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax
 [official-documentation]: https://hexdocs.pm/elixir/

--- a/concepts/docs/introduction.md
+++ b/concepts/docs/introduction.md
@@ -4,7 +4,7 @@ Documentation in Elixir is a first-class citizen.
 
 There are two module attributes commonly used to document your code - `@moduledoc` for documenting a module and `@doc` for documenting a function that follows the attribute. The `@moduledoc` attribute usually appears on the first line of the module, and the `@doc` attribute usually appears right before a function definition, or the function's typespec if it has one. The documentation is commonly written in a multiline string using the heredoc syntax.
 
-Elixir documentation is written in [**Markdown**][markdown].
+Elixir documentation is written in [**Markdown**][markdown]. Tests can be embedded in documentation using "doc tests" which are indented 4 spaces and start with `iex>`, as shown below.
 
 ```elixir
 defmodule String do

--- a/exercises/concept/city-office/.docs/instructions.md
+++ b/exercises/concept/city-office/.docs/instructions.md
@@ -16,7 +16,7 @@ A collection of loosely related functions helpful for filling out various forms 
 
 ## 2. Document filling out fields with blank values
 
-Add documentation and a typespec to the `Form.blanks/1` function. The documentation should read:
+Add documentation, a doc test, and a typespec to the `Form.blanks/1` function. The documentation should read:
 
 ```
 Generates a string of a given length.
@@ -25,11 +25,13 @@ This string can be used to fill out a form field that is supposed to have no val
 Such fields cannot be left empty because a malicious third party could fill them out with false data.
 ```
 
+Add a doc test at the end of the documentation. Test with 3 as your input.
+
 The typespec should explain that the function accepts a single argument, a non-negative integer, and returns a string.
 
 ## 3. Document splitting values into lists of uppercase letters
 
-Add documentation and a typespec to the `Form.letters/1` function. The documentation should read:
+Add documentation, a doc test, and a typespec to the `Form.letters/1` function. The documentation should read:
 
 ```
 Splits the string into a list of uppercase letters.
@@ -38,11 +40,13 @@ This is needed for form fields that don't offer a single input for the whole str
 but instead require splitting the string into a predefined number of single-letter inputs.
 ```
 
+Add a doc test at the end of the documentation. Test with the word "hello".
+
 The typespec should explain that the function accepts a single argument, a string, and returns a list of strings.
 
 ## 4. Document checking if a value fits a field with a max length
 
-Add documentation and a typespec to the `Form.check_length/2` function. The documentation should read:
+Add documentation, 2 doc tests, and a typespec to the `Form.check_length/2` function. The documentation should read:
 
 ```
 Checks if the value has no more than the maximum allowed number of letters.
@@ -66,10 +70,12 @@ Document this fact by defining three custom public types:
 
 ## 6. Document formatting the address
 
-Add documentation and a typespec to the `Form.format_address/1` function. The documentation should read:
+Add documentation, 2 doc tests, and a typespec to the `Form.format_address/1` function. The documentation should read:
 
 ```
 Formats the address as an uppercase multiline string.
 ```
+
+Add 2 doc tests at the end of the documentation. Test once with a map and once with a tuple.
 
 The typespec should explain that the function accepts one argument, an address, and returns a string.

--- a/exercises/concept/city-office/.docs/instructions.md
+++ b/exercises/concept/city-office/.docs/instructions.md
@@ -51,6 +51,8 @@ This is needed to check that the values of fields do not exceed the maximum allo
 It also tells you by how much the value exceeds the maximum.
 ```
 
+Add 2 doc tests at the end of the documentation. One should check for the `:ok` case, and one should check for the `{:error, _}` case.
+
 The typespec should explain that the function accepts two arguments, a string and a non-negative integer, and returns one of two possible values. It returns either the `:ok` atom or a 2-tuple with the first element being the `:error` atom, and the second a positive integer.
 
 ## 5. Document different address formats

--- a/exercises/concept/city-office/.docs/introduction.md
+++ b/exercises/concept/city-office/.docs/introduction.md
@@ -6,7 +6,7 @@ Documentation in Elixir is a first-class citizen.
 
 There are two module attributes commonly used to document your code - `@moduledoc` for documenting a module and `@doc` for documenting a function that follows the attribute. The `@moduledoc` attribute usually appears on the first line of the module, and the `@doc` attribute usually appears right before a function definition, or the function's typespec if it has one. The documentation is commonly written in a multiline string using the heredoc syntax.
 
-Elixir documentation is written in [**Markdown**][markdown].
+Elixir documentation is written in [**Markdown**][markdown]. Tests can be embedded in documentation using "doc tests" which are indented 4 spaces and start with `iex>`, as shown below.
 
 ```elixir
 defmodule String do

--- a/exercises/concept/city-office/.meta/design.md
+++ b/exercises/concept/city-office/.meta/design.md
@@ -12,6 +12,7 @@ This exercise should provide a boilerplate with already implemented functions th
 - naming arguments in a typespec
 - the difference between `String.t()` and `string()`
 - using atom literals in the typespec is a typical pattern (e.g. `{:ok, any()} | {:error, any()}`)
+- define doc tests
 
 ## Out of scope
 

--- a/exercises/concept/city-office/.meta/exemplar.ex
+++ b/exercises/concept/city-office/.meta/exemplar.ex
@@ -12,6 +12,10 @@ defmodule Form do
 
   This string can be used to fill out a form field that is supposed to have no value.
   Such fields cannot be left empty because a malicious third party could fill them out with false data.
+
+  ## Example
+      iex> Form.blanks(3)
+      "XXX"
   """
   @spec blanks(non_neg_integer()) :: String.t()
   def blanks(n) do
@@ -23,6 +27,10 @@ defmodule Form do
 
   This is needed for form fields that don't offer a single input for the whole string,
   but instead require splitting the string into a predefined number of single-letter inputs.
+
+  ## Example
+      iex> Form.letters("hello")
+      ["H", "E", "L", "L", "O"]
   """
   @spec letters(String.t()) :: list(String.t())
   def letters(word) do
@@ -58,6 +66,19 @@ defmodule Form do
 
   @doc """
   Formats the address as an uppercase multiline string.
+
+  ## Examples
+
+      iex> Form.format_address(%{street: "101 Main Street", postal_code: "12345", city: "Smalltown"})
+      "101 MAIN STREET
+      12345 SMALLTOWN
+      "
+
+      iex> Form.format_address({"1 Elixir Way", "78910", "BEAMville"})
+      "1 ELIXIR WAY
+      78910 BEAMVILLE
+      "
+
   """
   @spec format_address(address()) :: String.t()
   def format_address(%{street: street, postal_code: postal_code, city: city}) do

--- a/exercises/concept/city-office/.meta/exemplar.ex
+++ b/exercises/concept/city-office/.meta/exemplar.ex
@@ -36,6 +36,14 @@ defmodule Form do
 
   This is needed to check that the values of fields do not exceed the maximum allowed length.
   It also tells you by how much the value exceeds the maximum.
+
+  ## Examples
+
+      iex> Form.check_length("hello", 5)
+      :ok
+
+      iex> Form.check_length("hello", 3)
+      {:error, 2}
   """
   @spec check_length(String.t(), non_neg_integer()) :: :ok | {:error, pos_integer()}
   def check_length(word, length) do

--- a/exercises/concept/city-office/test/form_test.exs
+++ b/exercises/concept/city-office/test/form_test.exs
@@ -210,9 +210,8 @@ defmodule FormTest do
         doctest Form, only: [{:check_length, 2}], import: true
       end
 
-      output = capture_io(fn -> ExUnit.run() end)
-      IO.inspect(output, label: "output")
-      assert output =~ "2 doctests, 0 failures"
+      doctest_results = ExUnit.run()
+      assert doctest_results == %{excluded: 0, failures: 0, skipped: 0, total: 2}
       assert_doc({:check_length, 2}, "\n    :ok")
       assert_doc({:check_length, 2}, ~r/\n    {:error, \d+}/)
     end

--- a/exercises/concept/city-office/test/form_test.exs
+++ b/exercises/concept/city-office/test/form_test.exs
@@ -1,6 +1,5 @@
 defmodule FormTest do
   use ExUnit.Case
-  import ExUnit.CaptureIO
 
   # Dear Elixir learner,
   # If you're reading this test suite to gain some insights,
@@ -136,6 +135,18 @@ defmodule FormTest do
     test "has a correct spec" do
       assert_spec({:blanks, 1}, ["n :: non_neg_integer()", "non_neg_integer()"], "String.t()")
     end
+
+    @tag task_id: 2
+    test "has a passing doctest using 3 as input" do
+      defmodule BlanksOnly do
+        use ExUnit.Case
+        doctest Form, only: [{:blanks, 1}], import: true
+      end
+
+      doctest_results = ExUnit.run()
+      assert doctest_results == %{excluded: 0, failures: 0, skipped: 0, total: 1}
+      assert_doc({:blanks, 1}, ~s/\n    "XXX"/)
+    end
   end
 
   describe "letters/1" do
@@ -164,6 +175,18 @@ defmodule FormTest do
     @tag task_id: 3
     test "has a typespec" do
       assert_spec({:letters, 1}, ["word :: String.t()", "String.t()"], "[String.t()]")
+    end
+
+    @tag task_id: 3
+    test "has a passing doctest for hello" do
+      defmodule LettersOnly do
+        use ExUnit.Case
+        doctest Form, only: [{:letters, 1}], import: true
+      end
+
+      doctest_results = ExUnit.run()
+      assert doctest_results == %{excluded: 0, failures: 0, skipped: 0, total: 1}
+      assert_doc({:letters, 1}, ~s/\n    ["H", "E", "L", "L", "O"]/)
     end
   end
 
@@ -204,6 +227,7 @@ defmodule FormTest do
       )
     end
 
+    @tag task_id: 4
     test "has 2 passing doctests" do
       defmodule CheckLengthOnly do
         use ExUnit.Case
@@ -281,6 +305,20 @@ defmodule FormTest do
     @tag task_id: 6
     test "has a typespec" do
       assert_spec({:format_address, 1}, ["address :: address()", "address()"], "String.t()")
+    end
+
+    @tag task_id: 6
+    test "has 2 passing doctests, for map and tuple mode" do
+      defmodule FormatAddressOnly do
+        use ExUnit.Case
+        doctest Form, only: [{:format_address, 1}], import: true
+      end
+
+      doctest_results = ExUnit.run()
+      IO.inspect(doctest_results, label: "results")
+      assert doctest_results == %{excluded: 0, failures: 0, skipped: 0, total: 2}
+      assert_doc({:format_address, 1}, ~s/\n    iex> Form.format_address(%{/)
+      assert_doc({:format_address, 1}, ~s/\n    iex> Form.format_address({/)
     end
   end
 end

--- a/exercises/concept/city-office/test/form_test.exs
+++ b/exercises/concept/city-office/test/form_test.exs
@@ -1,5 +1,6 @@
 defmodule FormTest do
   use ExUnit.Case
+  import ExUnit.CaptureIO
 
   # Dear Elixir learner,
   # If you're reading this test suite to gain some insights,
@@ -39,7 +40,7 @@ defmodule FormTest do
         )
       else
         actual_doc = doc_content["en"]
-        assert actual_doc == unquote(expected_doc)
+        assert actual_doc =~ unquote(expected_doc)
       end
     end
   end
@@ -201,6 +202,19 @@ defmodule FormTest do
         ["word :: String.t(), length :: non_neg_integer()", "String.t(), non_neg_integer()"],
         ":ok | {:error, pos_integer()}"
       )
+    end
+
+    test "has 2 passing doctests" do
+      defmodule CheckLengthOnly do
+        use ExUnit.Case
+        doctest Form, only: [{:check_length, 2}], import: true
+      end
+
+      output = capture_io(fn -> ExUnit.run() end)
+      IO.inspect(output, label: "output")
+      assert output =~ "2 doctests, 0 failures"
+      assert_doc({:check_length, 2}, "\n    :ok")
+      assert_doc({:check_length, 2}, ~r/\n    {:error, \d+}/)
     end
   end
 


### PR DESCRIPTION
The docs concept didn't explain doc tests or check that people could write them, and that seemed like a gap. This fills that gap.

(The test for this is based on ExUnit's own tests.)
