### PR TITLE
File sniffer: Add instruction and test to return nil for unknown inputs

### DIFF
--- a/exercises/concept/file-sniffer/.docs/instructions.md
+++ b/exercises/concept/file-sniffer/.docs/instructions.md
@@ -14,21 +14,28 @@ Use the following table for reference:
 
 ## 1. Given an extension, return the expected media type
 
-Implement the `type_from_extension/1` function. It should take a file extension (string) and return the media type (string).
+Implement the `type_from_extension/1` function. It should take a file extension (string) and return the media type (string) or nil if the extension does not match with the expected ones.
 
 ```elixir
 FileSniffer.type_from_extension("exe")
 # => "application/octet-stream"
+
+FileSniffer.type_from_extension("txt")
+# => nil
 ```
 
 ## 2. Given a binary file, return the expected media type
 
-Implement the `type_from_binary/1` function. It should take a file (binary) and return the media type (string).
+Implement the `type_from_binary/1` function. It should take a file (binary) and return the media type (string) or nil if the extension does not match with the expected ones.
 
 ```elixir
 file = File.read!("application.exe")
 FileSniffer.type_from_binary(file)
 # => "application/octet-stream"
+
+file = File.read!("example.txt")
+FileSniffer.type_from_binary(file)
+# => nil
 ```
 
 Don't worry about reading the file as a binary. Assume that has been done for you and is provided by the tests as an argument.

--- a/exercises/concept/file-sniffer/.meta/exemplar.ex
+++ b/exercises/concept/file-sniffer/.meta/exemplar.ex
@@ -4,6 +4,7 @@ defmodule FileSniffer do
   def type_from_extension("jpg"), do: "image/jpg"
   def type_from_extension("gif"), do: "image/gif"
   def type_from_extension("exe"), do: "application/octet-stream"
+  def type_from_extension(_file_extension), do: nil
 
   def type_from_binary(<<0x42, 0x4D, _::binary>>), do: "image/bmp"
 
@@ -13,6 +14,7 @@ defmodule FileSniffer do
   def type_from_binary(<<0xFF, 0xD8, 0xFF, _::binary>>), do: "image/jpg"
   def type_from_binary(<<0x47, 0x49, 0x46, _::binary>>), do: "image/gif"
   def type_from_binary(<<0x7F, 0x45, 0x4C, 0x46, _::binary>>), do: "application/octet-stream"
+  def type_from_binary(_binary), do: nil
 
   def verify(binary, extension) do
     binary_type = type_from_binary(binary)

--- a/exercises/concept/file-sniffer/test/file_sniffer_test.exs
+++ b/exercises/concept/file-sniffer/test/file_sniffer_test.exs
@@ -34,6 +34,23 @@ defmodule FileSnifferTest do
     end
   end
 
+  describe "return nil when type doesn't match:" do
+    @tag task_id: 1
+    test "txt" do
+      assert FileSniffer.type_from_extension("txt") == nil
+    end
+
+    @tag task_id: 1
+    test "md" do
+      assert FileSniffer.type_from_extension("md") == nil
+    end
+
+    @tag task_id: 1
+    test "svg" do
+      assert FileSniffer.type_from_extension("svg") == nil
+    end
+  end
+
   describe "get type from binary:" do
     @tag task_id: 2
     test "bmp" do
@@ -61,50 +78,30 @@ defmodule FileSnifferTest do
     end
   end
 
-  describe "raises error when given uncompleted signature file" do
+  describe "return nil when given uncompleted signature file" do
     @tag task_id: 2
     test "bmp" do
-      assert_raise(FunctionClauseError, fn ->
-        @bmp_file
-        |> String.slice(0..0)
-        |> FileSniffer.type_from_binary()
-      end)
+      assert FileSniffer.type_from_binary(String.slice(@bmp_file, 0..0)) == nil
     end
 
     @tag task_id: 2
     test "gif" do
-      assert_raise(FunctionClauseError, fn ->
-        @gif_file
-        |> String.slice(0..1)
-        |> FileSniffer.type_from_binary()
-      end)
+      assert FileSniffer.type_from_binary(String.slice(@gif_file, 0..1)) == nil
     end
 
     @tag task_id: 2
     test "jpg" do
-      assert_raise(FunctionClauseError, fn ->
-        @jpg_file
-        |> String.slice(0..1)
-        |> FileSniffer.type_from_binary()
-      end)
+      assert FileSniffer.type_from_binary(String.slice(@jpg_file, 0..1)) == nil
     end
 
     @tag task_id: 2
     test "png" do
-      assert_raise(FunctionClauseError, fn ->
-        @png_file
-        |> String.slice(0..5)
-        |> FileSniffer.type_from_binary()
-      end)
+      assert FileSniffer.type_from_binary(String.slice(@png_file, 0..5)) == nil
     end
 
     @tag task_id: 2
     test "exe" do
-      assert_raise(FunctionClauseError, fn ->
-        @exe_file
-        |> String.slice(0..2)
-        |> FileSniffer.type_from_binary()
-      end)
+      assert FileSniffer.type_from_binary(String.slice(@exe_file, 0..2)) == nil
     end
   end
 

--- a/exercises/concept/file-sniffer/test/file_sniffer_test.exs
+++ b/exercises/concept/file-sniffer/test/file_sniffer_test.exs
@@ -61,6 +61,53 @@ defmodule FileSnifferTest do
     end
   end
 
+  describe "raises error when given uncompleted signature file" do
+    @tag task_id: 2
+    test "bmp" do
+      assert_raise(FunctionClauseError, fn ->
+        @bmp_file
+        |> String.slice(0..0)
+        |> FileSniffer.type_from_binary()
+      end)
+    end
+
+    @tag task_id: 2
+    test "gif" do
+      assert_raise(FunctionClauseError, fn ->
+        @gif_file
+        |> String.slice(0..1)
+        |> FileSniffer.type_from_binary()
+      end)
+    end
+
+    @tag task_id: 2
+    test "jpg" do
+      assert_raise(FunctionClauseError, fn ->
+        @jpg_file
+        |> String.slice(0..1)
+        |> FileSniffer.type_from_binary()
+      end)
+    end
+
+    @tag task_id: 2
+    test "png" do
+      assert_raise(FunctionClauseError, fn ->
+        @png_file
+        |> String.slice(0..5)
+        |> FileSniffer.type_from_binary()
+      end)
+    end
+
+    @tag task_id: 2
+    test "exe" do
+      assert_raise(FunctionClauseError, fn ->
+        @exe_file
+        |> String.slice(0..2)
+        |> FileSniffer.type_from_binary()
+      end)
+    end
+  end
+
   describe "verify valid files" do
     @tag task_id: 3
     test "bmp" do


### PR DESCRIPTION
Closes #1152 and https://github.com/exercism/elixir-analyzer/issues/304

The instructions for the exercise say that the student needs to implement type_from_binary/1 by waiting for the binary signature.

The problem is that we only have tests for this in the analyzer.

So if the student creates type_from_binary/1 expecting only the first hex, it will pass the local tests, but fail in the analyzer tests.

This PR creates tests to ensure that the program will fail if the file does not have a complete binary signature.