### PR TITLE
Remove duplicate "position" in darts typespec

### DIFF
--- a/exercises/practice/darts/.meta/example.ex
+++ b/exercises/practice/darts/.meta/example.ex
@@ -4,7 +4,7 @@ defmodule Darts do
   @doc """
   Calculate the score of a single dart hitting a target
   """
-  @spec score(position :: position) :: integer
+  @spec score(position) :: integer
   def score({x, y}) do
     radius = :math.sqrt(x * x + y * y)
 

--- a/exercises/practice/darts/lib/darts.ex
+++ b/exercises/practice/darts/lib/darts.ex
@@ -4,7 +4,7 @@ defmodule Darts do
   @doc """
   Calculate the score of a single dart hitting a target
   """
-  @spec score(position :: position) :: integer
+  @spec score(position) :: integer
   def score({x, y}) do
   end
 end


### PR DESCRIPTION
The @type "position" reflexes a tuple like {x,y}. 
I think the @spec should not repeat "position" twice in the description of the first and only parameter.