### PR TITLE
add `introduction.md.tpl` files; unify introduction contents

### DIFF
--- a/concepts/alias/introduction.md
+++ b/concepts/alias/introduction.md
@@ -1,6 +1,8 @@
 # Introduction
 
-The special form `alias` allows you to shorten or change the name by which you reference an outside module. When used without any arguments, it trims down the module name to its last part, e.g. `MyApp.Logger.Settings` becomes `Settings`. A custom name can be specified with the `:as` option.
+To share code between different Elixir modules within the same project, you need to reference the outside module by its full name. But what if that name is too long or confusing?
+
+The special form `alias` allows you to shorten or change the name by which you reference an outside module. When used without any arguments, it trims down the module name to its last segment, e.g. `MyApp.Logger.Settings` becomes `Settings`. A custom name can be specified with the `:as` option.
 
 Usually aliases are added at the beginning of the module definition.
 

--- a/concepts/anonymous-functions/introduction.md
+++ b/concepts/anonymous-functions/introduction.md
@@ -1,10 +1,10 @@
 # Introduction
 
-Functions are treated as first class citizens in Elixir. This means functions:
+Functions are treated as first class citizens in Elixir. This means that:
 
-- Can be assigned to variables.
-- Can be passed around like data as arguments and return values.
-- Can be created dynamically.
+- Named and anonymous functions can be assigned to variables.
+- Named and anonymous functions can be passed around like data as arguments and return values.
+- Anonymous functions can be created dynamically.
 
 Anonymous functions, in contrast to named functions, don't have a static reference available to them, they are only available if they are assigned to a variable or immediately invoked.
 

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -33,7 +33,7 @@ defmodule Calculator do
     x + y
   end
 end
- ```
+```
 
 Invoking a function is done by specifying its module and function name and passing arguments for each of the function's arguments.
 

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -1,5 +1,7 @@
 # Introduction
 
+## Variables
+
 Elixir is a dynamically-typed language, meaning that the type of a variable is only checked at runtime. Using the match `=` operator, we can bind a value of any type to a variable name:
 
 ```elixir

--- a/concepts/behaviours/introduction.md
+++ b/concepts/behaviours/introduction.md
@@ -61,7 +61,7 @@ defmodule Countable do
 end
 ```
 
-Note that defining functions inside of `__using__/1` is discouraged for any other purpose than defining default callback implementations, but you can always define functions in another module and import them in the  `__using__/1` macro.
+Note that defining functions inside of `__using__/1` is discouraged for any other purpose than defining default callback implementations, but you can always define functions in another module and import them in the `__using__/1` macro.
 
 [concept-typespecs]: https://exercism.org/tracks/elixir/concepts/typespecs
 [hexdocs]: https://hexdocs.pm

--- a/concepts/bit-manipulation/introduction.md
+++ b/concepts/bit-manipulation/introduction.md
@@ -17,3 +17,5 @@ Bitwise.bsl(1, 2)
 ```
 
 All bitwise functions only work on integers.
+
+If you are running Elixir version 1.9 or lower, you will need to call `require Bitwise` at the beginning of the module definition to be able to use the _Bitwise_ module.

--- a/concepts/bitstrings/introduction.md
+++ b/concepts/bitstrings/introduction.md
@@ -2,7 +2,7 @@
 
 Working with binary data is an important concept in any language, and Elixir provides an elegant syntax to write, match, and construct binary data.
 
-In Elixir, binary data is referred to as the bitstring type. The binary data *type* (not to be confused with binary data in general) is a specific form of a bitstring, which we will discuss in a later exercise.
+In Elixir, binary data is referred to as the bitstring type. The binary data _type_ (not to be confused with binary data in general) is a specific form of a bitstring, which we will discuss in a later exercise.
 
 Bitstring literals are defined using the bitstring special form `<<>>`. When defining a bitstring literal, it is defined in segments. Each segment has a value and type, separated by the `::` operator. The type specifies how many bits will be used to encode the value. If the value of the segment overflows the capacity of the segment's type, it will be truncated from the left.
 

--- a/concepts/booleans/introduction.md
+++ b/concepts/booleans/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Elixir represents true and false values with the boolean type. There are only two values: `true` and `false`.
+Elixir represents true and false values with the boolean type. There are only two values: `true` and `false`. These values can be bound to a variable:
 
 ```elixir
 true_variable = true

--- a/concepts/dates-and-time/introduction.md
+++ b/concepts/dates-and-time/introduction.md
@@ -3,19 +3,22 @@
 Elixir's standard library offers 4 different modules for working with dates and time, each with its own struct.
 
 - The `Date` module. A `Date` struct can be created with the `~D` sigil.
-    ```elixir
-    ~D[2021-01-01]
-    ```
+
+  ```elixir
+  ~D[2021-01-01]
+  ```
 
 - The `Time` module. A `Time` struct can be created with the `~T` sigil.
-    ```elixir
-    ~T[12:00:00]
-    ```
+
+  ```elixir
+  ~T[12:00:00]
+  ```
 
 - The `NaiveDateTime` module for datetimes without a timezone. A `NaiveDateTime` struct can be created with the `~N` sigil.
-    ```elixir
-    ~N[2021-01-01 12:00:00]
-    ```
+
+  ```elixir
+  ~N[2021-01-01 12:00:00]
+  ```
 
 - The `DateTime` module for datetimes with a timezone. Using this module for timezones other than UTC requires an external dependency, a timezone database.
 

--- a/concepts/enum/introduction.md
+++ b/concepts/enum/introduction.md
@@ -31,7 +31,7 @@ To transform it back to a map, use `Enum.into/2`. `Enum.into/2` is a function th
 
 `Enum` also has `Enum.into/3`. `Enum.into/3` is a variation of `Enum.into/2` that accepts a transformation function to be applied while transforming the enumerable into a collectable.
 
-#### Mapping maps
+### Mapping maps
 
 Instead of using `Enum.into/3` or `Enum.map/2` plus `Enum.into/1` to apply a transformation (mapping) to a map, we can also use a dedicated `Map.new/2` function. It works exactly like `Enum.into/3` in that it accepts an enumerable and a transformation function, but it always returns a new map instead of letting us choose a collectible.
 

--- a/concepts/genserver/introduction.md
+++ b/concepts/genserver/introduction.md
@@ -103,7 +103,7 @@ If that person is available, you'll receive a reply immediately (synchronously).
 
 A message that doesn't require a reply can be sent to a server process with `GenServer.cast/2`. Its arguments are identical to those of `GenServer.call/2`.
 
-The `handle_cast/2` callback is responsible for handling those messages. It receives two arguments, `message` and `state`, which are the same arguments as in the  `handle_call/3` callback (except for `from`).
+The `handle_cast/2` callback is responsible for handling those messages. It receives two arguments, `message` and `state`, which are the same arguments as in the `handle_call/3` callback (except for `from`).
 
 The `handle_cast/2` callback usually returns a 2 tuple of `{:noreply, state}`.
 

--- a/concepts/genserver/introduction.md
+++ b/concepts/genserver/introduction.md
@@ -64,6 +64,7 @@ end
 A server can be started by calling `GenServer.start/3` or `GenServer.start_link/3`. We learned about the difference between those functions in the [links concept][concept-links].
 
 Those two functions:
+
 - Accept a module implementing the `GenServer` behaviour as the first argument.
 - Accept anything as the second argument called `init_arg`. As the name suggest, this argument gets passed to the `init/1` callback.
 - Accept an optional third argument with advanced options for running the process that we wont' cover now.
@@ -71,6 +72,7 @@ Those two functions:
 Starting a server by calling `GenServer.start/3` or `GenServer.start_link/3` will invoke the `init/1` callback in a blocking way. The return value of `init/1` dictates if the server can be started successfully.
 
 The `init/1` callback usually returns one of those values:
+
 - `{:ok, state}`. The server will start its receive loop using `state` as its initial state. `state` can be of any type.
 - `{:stop, reason}`. `reason` can be of any type. The server will not start its receive loop. The process will exit with the given reason.
 

--- a/concepts/if/introduction.md
+++ b/concepts/if/introduction.md
@@ -28,6 +28,5 @@ This syntax is helpful for very short expressions, but should be avoided if the 
 
 In Elixir, all datatypes evaluate to a _truthy_ or _falsy_ value when they are encountered in a boolean context (like an `if` expression). All data is considered _truthy_ **except** for `false` and `nil`. In particular, empty strings, the integer `0`, and empty lists are all considered _truthy_ in Elixir.
 
-[nil-dictionary]: https://www.merriam-webster.com/dictionary/nil
 [getting-started-if-unless]: https://elixir-lang.org/getting-started/case-cond-and-if.html#if-and-unless
 [kernel-if]: https://hexdocs.pm/elixir/Kernel.html#if/2

--- a/concepts/if/introduction.md
+++ b/concepts/if/introduction.md
@@ -29,5 +29,5 @@ This syntax is helpful for very short expressions, but should be avoided if the 
 In Elixir, all datatypes evaluate to a _truthy_ or _falsy_ value when they are encountered in a boolean context (like an `if` expression). All data is considered _truthy_ **except** for `false` and `nil`. In particular, empty strings, the integer `0`, and empty lists are all considered _truthy_ in Elixir.
 
 [nil-dictionary]: https://www.merriam-webster.com/dictionary/nil
-[kernel-if]: https://hexdocs.pm/elixir/Kernel.html#if/2
 [getting-started-if-unless]: https://elixir-lang.org/getting-started/case-cond-and-if.html#if-and-unless
+[kernel-if]: https://hexdocs.pm/elixir/Kernel.html#if/2

--- a/concepts/regular-expressions/introduction.md
+++ b/concepts/regular-expressions/introduction.md
@@ -83,6 +83,8 @@ _Anchors_ are used to tie the regular expression to the beginning or end of the 
 - `^` anchors to the beginning of the string
 - `$` anchors to the end of the string
 
+## Interpolation
+
 Because the `~r` is a shortcut for `"pattern" |> Regex.escape() |> Regex.compile!()`, you may also use string interpolation to dynamically build a regular expression pattern:
 
 ```elixir

--- a/concepts/try-rescue-else-after/introduction.md
+++ b/concepts/try-rescue-else-after/introduction.md
@@ -2,9 +2,9 @@
 
 Using `try..rescue` is a powerful construct for catching errors when they occur. Rescuing errors allows functions to return defined values when it is necessary. The `try..rescue` construct also offers us two additional features we can make use of:
 
-- the `else` block:
+- the `else` block
   - When the try block succeeds, the result is matched to this block.
-- the `after` block:
+- the `after` block
   - Whether the try block succeeds or raises, the code in the `after` block is always executed as long as the program is running at that point.
   - The result of the `after` block is not returned to the calling scope.
 

--- a/exercises/concept/basketball-website/.docs/introduction.md.tpl
+++ b/exercises/concept/basketball-website/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Access Behaviour
-
 %{concept:access-behaviour}

--- a/exercises/concept/basketball-website/.docs/introduction.md.tpl
+++ b/exercises/concept/basketball-website/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Access Behaviour
+
+%{concept:access-behaviour}

--- a/exercises/concept/bird-count/.docs/introduction.md.tpl
+++ b/exercises/concept/bird-count/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Recursion
-
 %{concept:recursion}

--- a/exercises/concept/bird-count/.docs/introduction.md.tpl
+++ b/exercises/concept/bird-count/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Recursion
+
+%{concept:recursion}

--- a/exercises/concept/boutique-inventory/.docs/introduction.md.tpl
+++ b/exercises/concept/boutique-inventory/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Enum
-
 %{concept:enum}

--- a/exercises/concept/boutique-inventory/.docs/introduction.md.tpl
+++ b/exercises/concept/boutique-inventory/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Enum
+
+%{concept:enum}

--- a/exercises/concept/boutique-suggestions/.docs/introduction.md.tpl
+++ b/exercises/concept/boutique-suggestions/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## List Comprehensions
-
 %{concept:list-comprehensions}

--- a/exercises/concept/boutique-suggestions/.docs/introduction.md.tpl
+++ b/exercises/concept/boutique-suggestions/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## List Comprehensions
+
+%{concept:list-comprehensions}

--- a/exercises/concept/bread-and-potions/.docs/introduction.md.tpl
+++ b/exercises/concept/bread-and-potions/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Protocols
-
 %{concept:protocols}

--- a/exercises/concept/bread-and-potions/.docs/introduction.md.tpl
+++ b/exercises/concept/bread-and-potions/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Protocols
+
+%{concept:protocols}

--- a/exercises/concept/captains-log/.docs/introduction.md.tpl
+++ b/exercises/concept/captains-log/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Randomness
+
+%{concept:randomness}
+
+## Erlang Libraries
+
+%{concept:erlang-libraries}

--- a/exercises/concept/captains-log/.docs/introduction.md.tpl
+++ b/exercises/concept/captains-log/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Randomness
-
 %{concept:randomness}
-
-## Erlang Libraries
 
 %{concept:erlang-libraries}

--- a/exercises/concept/chessboard/.docs/introduction.md.tpl
+++ b/exercises/concept/chessboard/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Ranges
+
+%{concept:ranges}

--- a/exercises/concept/chessboard/.docs/introduction.md.tpl
+++ b/exercises/concept/chessboard/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Ranges
-
 %{concept:ranges}

--- a/exercises/concept/city-office/.docs/introduction.md
+++ b/exercises/concept/city-office/.docs/introduction.md
@@ -78,5 +78,5 @@ Typespecs aren't limited to just the built-in types. Custom types can be defined
 
 A custom type can be used from the same module where it's defined, or from another module.
 
-[types]: https://hexdocs.pm/elixir/typespecs.html#types-and-their-syntax
 [markdown]: https://docs.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax
+[types]: https://hexdocs.pm/elixir/typespecs.html#types-and-their-syntax

--- a/exercises/concept/city-office/.docs/introduction.md.tpl
+++ b/exercises/concept/city-office/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Docs
-
 %{concept:docs}
-
-## Typespecs
 
 %{concept:typespecs}

--- a/exercises/concept/city-office/.docs/introduction.md.tpl
+++ b/exercises/concept/city-office/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Docs
+
+%{concept:docs}
+
+## Typespecs
+
+%{concept:typespecs}

--- a/exercises/concept/community-garden/.docs/introduction.md.tpl
+++ b/exercises/concept/community-garden/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Agent
-
 %{concept:agent}

--- a/exercises/concept/community-garden/.docs/introduction.md.tpl
+++ b/exercises/concept/community-garden/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Agent
+
+%{concept:agent}

--- a/exercises/concept/dancing-dots/.docs/introduction.md
+++ b/exercises/concept/dancing-dots/.docs/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-## `use`
+## Use
 
 The `use` macro allows us to quickly extend our module with functionally provided by another module. When we `use` a module, that module can inject code into our module - it can for example define functions, `import` or `alias` other modules, or set module attributes.
 

--- a/exercises/concept/dancing-dots/.docs/introduction.md
+++ b/exercises/concept/dancing-dots/.docs/introduction.md
@@ -97,7 +97,7 @@ defmodule Countable do
 end
 ```
 
-Note that defining functions inside of `__using__/1` is discouraged for any other purpose than defining default callback implementations, but you can always define functions in another module and import them in the  `__using__/1` macro.
+Note that defining functions inside of `__using__/1` is discouraged for any other purpose than defining default callback implementations, but you can always define functions in another module and import them in the `__using__/1` macro.
 
 [concept-ast]: https://exercism.org/tracks/elixir/concepts/ast
 [concept-typespecs]: https://exercism.org/tracks/elixir/concepts/typespecs

--- a/exercises/concept/dancing-dots/.docs/introduction.md.tpl
+++ b/exercises/concept/dancing-dots/.docs/introduction.md.tpl
@@ -1,6 +1,6 @@
 # Introduction
 
-## `use`
+## Use
 
 %{concept:use}
 

--- a/exercises/concept/dancing-dots/.docs/introduction.md.tpl
+++ b/exercises/concept/dancing-dots/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Use
-
 %{concept:use}
-
-## Behaviours
 
 %{concept:behaviours}

--- a/exercises/concept/dancing-dots/.docs/introduction.md.tpl
+++ b/exercises/concept/dancing-dots/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## `use`
+
+%{concept:use}
+
+## Behaviours
+
+%{concept:behaviours}

--- a/exercises/concept/date-parser/.docs/introduction.md.tpl
+++ b/exercises/concept/date-parser/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Regular Expressions
+
+%{concept:regular-expressions}

--- a/exercises/concept/date-parser/.docs/introduction.md.tpl
+++ b/exercises/concept/date-parser/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Regular Expressions
-
 %{concept:regular-expressions}

--- a/exercises/concept/dna-encoding/.docs/introduction.md
+++ b/exercises/concept/dna-encoding/.docs/introduction.md
@@ -4,7 +4,7 @@
 
 Working with binary data is an important concept in any language, and Elixir provides an elegant syntax to write, match, and construct binary data.
 
-In Elixir, binary data is referred to as the bitstring type. The binary data*type* (not to be confused with binary data in general) is a specific form of a bitstring, which we will discuss in a later exercise.
+In Elixir, binary data is referred to as the bitstring type. The binary data *type* (not to be confused with binary data in general) is a specific form of a bitstring, which we will discuss in a later exercise.
 
 Bitstring literals are defined using the bitstring special form `<<>>`. When defining a bitstring literal, it is defined in segments. Each segment has a value and type, separated by the `::` operator. The type specifies how many bits will be used to encode the value. If the value of the segment overflows the capacity of the segment's type, it will be truncated from the left.
 

--- a/exercises/concept/dna-encoding/.docs/introduction.md
+++ b/exercises/concept/dna-encoding/.docs/introduction.md
@@ -4,7 +4,7 @@
 
 Working with binary data is an important concept in any language, and Elixir provides an elegant syntax to write, match, and construct binary data.
 
-In Elixir, binary data is referred to as the bitstring type. The binary data *type* (not to be confused with binary data in general) is a specific form of a bitstring, which we will discuss in a later exercise.
+In Elixir, binary data is referred to as the bitstring type. The binary data _type_ (not to be confused with binary data in general) is a specific form of a bitstring, which we will discuss in a later exercise.
 
 Bitstring literals are defined using the bitstring special form `<<>>`. When defining a bitstring literal, it is defined in segments. Each segment has a value and type, separated by the `::` operator. The type specifies how many bits will be used to encode the value. If the value of the segment overflows the capacity of the segment's type, it will be truncated from the left.
 

--- a/exercises/concept/dna-encoding/.docs/introduction.md.tpl
+++ b/exercises/concept/dna-encoding/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Bitstrings
+
+%{concept:bitstrings}
+
+## Tail Call Recursion
+
+%{concept:tail-call-recursion}

--- a/exercises/concept/dna-encoding/.docs/introduction.md.tpl
+++ b/exercises/concept/dna-encoding/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Bitstrings
-
 %{concept:bitstrings}
-
-## Tail Call Recursion
 
 %{concept:tail-call-recursion}

--- a/exercises/concept/file-sniffer/.docs/introduction.md.tpl
+++ b/exercises/concept/file-sniffer/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Binaries
-
 %{concept:binaries}

--- a/exercises/concept/file-sniffer/.docs/introduction.md.tpl
+++ b/exercises/concept/file-sniffer/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Binaries
+
+%{concept:binaries}

--- a/exercises/concept/freelancer-rates/.docs/introduction.md.tpl
+++ b/exercises/concept/freelancer-rates/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Integers
+
+%{concept:integers}
+
+## Floating Point Numbers
+
+%{concept:floating-point-numbers}

--- a/exercises/concept/freelancer-rates/.docs/introduction.md.tpl
+++ b/exercises/concept/freelancer-rates/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Integers
-
 %{concept:integers}
-
-## Floating Point Numbers
 
 %{concept:floating-point-numbers}

--- a/exercises/concept/german-sysadmin/.docs/introduction.md.tpl
+++ b/exercises/concept/german-sysadmin/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Charlists
+
+%{concept:charlists}
+
+## Case
+
+%{concept:case}

--- a/exercises/concept/german-sysadmin/.docs/introduction.md.tpl
+++ b/exercises/concept/german-sysadmin/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Charlists
-
 %{concept:charlists}
-
-## Case
 
 %{concept:case}

--- a/exercises/concept/guessing-game/.docs/introduction.md.tpl
+++ b/exercises/concept/guessing-game/.docs/introduction.md.tpl
@@ -1,0 +1,13 @@
+# Introduction
+
+## Multiple Clause Functions
+
+%{concept:multiple-clause-functions}
+
+## Guards
+
+%{concept:guards}
+
+## Default Arguments
+
+%{concept:default-arguments}

--- a/exercises/concept/guessing-game/.docs/introduction.md.tpl
+++ b/exercises/concept/guessing-game/.docs/introduction.md.tpl
@@ -1,13 +1,7 @@
 # Introduction
 
-## Multiple Clause Functions
-
 %{concept:multiple-clause-functions}
 
-## Guards
-
 %{concept:guards}
-
-## Default Arguments
 
 %{concept:default-arguments}

--- a/exercises/concept/high-school-sweetheart/.docs/introduction.md.tpl
+++ b/exercises/concept/high-school-sweetheart/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Strings
+
+%{concept:strings}
+
+## Pipe Operator
+
+%{concept:pipe-operator}

--- a/exercises/concept/high-school-sweetheart/.docs/introduction.md.tpl
+++ b/exercises/concept/high-school-sweetheart/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Strings
-
 %{concept:strings}
-
-## Pipe Operator
 
 %{concept:pipe-operator}

--- a/exercises/concept/high-score/.docs/introduction.md.tpl
+++ b/exercises/concept/high-score/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Maps
-
 %{concept:maps}
-
-## Module Attributes As Constants
 
 %{concept:module-attributes-as-constants}

--- a/exercises/concept/high-score/.docs/introduction.md.tpl
+++ b/exercises/concept/high-score/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Maps
+
+%{concept:maps}
+
+## Module Attributes As Constants
+
+%{concept:module-attributes-as-constants}

--- a/exercises/concept/kitchen-calculator/.docs/introduction.md.tpl
+++ b/exercises/concept/kitchen-calculator/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Tuples
-
 %{concept:tuples}
-
-## Pattern Matching
 
 %{concept:pattern-matching}

--- a/exercises/concept/kitchen-calculator/.docs/introduction.md.tpl
+++ b/exercises/concept/kitchen-calculator/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Tuples
+
+%{concept:tuples}
+
+## Pattern Matching
+
+%{concept:pattern-matching}

--- a/exercises/concept/language-list/.docs/introduction.md
+++ b/exercises/concept/language-list/.docs/introduction.md
@@ -8,7 +8,7 @@ Lists are built-in to the Elixir language. They are considered a basic type, den
 empty_list = []
 one_item_list = [1]
 two_item_list = [1, 2]
-multiple_type_list = [1, :pi, 3.14]
+multiple_type_list = [1, :pi, 3.14, "four"]
 ```
 
 Elixir implements lists as a linked list, where each node stores the reference to the next list. The first item in the list is referred to as the _head_ and the remaining list of items is called the _tail_. We can use this notation in code:

--- a/exercises/concept/language-list/.docs/introduction.md.tpl
+++ b/exercises/concept/language-list/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Lists
+
+%{concept:lists}

--- a/exercises/concept/language-list/.docs/introduction.md.tpl
+++ b/exercises/concept/language-list/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Lists
-
 %{concept:lists}

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -37,7 +37,7 @@ defmodule Calculator do
     x + y
   end
 end
- ```
+```
 
 Invoking a function is done by specifying its module and function name and passing arguments for each of the function's arguments.
 

--- a/exercises/concept/lasagna/.docs/introduction.md.tpl
+++ b/exercises/concept/lasagna/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Basics
+
+%{concept:basics}

--- a/exercises/concept/lasagna/.docs/introduction.md.tpl
+++ b/exercises/concept/lasagna/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Basics
-
 %{concept:basics}

--- a/exercises/concept/library-fees/.docs/introduction.md
+++ b/exercises/concept/library-fees/.docs/introduction.md
@@ -5,19 +5,22 @@
 Elixir's standard library offers 4 different modules for working with dates and time, each with its own struct.
 
 - The `Date` module. A `Date` struct can be created with the `~D` sigil.
-    ```elixir
-    ~D[2021-01-01]
-    ```
+
+  ```elixir
+  ~D[2021-01-01]
+  ```
 
 - The `Time` module. A `Time` struct can be created with the `~T` sigil.
-    ```elixir
-    ~T[12:00:00]
-    ```
+
+  ```elixir
+  ~T[12:00:00]
+  ```
 
 - The `NaiveDateTime` module for datetimes without a timezone. A `NaiveDateTime` struct can be created with the `~N` sigil.
-    ```elixir
-    ~N[2021-01-01 12:00:00]
-    ```
+
+  ```elixir
+  ~N[2021-01-01 12:00:00]
+  ```
 
 - The `DateTime` module for datetimes with a timezone. Using this module for timezones other than UTC requires an external dependency, a timezone database.
 

--- a/exercises/concept/library-fees/.docs/introduction.md
+++ b/exercises/concept/library-fees/.docs/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-## Dates and time
+## Dates and Time
 
 Elixir's standard library offers 4 different modules for working with dates and time, each with its own struct.
 

--- a/exercises/concept/library-fees/.docs/introduction.md.tpl
+++ b/exercises/concept/library-fees/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Dates and Time
-
 %{concept:dates-and-time}

--- a/exercises/concept/library-fees/.docs/introduction.md.tpl
+++ b/exercises/concept/library-fees/.docs/introduction.md.tpl
@@ -1,5 +1,5 @@
 # Introduction
 
-## Dates and time
+## Dates and Time
 
 %{concept:dates-and-time}

--- a/exercises/concept/library-fees/.docs/introduction.md.tpl
+++ b/exercises/concept/library-fees/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Dates and time
+
+%{concept:dates-and-time}

--- a/exercises/concept/log-level/.docs/introduction.md.tpl
+++ b/exercises/concept/log-level/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Atoms
-
 %{concept:atoms}
-
-## Cond
 
 %{concept:cond}

--- a/exercises/concept/log-level/.docs/introduction.md.tpl
+++ b/exercises/concept/log-level/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Atoms
+
+%{concept:atoms}
+
+## Cond
+
+%{concept:cond}

--- a/exercises/concept/lucas-numbers/.docs/introduction.md.tpl
+++ b/exercises/concept/lucas-numbers/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Streams
+
+%{concept:streams}

--- a/exercises/concept/lucas-numbers/.docs/introduction.md.tpl
+++ b/exercises/concept/lucas-numbers/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Streams
-
 %{concept:streams}

--- a/exercises/concept/mensch-aergere-dich-nicht/.docs/introduction.md
+++ b/exercises/concept/mensch-aergere-dich-nicht/.docs/introduction.md
@@ -2,8 +2,11 @@
 
 ## Streams
 
-All functions in the `Enum` module are _eager_. When performing multiple operations on enumerables with the `Enum` module, each operation is going to generate an intermediate result.
+All functions in the [`Enum` module][exercism-enum] are _eager_. When performing multiple operations on enumerables with the `Enum` module, each operation is going to generate an intermediate result.
 
 The `Stream` module is a _lazy_ alternative to the _eager_ `Enum` module. It offers many of the same functions as `Enum`, but instead of generating intermediate results, it builds a series of computations that are only executed once the stream is passed to a function from the `Enum` module.
 
-Streams implement the _Enumerable protocol_ and are composable.
+Streams implement the _Enumerable [protocol][exercism-protocols]_ and are composable -- you can chain them together to create more complex functionality.
+
+[exercism-enum]: https://exercism.org/tracks/elixir/concepts/enum
+[exercism-protocols]: https://exercism.org/tracks/elixir/concepts/protocols

--- a/exercises/concept/mensch-aergere-dich-nicht/.docs/introduction.md.tpl
+++ b/exercises/concept/mensch-aergere-dich-nicht/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Streams
+
+%{concept:streams}

--- a/exercises/concept/mensch-aergere-dich-nicht/.docs/introduction.md.tpl
+++ b/exercises/concept/mensch-aergere-dich-nicht/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Streams
-
 %{concept:streams}

--- a/exercises/concept/name-badge/.docs/introduction.md
+++ b/exercises/concept/name-badge/.docs/introduction.md
@@ -39,8 +39,8 @@ This syntax is helpful for very short expressions, but should be avoided if the 
 
 ### _Truthy_ and _falsy_
 
-In Elixir, all data types evaluate to a _truthy_ or _falsy_ value when they are encountered in a boolean context (like an `if` expression). All data is considered _truthy_ **except** for `false` and `nil`. In particular, empty strings, the integer `0`, and empty lists are all considered _truthy_ in Elixir.
+In Elixir, all datatypes evaluate to a _truthy_ or _falsy_ value when they are encountered in a boolean context (like an `if` expression). All data is considered _truthy_ **except** for `false` and `nil`. In particular, empty strings, the integer `0`, and empty lists are all considered _truthy_ in Elixir.
 
 [nil-dictionary]: https://www.merriam-webster.com/dictionary/nil
-[kernel-if]: https://hexdocs.pm/elixir/Kernel.html#if/2
 [getting-started-if-unless]: https://elixir-lang.org/getting-started/case-cond-and-if.html#if-and-unless
+[kernel-if]: https://hexdocs.pm/elixir/Kernel.html#if/2

--- a/exercises/concept/name-badge/.docs/introduction.md.tpl
+++ b/exercises/concept/name-badge/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Nil
+
+%{concept:nil}
+
+## If
+
+%{concept:if}

--- a/exercises/concept/name-badge/.docs/introduction.md.tpl
+++ b/exercises/concept/name-badge/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Nil
-
 %{concept:nil}
-
-## If
 
 %{concept:if}

--- a/exercises/concept/need-for-speed/.docs/introduction.md
+++ b/exercises/concept/need-for-speed/.docs/introduction.md
@@ -1,8 +1,8 @@
 # Introduction
 
-To share code between different Elixir modules within the same project, you need to reference the outside module by its full name. But what if that name is too long or confusing?
-
 ## Alias
+
+To share code between different Elixir modules within the same project, you need to reference the outside module by its full name. But what if that name is too long or confusing?
 
 The special form `alias` allows you to shorten or change the name by which you reference an outside module. When used without any arguments, it trims down the module name to its last segment, e.g. `MyApp.Logger.Settings` becomes `Settings`. A custom name can be specified with the `:as` option.
 

--- a/exercises/concept/need-for-speed/.docs/introduction.md.tpl
+++ b/exercises/concept/need-for-speed/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Alias
-
 %{concept:alias}
-
-## Import
 
 %{concept:import}

--- a/exercises/concept/need-for-speed/.docs/introduction.md.tpl
+++ b/exercises/concept/need-for-speed/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Alias
+
+%{concept:alias}
+
+## Import
+
+%{concept:import}

--- a/exercises/concept/new-passport/.docs/introduction.md
+++ b/exercises/concept/new-passport/.docs/introduction.md
@@ -1,5 +1,7 @@
 # Introduction
 
+## With
+
 The [special form with][with] provides a way to focus on the "happy path" of a series of potentially failing steps and deal with the failures later.
 
 ```elixir

--- a/exercises/concept/new-passport/.docs/introduction.md.tpl
+++ b/exercises/concept/new-passport/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## With
+
+%{concept:with}

--- a/exercises/concept/new-passport/.docs/introduction.md.tpl
+++ b/exercises/concept/new-passport/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## With
-
 %{concept:with}

--- a/exercises/concept/newsletter/.docs/introduction.md.tpl
+++ b/exercises/concept/newsletter/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## File
-
 %{concept:file}

--- a/exercises/concept/newsletter/.docs/introduction.md.tpl
+++ b/exercises/concept/newsletter/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## File
+
+%{concept:file}

--- a/exercises/concept/pacman-rules/.docs/introduction.md
+++ b/exercises/concept/pacman-rules/.docs/introduction.md
@@ -2,14 +2,14 @@
 
 ## Booleans
 
-Elixir represents true and false values with the boolean type. There are only two values: _true_ and _false_. These values can be bound to a variable:
+Elixir represents true and false values with the boolean type. There are only two values: `true` and `false`. These values can be bound to a variable:
 
 ```elixir
 true_variable = true
 false_variable = false
 ```
 
-We can evaluate strict boolean expressions using the `and/2`, `or/2`, and `not/1` operator functions.
+We can evaluate strict boolean expressions using the `and/2`, `or/2`, and `not/1` operators.
 
 ```elixir
 true_variable = true and true

--- a/exercises/concept/pacman-rules/.docs/introduction.md.tpl
+++ b/exercises/concept/pacman-rules/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Booleans
+
+%{concept:booleans}

--- a/exercises/concept/pacman-rules/.docs/introduction.md.tpl
+++ b/exercises/concept/pacman-rules/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Booleans
-
 %{concept:booleans}

--- a/exercises/concept/remote-control-car/.docs/introduction.md.tpl
+++ b/exercises/concept/remote-control-car/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Structs
+
+%{concept:structs}

--- a/exercises/concept/remote-control-car/.docs/introduction.md.tpl
+++ b/exercises/concept/remote-control-car/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Structs
-
 %{concept:structs}

--- a/exercises/concept/rpg-character-sheet/.docs/introduction.md.tpl
+++ b/exercises/concept/rpg-character-sheet/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## IO
+
+%{concept:io}

--- a/exercises/concept/rpg-character-sheet/.docs/introduction.md.tpl
+++ b/exercises/concept/rpg-character-sheet/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## IO
-
 %{concept:io}

--- a/exercises/concept/rpn-calculator-inspection/.docs/introduction.md.tpl
+++ b/exercises/concept/rpn-calculator-inspection/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Links
+
+%{concept:links}
+
+## Tasks
+
+%{concept:tasks}

--- a/exercises/concept/rpn-calculator-inspection/.docs/introduction.md.tpl
+++ b/exercises/concept/rpn-calculator-inspection/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Links
-
 %{concept:links}
-
-## Tasks
 
 %{concept:tasks}

--- a/exercises/concept/rpn-calculator-output/.docs/introduction.md
+++ b/exercises/concept/rpn-calculator-output/.docs/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-## Try Rescue Else After
+## Try/Rescue/Else/After
 
 Using `try..rescue` is a powerful construct for catching errors when they occur. Rescuing errors allows functions to return defined values when it is necessary. The `try..rescue` construct also offers us two additional features we can make use of:
 

--- a/exercises/concept/rpn-calculator-output/.docs/introduction.md.tpl
+++ b/exercises/concept/rpn-calculator-output/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Try/Rescue/Else/After
-
 %{concept:try-rescue-else-after}
-
-## Dynamic Dispatch
 
 %{concept:dynamic-dispatch}

--- a/exercises/concept/rpn-calculator-output/.docs/introduction.md.tpl
+++ b/exercises/concept/rpn-calculator-output/.docs/introduction.md.tpl
@@ -1,6 +1,6 @@
 # Introduction
 
-## Try Rescue Else After
+## Try/Rescue/Else/After
 
 %{concept:try-rescue-else-after}
 

--- a/exercises/concept/rpn-calculator-output/.docs/introduction.md.tpl
+++ b/exercises/concept/rpn-calculator-output/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Try Rescue Else After
+
+%{concept:try-rescue-else-after}
+
+## Dynamic Dispatch
+
+%{concept:dynamic-dispatch}

--- a/exercises/concept/rpn-calculator/.docs/introduction.md
+++ b/exercises/concept/rpn-calculator/.docs/introduction.md
@@ -11,7 +11,7 @@ Map.fetch!(%{a: 1}, :b)
 # => raises KeyError
 ```
 
-## Try Rescue
+## Try/Rescue
 
 Elixir provides a construct for rescuing from errors using `try .. rescue`
 

--- a/exercises/concept/rpn-calculator/.docs/introduction.md.tpl
+++ b/exercises/concept/rpn-calculator/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Errors
+
+%{concept:errors}
+
+## Try Rescue
+
+%{concept:try-rescue}

--- a/exercises/concept/rpn-calculator/.docs/introduction.md.tpl
+++ b/exercises/concept/rpn-calculator/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Errors
-
 %{concept:errors}
-
-## Try/Rescue
 
 %{concept:try-rescue}

--- a/exercises/concept/rpn-calculator/.docs/introduction.md.tpl
+++ b/exercises/concept/rpn-calculator/.docs/introduction.md.tpl
@@ -4,6 +4,6 @@
 
 %{concept:errors}
 
-## Try Rescue
+## Try/Rescue
 
 %{concept:try-rescue}

--- a/exercises/concept/secrets/.docs/introduction.md
+++ b/exercises/concept/secrets/.docs/introduction.md
@@ -2,7 +2,7 @@
 
 ## Anonymous Functions
 
-Functions are treated as first class citizens in Elixir. This means functions:
+Functions are treated as first class citizens in Elixir. This means that:
 
 - Named and anonymous functions can be assigned to variables.
 - Named and anonymous functions can be passed around like data as arguments and return values.

--- a/exercises/concept/secrets/.docs/introduction.md.tpl
+++ b/exercises/concept/secrets/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Anonymous Functions
+
+%{concept:anonymous-functions}
+
+## Bit Manipulation
+
+%{concept:bit-manipulation}

--- a/exercises/concept/secrets/.docs/introduction.md.tpl
+++ b/exercises/concept/secrets/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Anonymous Functions
-
 %{concept:anonymous-functions}
-
-## Bit Manipulation
 
 %{concept:bit-manipulation}

--- a/exercises/concept/stack-underflow/.docs/introduction.md.tpl
+++ b/exercises/concept/stack-underflow/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Exceptions
+
+%{concept:exceptions}

--- a/exercises/concept/stack-underflow/.docs/introduction.md.tpl
+++ b/exercises/concept/stack-underflow/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Exceptions
-
 %{concept:exceptions}

--- a/exercises/concept/take-a-number-deluxe/.docs/introduction.md
+++ b/exercises/concept/take-a-number-deluxe/.docs/introduction.md
@@ -66,6 +66,7 @@ end
 A server can be started by calling `GenServer.start/3` or `GenServer.start_link/3`. We learned about the difference between those functions in the [links concept][concept-links].
 
 Those two functions:
+
 - Accept a module implementing the `GenServer` behaviour as the first argument.
 - Accept anything as the second argument called `init_arg`. As the name suggest, this argument gets passed to the `init/1` callback.
 - Accept an optional third argument with advanced options for running the process that we wont' cover now.
@@ -73,6 +74,7 @@ Those two functions:
 Starting a server by calling `GenServer.start/3` or `GenServer.start_link/3` will invoke the `init/1` callback in a blocking way. The return value of `init/1` dictates if the server can be started successfully.
 
 The `init/1` callback usually returns one of those values:
+
 - `{:ok, state}`. The server will start its receive loop using `state` as its initial state. `state` can be of any type.
 - `{:stop, reason}`. `reason` can be of any type. The server will not start its receive loop. The process will exit with the given reason.
 

--- a/exercises/concept/take-a-number-deluxe/.docs/introduction.md
+++ b/exercises/concept/take-a-number-deluxe/.docs/introduction.md
@@ -105,7 +105,7 @@ If that person is available, you'll receive a reply immediately (synchronously).
 
 A message that doesn't require a reply can be sent to a server process with `GenServer.cast/2`. Its arguments are identical to those of `GenServer.call/2`.
 
-The `handle_cast/2` callback is responsible for handling those messages. It receives two arguments, `message` and `state`, which are the same arguments as in the  `handle_call/3` callback (except for `from`).
+The `handle_cast/2` callback is responsible for handling those messages. It receives two arguments, `message` and `state`, which are the same arguments as in the `handle_call/3` callback (except for `from`).
 
 The `handle_cast/2` callback usually returns a 2 tuple of `{:noreply, state}`.
 

--- a/exercises/concept/take-a-number-deluxe/.docs/introduction.md.tpl
+++ b/exercises/concept/take-a-number-deluxe/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## GenServer
+
+%{concept:genserver}

--- a/exercises/concept/take-a-number-deluxe/.docs/introduction.md.tpl
+++ b/exercises/concept/take-a-number-deluxe/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## GenServer
-
 %{concept:genserver}

--- a/exercises/concept/take-a-number/.docs/introduction.md.tpl
+++ b/exercises/concept/take-a-number/.docs/introduction.md.tpl
@@ -1,0 +1,9 @@
+# Introduction
+
+## Processes
+
+%{concept:processes}
+
+## PIDs
+
+%{concept:pids}

--- a/exercises/concept/take-a-number/.docs/introduction.md.tpl
+++ b/exercises/concept/take-a-number/.docs/introduction.md.tpl
@@ -1,9 +1,5 @@
 # Introduction
 
-## Processes
-
 %{concept:processes}
-
-## PIDs
 
 %{concept:pids}

--- a/exercises/concept/top-secret/.docs/introduction.md.tpl
+++ b/exercises/concept/top-secret/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## AST
-
 %{concept:ast}

--- a/exercises/concept/top-secret/.docs/introduction.md.tpl
+++ b/exercises/concept/top-secret/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## AST
+
+%{concept:ast}

--- a/exercises/concept/wine-cellar/.docs/introduction.md.tpl
+++ b/exercises/concept/wine-cellar/.docs/introduction.md.tpl
@@ -1,5 +1,3 @@
 # Introduction
 
-## Keyword Lists
-
 %{concept:keyword-lists}

--- a/exercises/concept/wine-cellar/.docs/introduction.md.tpl
+++ b/exercises/concept/wine-cellar/.docs/introduction.md.tpl
@@ -1,0 +1,5 @@
+# Introduction
+
+## Keyword Lists
+
+%{concept:keyword-lists}


### PR DESCRIPTION
Closes: #686 

---

Please see individual commits, and feel free to take over and push commits to this branch.

I may have made changes in the wrong direction while trying to unify the contents of a concept exercise's `introduction.md` with that of a corresponding concept `introduction.md` file.

I initially created the template files like this:

```markdown
# Introduction

## Atoms

%{concept:atoms}

## Cond

%{concept:cond}
```

But I've changed them to the below format instead.

```markdown
# Introduction

%{concept:atoms}

%{concept:cond}
```

`configlet generate` will support both. In the latter format, the contents of the level-2 heading are taken from concept's `name` in the track `config.json`.

Note that an unreleased `configlet` version was used for the `configlet generate` in this PR.

Edit: now released - see https://github.com/exercism/configlet/releases/tag/4.0.0-beta.5