### PR TITLE
docs(freelancer-rates): fix typo

### DIFF
--- a/exercises/concept/freelancer-rates/.docs/instructions.md
+++ b/exercises/concept/freelancer-rates/.docs/instructions.md
@@ -47,7 +47,7 @@ The returned monthly rate should be rounded up (take the ceiling) to the nearest
 
 ## 4. Calculate the number of workdays given a budget, hourly rate and discount
 
-Implement a function that takes a budget, a hourly rate, and a discount, and calculates how many days of work that covers.
+Implement a function that takes a budget, an hourly rate, and a discount, and calculates how many days of work that covers.
 
 ```elixir
 FreelancerRates.days_in_budget(20000, 80, 11.0)


### PR DESCRIPTION
Change "a hourly rate" to "an hourly rate" in step 4 of the instructions.