### PR TITLE
Remove pipe operator from language-list instructions

### DIFF
--- a/exercises/concept/language-list/.docs/instructions.md
+++ b/exercises/concept/language-list/.docs/instructions.md
@@ -16,9 +16,11 @@ LanguageList.new()
 Define the `add/2` function that takes 2 arguments (a _language list_ and a string literal of a _language_). It should return the resulting list with the new language prepended to the given list.
 
 ```elixir
-LanguageList.new()
-|> LanguageList.add("Clojure")
-|> LanguageList.add("Haskell")
+language_list = LanguageList.new()
+# => []
+language_list = LanguageList.add(language_list, "Clojure")
+# => ["Clojure"]
+language_list = LanguageList.add(language_list, "Haskell")
 # => ["Haskell", "Clojure"]
 ```
 
@@ -27,10 +29,13 @@ LanguageList.new()
 Define the `remove/1` function that takes 1 argument (a _language list_). It should return the list without the first item. Assume the list will always have at least one item.
 
 ```elixir
-LanguageList.new()
-|> LanguageList.add("Clojure")
-|> LanguageList.add("Haskell")
-|> LanguageList.remove()
+language_list = LanguageList.new()
+# => []
+language_list = LanguageList.add(language_list, "Clojure")
+# => ["Clojure"]
+language_list = LanguageList.add(language_list, "Haskell")
+# => ["Haskell", "Clojure"]
+language_list = LanguageList.remove(language_list)
 # => ["Clojure"]
 ```
 
@@ -39,10 +44,13 @@ LanguageList.new()
 Define the `first/1` function that takes 1 argument (a _language list_). It should return the first language in the list. Assume the list will always have at least one item.
 
 ```elixir
-LanguageList.new()
-|> LanguageList.add("Elm")
-|> LanguageList.add("Prolog")
-|> LanguageList.first()
+language_list = LanguageList.new()
+# => []
+language_list = LanguageList.add(language_list, "Elm")
+# => ["Elm"]
+language_list = LanguageList.add(language_list, "Prolog")
+# => ["Prolog", "Elm"]
+LanguageList.first(language_list)
 # => "Prolog"
 ```
 
@@ -51,10 +59,13 @@ LanguageList.new()
 Define the `count/1` function that takes 1 argument (a _language list_). It should return the number of languages in the list.
 
 ```elixir
-LanguageList.new()
-|> LanguageList.add("Elm")
-|> LanguageList.add("Prolog")
-|> LanguageList.count()
+language_list = LanguageList.new()
+# => []
+language_list = LanguageList.add(language_list, "Elm")
+# => ["Elm"]
+language_list = LanguageList.add(language_list, "Prolog")
+# => ["Prolog", "Elm"]
+LanguageList.count(language_list)
 # => 2
 ```
 
@@ -63,8 +74,10 @@ LanguageList.new()
 Define the `functional_list?/1` function which takes 1 argument (a _language list_). It should return a boolean value. It should return true if _"Elixir"_ is one of the languages in the list.
 
 ```elixir
-LanguageList.new()
-|> LanguageList.add("Elixir")
-|> LanguageList.functional_list?()
+language_list = LanguageList.new()
+# => []
+language_list = LanguageList.add(language_list, "Elixir")
+# => ["Elixir"]
+LanguageList.functional_list?(language_list)
 # => true
 ```


### PR DESCRIPTION
Update instructions so they don't use the pipe operator since it's taught later.

Resolves https://github.com/exercism/elixir/issues/1171