### PR TITLE
Test against Elixir 1.14 and OTP 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: '1.8.0'
-            otp: '21.0'
           - elixir: '1.9.0'
             otp: '21.0'
           - elixir: '1.10.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: [1.13]
-        otp: [24.1]
+        elixir: [1.14]
+        otp: [25.0]
 
     steps:
       - name: Checkout code
@@ -89,6 +89,8 @@ jobs:
             otp: '24.0'
           - elixir: '1.13.0'
             otp: '24.1'
+          - elixir: '1.14.0'
+            otp: '25.0'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr.ci.yml
+++ b/.github/workflows/pr.ci.yml
@@ -72,8 +72,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: '1.8.0'
-            otp: '21.0'
           - elixir: '1.9.0'
             otp: '21.0'
           - elixir: '1.10.0'

--- a/.github/workflows/pr.ci.yml
+++ b/.github/workflows/pr.ci.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: [1.13]
-        otp: [24.1]
+        elixir: [1.14]
+        otp: [25.0]
 
     steps:
       - name: Checkout PR
@@ -86,6 +86,8 @@ jobs:
             otp: '24.0'
           - elixir: '1.13.0'
             otp: '24.1'
+          - elixir: '1.14.0'
+            otp: '25.0'
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Setup
 
-The exercises currently target Elixir versions from 1.8 to 1.14 and Erlang/OTP versions from 21 to 25. Detailed installation instructions can be found at
+The exercises currently target Elixir versions from 1.9 to 1.14 and Erlang/OTP versions from 21 to 25. Detailed installation instructions can be found at
 [http://elixir-lang.org/install.html](http://elixir-lang.org/install.html). We recommend using the [asdf version manager](https://github.com/asdf-vm/asdf) to manage multiple Elixir versions.
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Setup
 
-The exercises currently target Elixir versions from 1.8 to 1.13 and Erlang/OTP versions from 21 to 24. Detailed installation instructions can be found at
+The exercises currently target Elixir versions from 1.8 to 1.14 and Erlang/OTP versions from 21 to 25. Detailed installation instructions can be found at
 [http://elixir-lang.org/install.html](http://elixir-lang.org/install.html). We recommend using the [asdf version manager](https://github.com/asdf-vm/asdf) to manage multiple Elixir versions.
 
 ## Testing

--- a/bin/bootstrap_practice_exercise.exs
+++ b/bin/bootstrap_practice_exercise.exs
@@ -170,7 +170,7 @@ defmodule #{module}.MixProject do
     [
       app: :#{exercise_snake_case},
       version: "0.1.0",
-      # elixir: "~> 1.8",
+      # elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]

--- a/exercises/practice/grains/.meta/example.ex
+++ b/exercises/practice/grains/.meta/example.ex
@@ -1,5 +1,5 @@
 defmodule Grains do
-  use Bitwise, only_operators: true
+  import Bitwise
   def square(number) when number in 1..64, do: {:ok, 1 <<< (number - 1)}
   def square(_), do: {:error, "The requested square must be between 1 and 64 (inclusive)"}
 

--- a/exercises/practice/grep/.meta/example.ex
+++ b/exercises/practice/grep/.meta/example.ex
@@ -1,5 +1,5 @@
 defmodule Grep do
-  use Bitwise
+  import Bitwise
 
   @line_num_flag 1
   @file_name 2

--- a/exercises/practice/secret-handshake/.meta/example.ex
+++ b/exercises/practice/secret-handshake/.meta/example.ex
@@ -1,5 +1,5 @@
 defmodule SecretHandshake do
-  use Bitwise
+  import Bitwise
 
   @codes ["wink", "double blink", "close your eyes", "jump"]
 

--- a/exercises/practice/variable-length-quantity/.meta/example.ex
+++ b/exercises/practice/variable-length-quantity/.meta/example.ex
@@ -1,5 +1,5 @@
 defmodule VariableLengthQuantity do
-  use Bitwise
+  import Bitwise
 
   @doc """
   Encode integers into a bitstring of VLQ encoded bytes


### PR DESCRIPTION
Only one fix was necessary, `use Bitwise` -> `import Bitwise`. It works in all older versions with `import Bitwise` too.