### PR TITLE
Dancing Dots: Fix test

### DIFF
--- a/exercises/concept/dancing-dots/test/dancing_dots/animation_test.exs
+++ b/exercises/concept/dancing-dots/test/dancing_dots/animation_test.exs
@@ -64,7 +64,7 @@ defmodule DancingDots.AnimationTest do
         end
       end)
 
-      refute function_exported?(TestAnimation3, :handle_frame, 3)
+      refute function_exported?(TestAnimation4, :handle_frame, 3)
     end
 
     @tag task_id: 2


### PR DESCRIPTION
The test `"__using__ does not provide a default implementation of handle_frame/3"` was passing, even with the wrong Module.
And according to the documentation for [function_exported](https://www.erlang.org/doc/man/erlang.html#function_exported-3), it is because the Module was not loaded in which case returns `false` and the test succeeds.