### PR TITLE
Do not teach about Bitwise operators (^^^), only not-operator macros (bxor)

### DIFF
--- a/concepts/bit-manipulation/about.md
+++ b/concepts/bit-manipulation/about.md
@@ -2,26 +2,26 @@
 
 [Bitwise binary functions][bitwise-wiki] can be performed on integers using functions from the [Bitwise module][bitwise-hexdocs].
 
-- [`&&&/2`][bitwise-and]: bitwise AND
-- [`<<</2`][bitwise-shift-left]: bitwise SHIFT LEFT
-- [`>>>/2`][bitwise-shift-right]: bitwise SHIFT RIGHT
-- [`^^^/2`][bitwise-xor]: bitwise XOR
-- [`|||/2`][bitwise-or]: bitwise OR
-- [`~~~/1`][bitwise-not]: bitwise NOT
+- [`band/2`][bitwise-and]: bitwise AND
+- [`bsl/2`][bitwise-shift-left]: bitwise SHIFT LEFT
+- [`bsr/2`][bitwise-shift-right]: bitwise SHIFT RIGHT
+- [`bxor/2`][bitwise-xor]: bitwise XOR
+- [`bor/2`][bitwise-or]: bitwise OR
+- [`bnot/1`][bitwise-not]: bitwise NOT
 
 ```elixir
-Bitwise.&&&(0b1110, 0b1001)
+Bitwise.band(0b1110, 0b1001)
 # => 8 # 0b1000
 
-Bitwise.^^^(0b1110, 0b1001)
+Bitwise.bxor(0b1110, 0b1001)
 # => 7 # 0b0111
 ```
 
 [bitwise-hexdocs]: https://hexdocs.pm/elixir/Bitwise.html
 [bitwise-wiki]: https://en.wikipedia.org/wiki/Bitwise_operation
-[bitwise-and]: https://hexdocs.pm/elixir/Bitwise.html#&&&/2
-[bitwise-shift-left]: https://hexdocs.pm/elixir/Bitwise.html#<<</2
-[bitwise-shift-right]: https://hexdocs.pm/elixir/Bitwise.html#>>>/2
-[bitwise-xor]: https://hexdocs.pm/elixir/Bitwise.html#^^^/2
-[bitwise-or]: https://hexdocs.pm/elixir/Bitwise.html#|||/2
-[bitwise-not]: https://hexdocs.pm/elixir/Bitwise.html#~~~/2
+[bitwise-and]: https://hexdocs.pm/elixir/Bitwise.html#band/2
+[bitwise-shift-left]: https://hexdocs.pm/elixir/Bitwise.html#bsl/2
+[bitwise-shift-right]: https://hexdocs.pm/elixir/Bitwise.html#bsr/2
+[bitwise-xor]: https://hexdocs.pm/elixir/Bitwise.html#bxor/2
+[bitwise-or]: https://hexdocs.pm/elixir/Bitwise.html#bor/2
+[bitwise-not]: https://hexdocs.pm/elixir/Bitwise.html#bnot/2

--- a/concepts/bit-manipulation/introduction.md
+++ b/concepts/bit-manipulation/introduction.md
@@ -2,17 +2,17 @@
 
 Elixir supports many functions for working with bits found in the _Bitwise module_.
 
-- `&&&/2`: bitwise AND
-- `<<</2`: bitwise SHIFT LEFT
-- `>>>/2`: bitwise SHIFT RIGHT
-- `^^^/2`: bitwise XOR
-- `|||/2`: bitwise OR
-- `~~~/1`: bitwise NOT
+- `band/2`: bitwise AND
+- `bsl/2`: bitwise SHIFT LEFT
+- `bsr/2`: bitwise SHIFT RIGHT
+- `bxor/2`: bitwise XOR
+- `bor/2`: bitwise OR
+- `bnot/1`: bitwise NOT
 
-Here is an example how to use a bitwise operator:
+Here is an example how to use a bitwise function:
 
 ```elixir
-Bitwise.<<<(1, 2)
+Bitwise.bsl(1, 2)
 # => 4
 ```
 

--- a/exercises/concept/secrets/.docs/introduction.md
+++ b/exercises/concept/secrets/.docs/introduction.md
@@ -41,17 +41,17 @@ variable.(1)
 
 Elixir supports many functions for working with bits found in the _Bitwise module_.
 
-- `&&&/2`: bitwise AND
-- `<<</2`: bitwise SHIFT LEFT
-- `>>>/2`: bitwise SHIFT RIGHT
-- `^^^/2`: bitwise XOR
-- `|||/2`: bitwise OR
-- `~~~/1`: bitwise NOT
+- `band/2`: bitwise AND
+- `bsl/2`: bitwise SHIFT LEFT
+- `bsr/2`: bitwise SHIFT RIGHT
+- `bxor/2`: bitwise XOR
+- `bor/2`: bitwise OR
+- `bnot/1`: bitwise NOT
 
-Here is an example how to use a bitwise operator:
+Here is an example how to use a bitwise function:
 
 ```elixir
-Bitwise.<<<(1, 2)
+Bitwise.bsl(1, 2)
 # => 4
 ```
 

--- a/exercises/concept/secrets/.meta/exemplar.ex
+++ b/exercises/concept/secrets/.meta/exemplar.ex
@@ -19,11 +19,11 @@ defmodule Secrets do
   end
 
   def secret_and(secret) do
-    fn x -> Bitwise.&&&(x, secret) end
+    fn x -> Bitwise.band(x, secret) end
   end
 
   def secret_xor(secret) do
-    fn x -> Bitwise.^^^(x, secret) end
+    fn x -> Bitwise.bxor(x, secret) end
   end
 
   def secret_combine(secret_function1, secret_function2) do


### PR DESCRIPTION
Bitwise.^^^ got deprecated, so there's no full set of operators available. Since we need a XOR, it's just easier to teach about the (not operator) macros instead. The goal of the exercise is to learn about bit manipulation in general, it shouldn't matter whether it's with operators or not.

Closes #1142

Related elixir-lang PR: https://github.com/elixir-lang/elixir/commit/d9a23d0d38ce1ada6583eca1c6ce6c861114fca7

Related elixir-lang issue: https://github.com/elixir-lang/elixir/issues/11590

> [josevalim](https://github.com/josevalim) [on 24 Jan](https://github.com/elixir-lang/elixir/issues/11590#issuecomment-1019777554)
> The operator will change precedence in Elixir v2.0.0 but not be removed. So my advice is to consider it as if it will be removed as the precedence change may break code.