### PR TITLE
Update bitwise shift left example

### DIFF
--- a/concepts/bit-manipulation/introduction.md
+++ b/concepts/bit-manipulation/introduction.md
@@ -13,7 +13,7 @@ Here is an example how to use a bitwise function:
 
 ```elixir
 Bitwise.bsl(1, 3)
-# => 3
+# => 8
 ```
 
 All bitwise functions only work on integers.

--- a/concepts/bit-manipulation/introduction.md
+++ b/concepts/bit-manipulation/introduction.md
@@ -12,8 +12,8 @@ Elixir supports many functions for working with bits found in the _Bitwise modul
 Here is an example how to use a bitwise function:
 
 ```elixir
-Bitwise.bsl(1, 2)
-# => 4
+Bitwise.bsl(1, 3)
+# => 3
 ```
 
 All bitwise functions only work on integers.

--- a/exercises/concept/secrets/.docs/introduction.md
+++ b/exercises/concept/secrets/.docs/introduction.md
@@ -51,8 +51,8 @@ Elixir supports many functions for working with bits found in the _Bitwise modul
 Here is an example how to use a bitwise function:
 
 ```elixir
-Bitwise.bsl(1, 2)
-# => 4
+Bitwise.bsl(1, 3)
+# => 8
 ```
 
 All bitwise functions only work on integers.


### PR DESCRIPTION
The introduction to bitwise shift used `Bitwise.bsl(1, 2)`
as the example. This is ambiguous, as
`Bitwise.bsl(1, 2)` and `Bitwise.bsl(2, 1)` both result in 4.

Here I updated the example to shift 1 left 3 places, resulting
in a value of 8. This is unambiguous because 3 shifted left once
results in a value of 6.

Closes #1189