### PR TITLE
Make GenServer name warning stand out

### DIFF
--- a/concepts/genserver/about.md
+++ b/concepts/genserver/about.md
@@ -4,7 +4,9 @@
 
 Remember the receive loop from when we learned about [processes][concept-processes]? The `GenServer` behaviour provides abstractions for implementing such loops, and for exchanging messages with a process that runs such a loop. It makes it easier to keep state and execute asynchronous code.
 
+~~~~exercism/note
 Be warned that the name `GenServer` is loaded. It is also used to describe a _module_ that _uses_ the `GenServer` behaviour, as well as a _process_ that was started from a module that _uses_ the `GenServer` behaviour.
+~~~~
 
 The `GenServer` behaviour defines one required callback, `init/1`, and a few interesting optional callbacks: `handle_call/3`, `handle_cast/2`, and `handle_info/3`. The _clients_ using a `GenServer` aren't supposed to call those callbacks directly. Instead, the `GenServer` module provides functions that clients can use to communicate with a `GenServer` process.
 

--- a/concepts/genserver/introduction.md
+++ b/concepts/genserver/introduction.md
@@ -4,7 +4,9 @@
 
 Remember the receive loop from when we learned about [processes][concept-processes]? The `GenServer` behaviour provides abstractions for implementing such loops, and for exchanging messages with a process that runs such a loop. It makes it easier to keep state and execute asynchronous code.
 
+~~~~exercism/note
 Be warned that the name `GenServer` is loaded. It is also used to describe a _module_ that _uses_ the `GenServer` behaviour, as well as a _process_ that was started from a module that _uses_ the `GenServer` behaviour.
+~~~~
 
 The `GenServer` behaviour defines one required callback, `init/1`, and a few interesting optional callbacks: `handle_call/3`, `handle_cast/2`, and `handle_info/3`. The _clients_ using a `GenServer` aren't supposed to call those callbacks directly. Instead, the `GenServer` module provides functions that clients can use to communicate with a `GenServer` process.
 

--- a/exercises/concept/take-a-number-deluxe/.docs/introduction.md
+++ b/exercises/concept/take-a-number-deluxe/.docs/introduction.md
@@ -6,7 +6,9 @@
 
 Remember the receive loop from when we learned about [processes][concept-processes]? The `GenServer` behaviour provides abstractions for implementing such loops, and for exchanging messages with a process that runs such a loop. It makes it easier to keep state and execute asynchronous code.
 
+~~~~exercism/note
 Be warned that the name `GenServer` is loaded. It is also used to describe a _module_ that _uses_ the `GenServer` behaviour, as well as a _process_ that was started from a module that _uses_ the `GenServer` behaviour.
+~~~~
 
 The `GenServer` behaviour defines one required callback, `init/1`, and a few interesting optional callbacks: `handle_call/3`, `handle_cast/2`, and `handle_info/3`. The _clients_ using a `GenServer` aren't supposed to call those callbacks directly. Instead, the `GenServer` module provides functions that clients can use to communicate with a `GenServer` process.
 


### PR DESCRIPTION
@ErikSchierboom's feedback:

> takea-number-deluxe: you could consider using a warning/info admonition for the “Be warned that the name GenServer is loaded. It is also used to describe a module that uses the GenServer behaviour, as well as a process that was started from a module that uses the GenServer behaviour.” text, which is quite an important part I feel (ignore if that is not true)
