### PR TITLE
handle_frame should clearly say single frame

### DIFF
--- a/exercises/concept/dancing-dots/.docs/instructions.md
+++ b/exercises/concept/dancing-dots/.docs/instructions.md
@@ -35,7 +35,7 @@ Use the `Animation` behaviour to implement a flickering animation.
 
 It should use the default `init/1` callback because it doesn't take any options.
 
-Implement the `handle_frame/3` callback. This function handles a single frame. If the frame is a multiple of four, the function should return the dot with half of its original opacity. In other frames, it should return the dot unchanged.
+Implement the `handle_frame/3` callback, which handles a single frame. If the frame number is a multiple of four, the function should return the dot with half of its original opacity. In other frames, it should return the dot unchanged.
 
 Frames are counted from `1`. The dot passed to `handle_frame/3` is always the dot in its original state, not in the state from the previous frame.
 

--- a/exercises/concept/dancing-dots/.docs/instructions.md
+++ b/exercises/concept/dancing-dots/.docs/instructions.md
@@ -35,7 +35,7 @@ Use the `Animation` behaviour to implement a flickering animation.
 
 It should use the default `init/1` callback because it doesn't take any options.
 
-Implement the `handle_frame/3` callback. In every 4th frame, it should return the dot with half of its original opacity. In other frames, it should return the dot unchanged.
+Implement the `handle_frame/3` callback. This function handles a single frame. If the frame is a multiple of four, the function should return the dot with half of its original opacity. In other frames, it should return the dot unchanged.
 
 Frames are counted from `1`. The dot passed to `handle_frame/3` is always the dot in its original state, not in the state from the previous frame.
 


### PR DESCRIPTION
When I did this exercise I did not understand that handle_frame only handles a single frame. I ended up writing a recursive function that went through frames, counting at 1 up to frame_number. I imagined actual animation where you piece frames together.

It NOW makes sense that handle_frame not handle_frames handles a single frame, but i did not figure this out from the instructions.

```
def handle_frame(dot, frame_number, opts) do
  hf_rec_hlpr(dot, frame_number, opts, 1)
end

def hf_rec_hlpr(dot, frame_number, opts, n) do
  cond do
    n > frame_number ->
      dot

    rem(n, 4) == 0 ->
      hf_rec_hlpr(Map.update!(dot, :opacity, fn x -> x / 2 end), frame_number, opts, n + 1)

    True ->
      hf_rec_hlpr(dot, frame_number, opts, n + 1)
  end
end
```
