### PR TITLE
[language-list] use less suggestive function name

### DIFF
--- a/exercises/concept/language-list/.docs/hints.md
+++ b/exercises/concept/language-list/.docs/hints.md
@@ -28,7 +28,7 @@
 - You need to define a [named function][named-function] with 1 argument. The first argument is a [list][list] of language [string-literals][string].
 - Elixir [provides a function][length] to count the length of a list.
 
-## 6. Define a function to determine if the list is exciting
+## 6. Define a function to determine if the list includes a functional language
 
 - You need to define a [named function][named-function] with 1 argument. The first argument is a [list][list] of language [string-literals][string].
 - Your function should return a boolean value indicating whether `"Elixir"` is a member of the list. Elixir [provides a function][in] to test list membership.

--- a/exercises/concept/language-list/.docs/instructions.md
+++ b/exercises/concept/language-list/.docs/instructions.md
@@ -58,13 +58,13 @@ LanguageList.new()
 # => 2
 ```
 
-## 6. Define a function to determine if the list is exciting
+## 6. Define a function to determine if the list includes a functional language
 
-Define the `exciting_list?/1` function which takes 1 argument (a _language list_). It should return a boolean value. It should return true if _"Elixir"_ is one of the languages in the list.
+Define the `functional_list?/1` function which takes 1 argument (a _language list_). It should return a boolean value. It should return true if _"Elixir"_ is one of the languages in the list.
 
 ```elixir
 LanguageList.new()
 |> LanguageList.add("Elixir")
-|> LanguageList.exciting_list?()
+|> LanguageList.functional_list?()
 # => true
 ```

--- a/exercises/concept/language-list/.meta/exemplar.ex
+++ b/exercises/concept/language-list/.meta/exemplar.ex
@@ -19,7 +19,7 @@ defmodule LanguageList do
     length(list)
   end
 
-  def exciting_list?(list) do
+  def functional_list?(list) do
     "Elixir" in list
   end
 end

--- a/exercises/concept/language-list/lib/language_list.ex
+++ b/exercises/concept/language-list/lib/language_list.ex
@@ -19,7 +19,7 @@ defmodule LanguageList do
     # Please implement the count/1 function
   end
 
-  def exciting_list?(list) do
-    # Please implement the exciting_list?/1 function
+  def functional_list?(list) do
+    # Please implement the functional_list?/1 function
   end
 end

--- a/exercises/concept/language-list/test/language_list_test.exs
+++ b/exercises/concept/language-list/test/language_list_test.exs
@@ -102,15 +102,15 @@ defmodule LanguageListTest do
     end
   end
 
-  describe "exciting_list?/1" do
+  describe "functional_list?/1" do
     @tag task_id: 6
-    test "an exciting language list" do
-      assert LanguageList.exciting_list?(["Clojure", "Haskell", "Erlang", "F#", "Elixir"])
+    test "a functional language list" do
+      assert LanguageList.functional_list?(["Clojure", "Haskell", "Erlang", "F#", "Elixir"])
     end
 
     @tag task_id: 6
-    test "not an exciting language list" do
-      refute LanguageList.exciting_list?(["Java", "C", "JavaScript"])
+    test "not a functional language list" do
+      refute LanguageList.functional_list?(["Java", "C", "JavaScript"])
     end
   end
 end


### PR DESCRIPTION
Calling this function "exciting_list?" suggests that other languages aren't exciting. Small things like that matter 😄 