### PR TITLE
Add more test cases to german-sysadmin

### DIFF
--- a/exercises/concept/german-sysadmin/test/username_test.exs
+++ b/exercises/concept/german-sysadmin/test/username_test.exs
@@ -8,18 +8,38 @@ defmodule UsernameTest do
     end
 
     @tag task_id: 1
-    test "it removes everything but lowercase letters" do
+    test "it allows lowercase Latin letters" do
+      assert Username.sanitize('anne') == 'anne'
+    end
+
+    @tag task_id: 1
+    test "it allows the whole lowercase Latin alphabet" do
+      lowercase_latin_letters = 'abcdefghijklmnopqrstuvwxyz'
+
+      assert Username.sanitize(lowercase_latin_letters) == lowercase_latin_letters
+    end
+
+    @tag task_id: 1
+    test "it removes numbers" do
       assert Username.sanitize('schmidt1985') == 'schmidt'
     end
 
     @tag task_id: 1
-    test "it keeps all lowercase Latin letters (and ignores German letters that require special handling)" do
-      input = Enum.to_list(0..0x10FFFF) -- [?_, ?ß, ?ä, ?ö, ?ü]
-      expected = 'abcdefghijklmnopqrstuvwxyz'
-      actual = Username.sanitize(input)
+    test "it removes punctuation" do
+      assert Username.sanitize('*fritz*!$%') == 'fritz'
+    end
 
-      assert Enum.count(actual) == Enum.count(expected)
-      assert Enum.take(actual, Enum.count(expected)) == expected
+    @tag task_id: 1
+    test "it removes whitespace" do
+      assert Username.sanitize(' olaf ') == 'olaf'
+    end
+
+    @tag task_id: 1
+    test "it removes all disallowed characters" do
+      allowed_characters = 'abcdefghijklmnopqrstuvwxyz_ßäöü'
+      input = Enum.to_list(0..0x10FFFF) -- allowed_characters
+
+      assert Username.sanitize(input) == ''
     end
 
     @tag task_id: 2

--- a/exercises/concept/german-sysadmin/test/username_test.exs
+++ b/exercises/concept/german-sysadmin/test/username_test.exs
@@ -8,22 +8,27 @@ defmodule UsernameTest do
     end
 
     @tag task_id: 1
-    test "it keeps lowercase latin letters" do
+    test "it removes everything but lowercase letters" do
+      assert Username.sanitize('schmidt1985') == 'schmidt'
+    end
+
+    @tag task_id: 1
+    test "it keeps all lowercase Latin letters (and ignores German letters that require special handling)" do
       input = Enum.to_list(0..0x10FFFF) -- [?_, ?ß, ?ä, ?ö, ?ü]
       expected = 'abcdefghijklmnopqrstuvwxyz'
       actual = Username.sanitize(input)
 
-      assert Enum.take(actual, Enum.count(expected)) == expected
       assert Enum.count(actual) == Enum.count(expected)
+      assert Enum.take(actual, Enum.count(expected)) == expected
     end
 
     @tag task_id: 2
-    test "it keeps underscores" do
+    test "it allows underscores" do
       assert Username.sanitize('marcel_huber') == 'marcel_huber'
     end
 
     @tag task_id: 3
-    test "it substitutes german letters" do
+    test "it substitutes German letters" do
       assert Username.sanitize('krüger') == 'krueger'
       assert Username.sanitize('köhler') == 'koehler'
       assert Username.sanitize('jäger') == 'jaeger'


### PR DESCRIPTION
- Added a simpler test for lowercase retention that matches the example from the README
- Renamed the test that keeps lowercase to indicate it also keeps Latin and German
- Switched the order of the asserts so you get the information that the counts do not match before the strings are compared (this would have helped me a lot)
- Used the 'allows' language from the README in the underscores test