### PR TITLE
Update boutique-inventory with Map.new/2

### DIFF
--- a/concepts/enum/about.md
+++ b/concepts/enum/about.md
@@ -60,6 +60,27 @@ Enum.reduce([1, 2, 3, 4, 5], [], fn x, acc -> [x + 10 | acc] end)
 # => [15, 14, 13, 12, 11]
 ```
 
+## Mapping maps
+
+- With [`Map.new/2`][map-new]:
+  ```elixir
+  %{a: 1, b: 2}
+  |> Map.new(fn {key, value} -> {key, value * 10} end)
+  ```
+
+- With [`Enum.into/3`][map-into]:
+  ```elixir
+  %{a: 1, b: 2}
+  |> Enum.into(%{}, fn {key, value} -> {key, value * 10} end)
+  ```
+
+- With [`Enum.map/3`][map-into-3]:
+  ```elixir
+  %{a: 1, b: 2}
+  |> Enum.map(fn {key, value} -> {key, value * 10} end)
+  |> Enum.into(%{})
+  ```
+
 [enum-functions]: https://hexdocs.pm/elixir/Enum.html#functions
 [enum-sort/2]: https://hexdocs.pm/elixir/Enum.html#sort/2
 [enum-sort_by/2]: https://hexdocs.pm/elixir/Enum.html#sort_by/2
@@ -71,6 +92,9 @@ Enum.reduce([1, 2, 3, 4, 5], [], fn x, acc -> [x + 10 | acc] end)
 [enum-max/3]: https://hexdocs.pm/elixir/Enum.html#max/3
 [enum-reduce/3]: https://hexdocs.pm/elixir/Enum.html#reduce/3
 [enum-reduce_while/3]: https://hexdocs.pm/elixir/Enum.html#reduce_while/3
+[enum-into]: https://hexdocs.pm/elixir/Enum.html#into/3
+[enum-map]: https://hexdocs.pm/elixir/Enum.html#map/2
+[map-new]: https://hexdocs.pm/elixir/Map.html#new/2
 [list]: https://hexdocs.pm/elixir/List.html
 [map]: https://hexdocs.pm/elixir/Map.html
 [range]: https://hexdocs.pm/elixir/Range.html

--- a/concepts/enum/introduction.md
+++ b/concepts/enum/introduction.md
@@ -29,6 +29,12 @@ When using maps with `Enum` functions, the map gets automatically converted to a
 
 To transform it back to a map, use `Enum.into/2`. `Enum.into/2` is a function that transforms an enumerable into a collectable - any data structure implementing the `Collectable` protocol. It can be thought of as the opposite of `Enum.reduce/3`.
 
+`Enum` also have `Enum.into/3`. `Enum.into/3` is a variation of `Enum.into/2` that accepts a transformation function to be applied while transforming the enumerable into a collectable.
+
+#### Mapping maps
+
+Since Elixir 1.13 (December 2021), there is another way of applying a transformation (mapping) to a map. Instead of using `Enum.into/3` or `Enum.map/2` plus `Enum.into/1`, we can also use a dedicated `Map.new/2` function. It works exactly like `Enum.into/3` in that it accepts an enumerable and a transformation function, but it always returns a new map instead of letting us choose a collectible.
+
 [exercism-protocols]: https://exercism.org/tracks/elixir/concepts/protocols
 [exercism-lists]: https://exercism.org/tracks/elixir/concepts/lists
 [exercism-maps]: https://exercism.org/tracks/elixir/concepts/maps

--- a/concepts/enum/introduction.md
+++ b/concepts/enum/introduction.md
@@ -33,7 +33,7 @@ To transform it back to a map, use `Enum.into/2`. `Enum.into/2` is a function th
 
 #### Mapping maps
 
-Since Elixir 1.13 (December 2021), there is another way of applying a transformation (mapping) to a map. Instead of using `Enum.into/3` or `Enum.map/2` plus `Enum.into/1`, we can also use a dedicated `Map.new/2` function. It works exactly like `Enum.into/3` in that it accepts an enumerable and a transformation function, but it always returns a new map instead of letting us choose a collectible.
+Instead of using `Enum.into/3` or `Enum.map/2` plus `Enum.into/1` to apply a transformation (mapping) to a map, we can also use a dedicated `Map.new/2` function. It works exactly like `Enum.into/3` in that it accepts an enumerable and a transformation function, but it always returns a new map instead of letting us choose a collectible.
 
 [exercism-protocols]: https://exercism.org/tracks/elixir/concepts/protocols
 [exercism-lists]: https://exercism.org/tracks/elixir/concepts/lists

--- a/concepts/enum/introduction.md
+++ b/concepts/enum/introduction.md
@@ -29,7 +29,7 @@ When using maps with `Enum` functions, the map gets automatically converted to a
 
 To transform it back to a map, use `Enum.into/2`. `Enum.into/2` is a function that transforms an enumerable into a collectable - any data structure implementing the `Collectable` protocol. It can be thought of as the opposite of `Enum.reduce/3`.
 
-`Enum` also have `Enum.into/3`. `Enum.into/3` is a variation of `Enum.into/2` that accepts a transformation function to be applied while transforming the enumerable into a collectable.
+`Enum` also has `Enum.into/3`. `Enum.into/3` is a variation of `Enum.into/2` that accepts a transformation function to be applied while transforming the enumerable into a collectable.
 
 #### Mapping maps
 

--- a/config.json
+++ b/config.json
@@ -346,6 +346,7 @@
           "atoms",
           "tuples",
           "nil",
+          "strings",
           "anonymous-functions"
         ],
         "status": "active"

--- a/exercises/concept/boutique-inventory/.docs/hints.md
+++ b/exercises/concept/boutique-inventory/.docs/hints.md
@@ -15,7 +15,7 @@
 
 ## 3. Update item names
 
-- There is a [built-in function][enum-map] for replacing every element in an enumerable with another element.
+- There is a [built-in function][enum-map] for transforming every element in an enumerable.
 - There is a [built-in function][string-replace] that can replace all instances of one string with a different one.
 
 ## 4. Increment the item's quantity

--- a/exercises/concept/boutique-inventory/.docs/hints.md
+++ b/exercises/concept/boutique-inventory/.docs/hints.md
@@ -13,14 +13,18 @@
 
 - There is a [built-in function][enum-filter] for filtering enumerables.
 
-## 3. Increment the item's quantity
+## 3. Update item names
+
+- There is a [built-in function][enum-map] for replacing every element in an enumerable with another element.
+- There is a [built-in function][string-replace] that can replace all instances of one string with a different one.
+
+## 4. Increment the item's quantity
 
 - Maps implement the enumerable protocol.
 - `Enum` functions convert maps to a list of `{key, value}` tuples.
-- There is a [built-in function][enum-map] for replacing every element in an enumerable with another element.
-- There is a [built-in function][enum-into] that can transform a list of `{key, value}` tuples back into a map.
+- There are two different functions that can transform a list of `{key, value}` tuples back into a map using a transformation function. [One of them always returns a new map][map-new], while [the other lets you choose a collectible][enum-into].
 
-## 4. Calculate the item's total quantity
+## 5. Calculate the item's total quantity
 
 - Maps implement the enumerable protocol.
 - `Enum` functions convert maps to a list of `{key, value}` tuples.
@@ -32,5 +36,7 @@
 [enum-sort-by]: https://hexdocs.pm/elixir/Enum.html#sort_by/3
 [enum-filter]: https://hexdocs.pm/elixir/Enum.html#filter/2
 [enum-map]: https://hexdocs.pm/elixir/Enum.html#map/2
-[enum-into]: https://hexdocs.pm/elixir/Enum.html#into/2
+[enum-into]: https://hexdocs.pm/elixir/Enum.html#into/3
 [enum-reduce]: https://hexdocs.pm/elixir/Enum.html#reduce/3
+[map-new]: https://hexdocs.pm/elixir/Map.html#new/2
+[string-replace]: https://hexdocs.pm/elixir/String.html#replace/4

--- a/exercises/concept/boutique-inventory/.docs/instructions.md
+++ b/exercises/concept/boutique-inventory/.docs/instructions.md
@@ -50,7 +50,33 @@ BoutiqueInventory.with_missing_price([
 #    ]
 ```
 
-## 3. Increment the item's quantity
+## 3. Update item names
+
+You noticed that some item names have a word that you don't like to use anymore. Now you need to update all the item names with that word.
+
+Implement the `update_names/3` function. It should take the inventory, the old word that you want to remove, and a new word that you want to use instead. It should return a list of items with updated names.
+
+```elixir
+BoutiqueInventory.update_names(
+  [
+    %{price: 40, name: "Black T-shirt", quantity_by_size: %{}},
+    %{price: 70, name: "Denim Pants", quantity_by_size: %{}},
+    %{price: 65, name: "Denim Skirt", quantity_by_size: %{}},
+    %{price: 40, name: "Orange T-shirt", quantity_by_size: %{}}
+  ],
+  "T-shirt",
+  "Tee"
+)
+# => [
+#      %{price: 40, name: "Black Tee", quantity_by_size: %{}},
+#      %{price: 70, name: "Denim Pants", quantity_by_size: %{}},
+#      %{price: 65, name: "Denim Skirt", quantity_by_size: %{}},
+#      %{price: 40, name: "Orange Tee", quantity_by_size: %{}}
+#    ]
+```
+
+
+## 4. Increment the item's quantity
 
 Some items were selling especially well, so you ordered more, in all sizes.
 
@@ -73,7 +99,7 @@ BoutiqueInventory.increase_quantity(
 
 ```
 
-## 4. Calculate the item's total quantity
+## 5. Calculate the item's total quantity
 
 To know how much space you need in your storage, you need to know how many of each item you have in total.
 

--- a/exercises/concept/boutique-inventory/.docs/introduction.md
+++ b/exercises/concept/boutique-inventory/.docs/introduction.md
@@ -35,7 +35,7 @@ To transform it back to a map, use `Enum.into/2`. `Enum.into/2` is a function th
 
 #### Mapping maps
 
-Since Elixir 1.13 (December 2021), there is another way of applying a transformation (mapping) to a map. Instead of using `Enum.into/3` or `Enum.map/2` plus `Enum.into/1`, we can also use a dedicated `Map.new/2` function. It works exactly like `Enum.into/3` in that it accepts an enumerable and a transformation function, but it always returns a new map instead of letting us choose a collectible.
+Instead of using `Enum.into/3` or `Enum.map/2` plus `Enum.into/1` to apply a transformation (mapping) to a map, we can also use a dedicated `Map.new/2` function. It works exactly like `Enum.into/3` in that it accepts an enumerable and a transformation function, but it always returns a new map instead of letting us choose a collectible.
 
 [exercism-protocols]: https://exercism.org/tracks/elixir/concepts/protocols
 [exercism-lists]: https://exercism.org/tracks/elixir/concepts/lists

--- a/exercises/concept/boutique-inventory/.docs/introduction.md
+++ b/exercises/concept/boutique-inventory/.docs/introduction.md
@@ -31,7 +31,7 @@ When using maps with `Enum` functions, the map gets automatically converted to a
 
 To transform it back to a map, use `Enum.into/2`. `Enum.into/2` is a function that transforms an enumerable into a collectable - any data structure implementing the `Collectable` protocol. It can be thought of as the opposite of `Enum.reduce/3`.
 
-`Enum` also have `Enum.into/3`. `Enum.into/3` is a variation of `Enum.into/2` that accepts a transformation function to be applied while transforming the enumerable into a collectable.
+`Enum` also has `Enum.into/3`. `Enum.into/3` is a variation of `Enum.into/2` that accepts a transformation function to be applied while transforming the enumerable into a collectable.
 
 #### Mapping maps
 

--- a/exercises/concept/boutique-inventory/.docs/introduction.md
+++ b/exercises/concept/boutique-inventory/.docs/introduction.md
@@ -31,6 +31,12 @@ When using maps with `Enum` functions, the map gets automatically converted to a
 
 To transform it back to a map, use `Enum.into/2`. `Enum.into/2` is a function that transforms an enumerable into a collectable - any data structure implementing the `Collectable` protocol. It can be thought of as the opposite of `Enum.reduce/3`.
 
+`Enum` also have `Enum.into/3`. `Enum.into/3` is a variation of `Enum.into/2` that accepts a transformation function to be applied while transforming the enumerable into a collectable.
+
+#### Mapping maps
+
+Since Elixir 1.13 (December 2021), there is another way of applying a transformation (mapping) to a map. Instead of using `Enum.into/3` or `Enum.map/2` plus `Enum.into/1`, we can also use a dedicated `Map.new/2` function. It works exactly like `Enum.into/3` in that it accepts an enumerable and a transformation function, but it always returns a new map instead of letting us choose a collectible.
+
 [exercism-protocols]: https://exercism.org/tracks/elixir/concepts/protocols
 [exercism-lists]: https://exercism.org/tracks/elixir/concepts/lists
 [exercism-maps]: https://exercism.org/tracks/elixir/concepts/maps

--- a/exercises/concept/boutique-inventory/.meta/config.json
+++ b/exercises/concept/boutique-inventory/.meta/config.json
@@ -3,7 +3,8 @@
     "angelikatyborska"
   ],
   "contributors": [
-    "neenjaw"
+    "neenjaw",
+    "fmmatheus"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/boutique-inventory/.meta/design.md
+++ b/exercises/concept/boutique-inventory/.meta/design.md
@@ -32,5 +32,6 @@
 
 - The function `sort_by_price/1` should use `Enum.sort_by`.
 - The function `with_missing_price/1` should use `Enum.filter` or `Enum.reject`.
-- The function `increase_quantity/2` should use `Enum.map`.
+- The function `update_names/3` should use `Enum.map`.
+- The function `increase_quantity/2` should use `Map.new`.
 - The function `total_quantity/1` should use `Enum.reduce`.

--- a/exercises/concept/boutique-inventory/.meta/exemplar.ex
+++ b/exercises/concept/boutique-inventory/.meta/exemplar.ex
@@ -7,11 +7,16 @@ defmodule BoutiqueInventory do
     Enum.filter(inventory, fn item -> Map.get(item, :price) == nil end)
   end
 
+  def update_names(inventory, old_word, new_word) do
+    Enum.map(inventory, fn item ->
+      Map.update!(item, :name, fn name -> String.replace(name, old_word, new_word) end)
+    end)
+  end
+
   def increase_quantity(item, count) do
     Map.update(item, :quantity_by_size, %{}, fn quantity_by_size ->
       quantity_by_size
-      |> Enum.map(fn {size, quantity} -> {size, quantity + count} end)
-      |> Enum.into(%{})
+      |> Map.new(fn {size, quantity} -> {size, quantity + count} end)
     end)
   end
 

--- a/exercises/concept/boutique-inventory/lib/boutique_inventory.ex
+++ b/exercises/concept/boutique-inventory/lib/boutique_inventory.ex
@@ -7,6 +7,10 @@ defmodule BoutiqueInventory do
     # Please implement the with_missing_price/1 function
   end
 
+  def update_names(inventory, old_word, new_word) do
+    # Please implement the update_names/3 function
+  end
+
   def increase_quantity(item, count) do
     # Please implement the increase_quantity/2 function
   end

--- a/exercises/concept/boutique-inventory/test/boutique_inventory_test.exs
+++ b/exercises/concept/boutique-inventory/test/boutique_inventory_test.exs
@@ -57,8 +57,45 @@ defmodule BoutiqueInventoryTest do
     end
   end
 
-  describe "increase_quantity/2" do
+  describe "update_names/3" do
     @tag task_id: 3
+    test "works for an empty inventory" do
+      assert BoutiqueInventory.update_names([], "T-Shirt", "Tee") == []
+    end
+
+    @tag task_id: 3
+    test "replaces the word in all the names" do
+      assert BoutiqueInventory.update_names(
+               [
+                 %{name: "Bambo Socks Avocado", price: 10, quantity_by_size: %{}},
+                 %{name: "3x Bambo Socks Palm Trees", price: 26, quantity_by_size: %{}},
+                 %{name: "Red Sequin Top", price: 87, quantity_by_size: %{}}
+               ],
+               "Bambo",
+               "Bamboo"
+             ) == [
+               %{name: "Bamboo Socks Avocado", price: 10, quantity_by_size: %{}},
+               %{name: "3x Bamboo Socks Palm Trees", price: 26, quantity_by_size: %{}},
+               %{name: "Red Sequin Top", price: 87, quantity_by_size: %{}}
+             ]
+    end
+
+    @tag task_id: 3
+    test "replaces all the instances of the word within one name" do
+      assert BoutiqueInventory.update_names(
+               [
+                 %{name: "GO! GO! GO! Tee", price: 8, quantity_by_size: %{}}
+               ],
+               "GO!",
+               "Go!"
+             ) == [
+               %{name: "Go! Go! Go! Tee", price: 8, quantity_by_size: %{}}
+             ]
+    end
+  end
+
+  describe "increase_quantity/2" do
+    @tag task_id: 4
     test "works for an empty quantity map" do
       assert BoutiqueInventory.increase_quantity(
                %{
@@ -74,7 +111,7 @@ defmodule BoutiqueInventoryTest do
              }
     end
 
-    @tag task_id: 3
+    @tag task_id: 4
     test "increases quantity of an item" do
       assert BoutiqueInventory.increase_quantity(
                %{
@@ -92,7 +129,7 @@ defmodule BoutiqueInventoryTest do
   end
 
   describe "total_quantity/1" do
-    @tag task_id: 4
+    @tag task_id: 5
     test "works for an empty quantity map" do
       assert BoutiqueInventory.total_quantity(%{
                name: "Red Denim Pants",
@@ -101,7 +138,7 @@ defmodule BoutiqueInventoryTest do
              }) == 0
     end
 
-    @tag task_id: 4
+    @tag task_id: 5
     test "sums up total quantity" do
       assert BoutiqueInventory.total_quantity(%{
                name: "Black Denim Skirt",


### PR DESCRIPTION
Supersedes https://github.com/exercism/elixir/pull/973/files by @fmmatheus

I'm sorry @fmmatheus but there was no response from you for many months, so I decided to open a new PR because we need this change.

This PR addresses two problems. Firstly, Elixir 1.13 introduced a better way to map maps. It's `Map.new/2` (note that `Map.map/2` was initially added but later deprecated). Secondly, the initial implementation of `increase_quantity` was not perfect because it uses `Enum.map/2` + `Enum.into/2` instead of just `Enum.into/3`. Now, the ideal implementation of `increase_quantity` uses `Map.new/2`.

This created the problem that `Enum.map/2` is no longer used in this exercise. To solve this problem, I am adding a new task based on @fmmatheus's idea from the original PR.
