### PR TITLE
Fix links in log-parser admonition

### DIFF
--- a/concepts/regular-expressions/introduction.md
+++ b/concepts/regular-expressions/introduction.md
@@ -7,7 +7,7 @@ The `Regex` module offers functions for working with regular expressions. Some o
 ~~~~exercism/note
 This exercise assumes that you already know regular expression syntax, including character classes, quantifiers, groups, and captures.
 
-If you need a refresh your regular expression knowledge, check out one of those sources: [Regular-Expressions.info][website-regex-info], [Rex Egg][website-rexegg], [RegexOne][website-regexone], [Regular Expressions 101][website-regex-101], [RegExr][website-regexr].
+If you need a refresh your regular expression knowledge, check out one of those sources: [Regular-Expressions.info](https://www.regular-expressions.info), [Rex Egg](https://www.rexegg.com/), [RegexOne](https://regexone.com/), [Regular Expressions 101](https://regex101.com/), [RegExr](https://regexr.com/).
 ~~~~
 
 ## Sigils

--- a/exercises/concept/log-parser/.docs/introduction.md
+++ b/exercises/concept/log-parser/.docs/introduction.md
@@ -9,7 +9,7 @@ The `Regex` module offers functions for working with regular expressions. Some o
 ~~~~exercism/note
 This exercise assumes that you already know regular expression syntax, including character classes, quantifiers, groups, and captures.
 
-If you need a refresh your regular expression knowledge, check out one of those sources: [Regular-Expressions.info][website-regex-info], [Rex Egg][website-rexegg], [RegexOne][website-regexone], [Regular Expressions 101][website-regex-101], [RegExr][website-regexr].
+If you need a refresh your regular expression knowledge, check out one of those sources: [Regular-Expressions.info](https://www.regular-expressions.info), [Rex Egg](https://www.rexegg.com/), [RegexOne](https://regexone.com/), [Regular Expressions 101](https://regex101.com/), [RegExr](https://regexr.com/).
 ~~~~
 
 ### Sigils
@@ -57,8 +57,3 @@ Common modifiers are:
 ```
 
 [sigils]: https://hexdocs.pm/elixir/syntax-reference.html#sigils
-[website-regex-info]: https://www.regular-expressions.info
-[website-rexegg]: https://www.rexegg.com/
-[website-regexone]: https://regexone.com/
-[website-regex-101]: https://regex101.com/
-[website-regexr]: https://regexr.com/


### PR DESCRIPTION
Relevant issue: https://github.com/exercism/exercism/issues/6347

I can also see that I forgot to put the references for the URLs at the bottom of one of those documents, but that's not the cause of this issue. The links don't render on the concept document either, and that has the right references, so I'm sure this PR is necessary.