### PR TITLE
Remove personal choice files from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-*.swp
 *.beam
-.DS_Store
 tmp
 tmp-exercises
 bin/configlet


### PR DESCRIPTION
Every dev should set up a personal global `.gitignore` with the files that need to be ignored due to their tooling choices 🙂 