### PR TITLE
Test updated for State of Tic Tac Toe: Corrects an invalid game state

### DIFF
--- a/exercises/practice/state-of-tic-tac-toe/.meta/tests.toml
+++ b/exercises/practice/state-of-tic-tac-toe/.meta/tests.toml
@@ -10,52 +10,56 @@
 # is regenerated, comments can be added via a `comment` key.
 
 [fe8e9fa9-37af-4d7e-aa24-2f4b8517161a]
-description = "Won games -> Finished game where X won via column victory"
+description = "Won games -> Finished game where X won via left column victory"
 
 [96c30df5-ae23-4cf6-bf09-5ef056dddea1]
-description = "Won games -> Finished game where X won via column victory"
+description = "Won games -> Finished game where X won via middle column victory"
 
 [0d7a4b0a-2afd-4a75-8389-5fb88ab05eda]
-description = "Won games -> Finished game where X won via column victory"
+description = "Won games -> Finished game where X won via right column victory"
 
 [bd1007c0-ec5d-4c60-bb9f-1a4f22177d51]
-description = "Won games -> Finished game where O won via column victory"
+description = "Won games -> Finished game where O won via left column victory"
 
 [c032f800-5735-4354-b1b9-46f14d4ee955]
-description = "Won games -> Finished game where O won via column victory"
+description = "Won games -> Finished game where O won via middle column victory"
 
 [662c8902-c94a-4c4c-9d9c-e8ca513db2b4]
-description = "Won games -> Finished game where O won via column victory"
+description = "Won games -> Finished game where O won via right column victory"
 
 [2d62121f-7e3a-44a0-9032-0d73e3494941]
-description = "Won games -> Finished game where X won via row victory"
+description = "Won games -> Finished game where X won via top row victory"
 
 [108a5e82-cc61-409f-aece-d7a18c1beceb]
-description = "Won games -> Finished game where X won via row victory"
+description = "Won games -> Finished game where X won via middle row victory"
+
+[346527db-4db9-4a96-b262-d7023dc022b0]
+description = "Won games -> Finished game where X won via middle row victory"
+reimplements = "108a5e82-cc61-409f-aece-d7a18c1beceb"
 
 [a013c583-75f8-4ab2-8d68-57688ff04574]
-description = "Won games -> Finished game where X won via row victory"
+description = "Won games -> Finished game where X won via bottom row victory"
 
 [2c08e7d7-7d00-487f-9442-e7398c8f1727]
-description = "Won games -> Finished game where O won via row victory"
+description = "Won games -> Finished game where O won via top row victory"
 
 [bb1d6c62-3e3f-4d1a-9766-f8803c8ed70f]
-description = "Won games -> Finished game where O won via row victory"
+description = "Won games -> Finished game where O won via middle row victory"
 
 [6ef641e9-12ec-44f5-a21c-660ea93907af]
-description = "Won games -> Finished game where O won via row victory"
+description = "Won games -> Finished game where O won via bottom row victory"
 
 [ab145b7b-26a7-426c-ab71-bf418cd07f81]
-description = "Won games -> Finished game where X won via diagonal victory"
+description = "Won games -> Finished game where X won via falling diagonal victory"
 
 [7450caab-08f5-4f03-a74b-99b98c4b7a4b]
-description = "Won games -> Finished game where X won via diagonal victory"
+description = "Won games -> Finished game where X won via rising diagonal victory"
 
 [c2a652ee-2f93-48aa-a710-a70cd2edce61]
-description = "Won games -> Finished game where O won via diagonal victory"
+description = "Won games -> Finished game where O won via falling diagonal victory"
 
 [5b20ceea-494d-4f0c-a986-b99efc163bcf]
-description = "Won games -> Finished game where O won via diagonal victory"
+description = "Won games -> Finished game where O won via rising diagonal victory"
 
 [035a49b9-dc35-47d3-9d7c-de197161b9d4]
 description = "Won games -> Finished game where X won via a row and a column victory"
@@ -67,22 +71,29 @@ description = "Won games -> Finished game where X won via two diagonal victories
 description = "Drawn games -> Draw"
 
 [227a76b2-0fef-4e16-a4bd-8f9d7e4c3b13]
-description = "Drawn games -> Draw"
+description = "Drawn games -> Another draw"
 
 [4d93f15c-0c40-43d6-b966-418b040012a9]
-description = "Ongoing games -> Ongoing game"
+description = "Ongoing games -> Ongoing game: one move in"
 
 [c407ae32-4c44-4989-b124-2890cf531f19]
-description = "Ongoing games -> Ongoing game"
+description = "Ongoing games -> Ongoing game: two moves in"
 
 [199b7a8d-e2b6-4526-a85e-78b416e7a8a9]
-description = "Ongoing games -> Ongoing game"
+description = "Ongoing games -> Ongoing game: five moves in"
 
 [1670145b-1e3d-4269-a7eb-53cd327b302e]
-description = "Invalid boards -> Invalid board"
+description = "Invalid boards -> Invalid board: X went twice"
 
 [47c048e8-b404-4bcf-9e51-8acbb3253f3b]
-description = "Invalid boards -> Invalid board"
+description = "Invalid boards -> Invalid board: O started"
 
 [b1dc8b13-46c4-47db-a96d-aa90eedc4e8d]
 description = "Invalid boards -> Invalid board"
+
+[6c1920f2-ab5c-4648-a0c9-997414dda5eb]
+description = "Invalid boards -> Invalid board: X won and O kept playing"
+reimplements = "6c1920f2-ab5c-4648-a0c9-997414dda5eb"
+
+[4801cda2-f5b7-4c36-8317-3cdd167ac22c]
+description = "Invalid boards -> Invalid board: players kept playing after a win"

--- a/exercises/practice/state-of-tic-tac-toe/test/state_of_tic_tac_toe_test.exs
+++ b/exercises/practice/state-of-tic-tac-toe/test/state_of_tic_tac_toe_test.exs
@@ -82,7 +82,7 @@ defmodule StateOfTicTacToeTest do
     @tag :pending
     test "Finished game where X won via row victory (2)" do
       board = """
-      O.O
+      O..
       XXX
       .O.
       """

--- a/exercises/practice/state-of-tic-tac-toe/test/state_of_tic_tac_toe_test.exs
+++ b/exercises/practice/state-of-tic-tac-toe/test/state_of_tic_tac_toe_test.exs
@@ -3,7 +3,7 @@ defmodule StateOfTicTacToeTest do
 
   describe "Won games" do
     # @tag :pending
-    test "Finished game where X won via column victory (1)" do
+    test "Finished game where X won via left column victory" do
       board = """
       XOO
       X..
@@ -14,7 +14,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Finished game where X won via column victory (2)" do
+    test "Finished game where X won via middle column victory" do
       board = """
       OXO
       .X.
@@ -25,7 +25,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Finished game where X won via column victory (3)" do
+    test "Finished game where X won via right column victory" do
       board = """
       OOX
       ..X
@@ -36,7 +36,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Finished game where O won via column victory (1)" do
+    test "Finished game where O won via left column victory" do
       board = """
       OXX
       OX.
@@ -47,7 +47,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Finished game where O won via column victory (2)" do
+    test "Finished game where O won via middle column victory" do
       board = """
       XOX
       .OX
@@ -58,7 +58,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Finished game where O won via column victory (3)" do
+    test "Finished game where O won via right column victory" do
       board = """
       XXO
       .XO
@@ -69,7 +69,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Finished game where X won via row victory (1)" do
+    test "Finished game where X won via top row victory" do
       board = """
       XXX
       XOO
@@ -80,7 +80,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Finished game where X won via row victory (2)" do
+    test "Finished game where X won via middle row victory" do
       board = """
       O..
       XXX
@@ -91,7 +91,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Finished game where X won via row victory (3)" do
+    test "Finished game where X won via bottom row victory" do
       board = """
       .OO
       O.X
@@ -102,7 +102,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Finished game where O won via row victory (1)" do
+    test "Finished game where O won via top row victory" do
       board = """
       OOO
       XXO
@@ -113,7 +113,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Finished game where O won via row victory (2)" do
+    test "Finished game where O won via middle row victory" do
       board = """
       XX.
       OOO
@@ -124,7 +124,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Finished game where O won via row victory (3)" do
+    test "Finished game where O won via bottom row victory" do
       board = """
       XOX
       .XX
@@ -135,7 +135,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Finished game where X won via diagonal victory (1)" do
+    test "Finished game where X won via falling diagonal victory" do
       board = """
       XOO
       .X.
@@ -146,7 +146,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Finished game where X won via diagonal victory (2)" do
+    test "Finished game where X won via rising diagonal victory" do
       board = """
       O.X
       OX.
@@ -157,7 +157,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Finished game where O won via diagonal victory (3)" do
+    test "Finished game where O won via falling diagonal victory" do
       board = """
       OXX
       OOX
@@ -168,7 +168,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Finished game where O won via diagonal victory (1)" do
+    test "Finished game where O won via rising diagonal victory" do
       board = """
       ..O
       .OX
@@ -203,7 +203,7 @@ defmodule StateOfTicTacToeTest do
 
   describe "Drawn games" do
     @tag :pending
-    test "Draw (1)" do
+    test "Draw" do
       board = """
       XOX
       XXO
@@ -214,7 +214,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Draw (2)" do
+    test "Another Draw" do
       board = """
       XXO
       OXX
@@ -229,7 +229,7 @@ defmodule StateOfTicTacToeTest do
 
   describe "Ongoing games" do
     @tag :pending
-    test "Ongoing game (1)" do
+    test "Ongoing game: one move in" do
       board = """
       ...
       X..
@@ -240,7 +240,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Ongoing game (2)" do
+    test "Ongoing game: two moves in" do
       board = """
       O..
       .X.
@@ -251,7 +251,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Ongoing game (3)" do
+    test "Ongoing game: five moves in" do
       board = """
       X..
       .XO
@@ -264,7 +264,7 @@ defmodule StateOfTicTacToeTest do
 
   describe "Invalid boards" do
     @tag :pending
-    test "Invalid board (1)" do
+    test "Invalid board: X went twice" do
       board = """
       XX.
       ...
@@ -275,7 +275,7 @@ defmodule StateOfTicTacToeTest do
     end
 
     @tag :pending
-    test "Invalid board (2)" do
+    test "Invalid board: O started" do
       board = """
       OOX
       ...


### PR DESCRIPTION
This fixes one of the tac-tac-toe games.

The game had the same number of X's and O's while X went first and won.
This is therefore an invalid game state but is used to test simple victory.

The test specifications have been updated so this matches the new version.