### PR TITLE
Fix typespec in meetup.ex

### DIFF
--- a/exercises/practice/meetup/lib/meetup.ex
+++ b/exercises/practice/meetup/lib/meetup.ex
@@ -20,7 +20,7 @@ defmodule Meetup do
   The schedule is in which week (1..4, last or "teenth") the meetup date should
   fall.
   """
-  @spec meetup(pos_integer, pos_integer, weekday, schedule) :: :calendar.date()
+  @spec meetup(pos_integer, pos_integer, weekday, schedule) :: Date.t()
   def meetup(year, month, weekday, schedule) do
   end
 end


### PR DESCRIPTION
`:calendar.date()` in Erlang is defined as `{year(), month(), day()}` tuple, whereas `Date.t()` and `Calendar.date()` in Elixir are maps. The function `assert_dates_equal` in `meetup_test.exs` expects the first argument to be a `%Date{}`, which doesn't match the typespec in `meetup.ex` (and Dialyzer will issue a warning when returning a `Date.t()` as well). This tiny PR fixes this.