### PR TITLE
Scale Generator: Fix return type in typespec

### DIFF
--- a/exercises/practice/scale-generator/.meta/example.ex
+++ b/exercises/practice/scale-generator/.meta/example.ex
@@ -17,8 +17,7 @@ defmodule ScaleGenerator do
   "M": E
   "A": F
   """
-  @spec step(scale :: list(String.t()), tonic :: String.t(), step :: String.t()) ::
-          list(String.t())
+  @spec step(scale :: list(String.t()), tonic :: String.t(), step :: String.t()) :: String.t()
   def step(scale, tonic, step) do
     scale |> rotate_chromatic(tonic) |> do_step(step)
   end

--- a/exercises/practice/scale-generator/lib/scale_generator.ex
+++ b/exercises/practice/scale-generator/lib/scale_generator.ex
@@ -13,8 +13,7 @@ defmodule ScaleGenerator do
   "M": E
   "A": F
   """
-  @spec step(scale :: list(String.t()), tonic :: String.t(), step :: String.t()) ::
-          list(String.t())
+  @spec step(scale :: list(String.t()), tonic :: String.t(), step :: String.t()) :: String.t()
   def step(scale, tonic, step) do
   end
 


### PR DESCRIPTION
Improve typespec from `step/3` because it returns String and not a list.