### PR TITLE
Remove outdated language-list hints

### DIFF
--- a/exercises/concept/language-list/.docs/hints.md
+++ b/exercises/concept/language-list/.docs/hints.md
@@ -6,36 +6,29 @@
 
 ## 1. Define a function to return an empty language list
 
-- You need to define a [named function][named-function] with 0 arguments.
+- The function needs to return `[]`.
 
 ## 2. Define a function to add a language to the list
 
-- You need to define a [named function][named-function] with 2 arguments. The first argument is a [list][list] of language [string-literals][string]. The second argument is a language [string-literal][string].
-- You can use list literal notation forms.
+- An element can be prepended to a list using `|`.
 
 ## 3. Define a function to remove a language from the list
 
-- You need to define a [named function][named-function] with 1 argument. The first argument is a [list][list] of language [string-literals][string].
 - Elixir [provides a function][tl] to return a list with the first item removed.
 
 ## 4. Define a function to return the first item in the list
 
-- You need to define a [named function][named-function] with 1 argument. The first argument is a [list][list] of language [string-literals][string].
 - Elixir [provides a function][hd] to get the first item from a list.
 
 ## 5. Define a function to return how many languages are in the list
 
-- You need to define a [named function][named-function] with 1 argument. The first argument is a [list][list] of language [string-literals][string].
 - Elixir [provides a function][length] to count the length of a list.
 
 ## 6. Define a function to determine if the list includes a functional language
 
-- You need to define a [named function][named-function] with 1 argument. The first argument is a [list][list] of language [string-literals][string].
 - Your function should return a boolean value indicating whether `"Elixir"` is a member of the list. Elixir [provides a function][in] to test list membership.
 
 [list]: https://elixir-lang.org/getting-started/basic-types.html#linked-lists
-[named-function]: https://elixir-lang.org/getting-started/modules-and-functions.html#named-functions
-[string]: https://elixir-lang.org/getting-started/basic-types.html#strings
 [hd]: https://hexdocs.pm/elixir/Kernel.html#hd/1
 [tl]: https://hexdocs.pm/elixir/Kernel.html#tl/1
 [length]: https://hexdocs.pm/elixir/Kernel.html#length/1


### PR DESCRIPTION
Same as https://github.com/exercism/elixir/pull/1173, pointed out by Exhort students 🙂 