### PR TITLE
Fix mixup between arguments and parameters

### DIFF
--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -37,7 +37,7 @@ defmodule Calculator do
 end
 ```
 
-Invoking a function is done by specifying its module and function name and passing arguments for each of the function's arguments.
+Invoking a function is done by specifying its module and function name and passing arguments for each of the function's parameters.
 
 ```elixir
 sum = Calculator.add(1, 2)

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -39,7 +39,7 @@ defmodule Calculator do
 end
 ```
 
-Invoking a function is done by specifying its module and function name and passing arguments for each of the function's arguments.
+Invoking a function is done by specifying its module and function name and passing arguments for each of the function's parameters.
 
 ```elixir
 sum = Calculator.add(1, 2)


### PR DESCRIPTION
Arguments are passed to a function, but a function definition has
parameters.

Here we were referring to both concepts with the same word.