### PR TITLE
Run older Elixir with OTP 21 instead of 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,9 @@ jobs:
       matrix:
         include:
           - elixir: '1.8.0'
-            otp: '20.0'
+            otp: '21.0'
           - elixir: '1.9.0'
-            otp: '20.0'
+            otp: '21.0'
           - elixir: '1.10.0'
             otp: '21.0'
           - elixir: '1.10.0'

--- a/.github/workflows/pr.ci.yml
+++ b/.github/workflows/pr.ci.yml
@@ -73,9 +73,9 @@ jobs:
       matrix:
         include:
           - elixir: '1.8.0'
-            otp: '20.0'
+            otp: '21.0'
           - elixir: '1.9.0'
-            otp: '20.0'
+            otp: '21.0'
           - elixir: '1.10.0'
             otp: '21.0'
           - elixir: '1.10.0'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Setup
 
-The exercises currently target Elixir versions from 1.8 to 1.13 and Erlang/OTP versions from 20 to 24. Detailed installation instructions can be found at
+The exercises currently target Elixir versions from 1.8 to 1.13 and Erlang/OTP versions from 21 to 24. Detailed installation instructions can be found at
 [http://elixir-lang.org/install.html](http://elixir-lang.org/install.html). We recommend using the [asdf version manager](https://github.com/asdf-vm/asdf) to manage multiple Elixir versions.
 
 ## Testing


### PR DESCRIPTION
The usage of OTP 20 is preventing the new GenServer learning exercise from being finished. See: https://github.com/exercism/elixir/pull/1076#issuecomment-1089187674