### PR TITLE
Community garden: require incremental plot ids

### DIFF
--- a/exercises/concept/community-garden/.docs/hints.md
+++ b/exercises/concept/community-garden/.docs/hints.md
@@ -19,7 +19,7 @@
 
 - The [`Agent`][elixir-doc-agent] module contains functions to obtain and update the state of the _agent process_.
 - The functions generally require a function which transforms the state and returns a specific form.
-- In order to keep track of the id for the next plot to assign, your _agent process_'s state may need to keep track of the plots and also the next id to use for a plot.
+- In order to keep track of the id for the next plot to assign, your _agent process_'s state needs to keep track of the plots and also the next id to use for a plot.
 
 ## 4. Release plots
 

--- a/exercises/concept/community-garden/.docs/instructions.md
+++ b/exercises/concept/community-garden/.docs/instructions.md
@@ -26,6 +26,8 @@ CommunityGarden.list_registrations(pid)
 
 Implement the `CommunityGarden.register/2` function. It should receive the `pid` for the community garden and a name to register the plot. It should return the `Plot` struct with the plot's id and person registered to when it is successful.
 
+The ids should be incremental and unique. You can keep an id counter in the agent's state.
+
 ```elixir
 CommunityGarden.register(pid, "Emma Balan")
 # => %Plot{plot_id: 1, registered_to: "Emma Balan"}

--- a/exercises/concept/community-garden/test/community_garden_test.exs
+++ b/exercises/concept/community-garden/test/community_garden_test.exs
@@ -27,15 +27,22 @@ defmodule CommunityGardenTest do
   end
 
   @tag task_id: 3
-  test "registered plots have unique id" do
+  test "the first plot has an id of 1" do
     assert {:ok, pid} = CommunityGarden.start()
-    CommunityGarden.register(pid, "Johnny Appleseed")
-    CommunityGarden.register(pid, "Frederick Law Olmsted")
-    CommunityGarden.register(pid, "Lancelot (Capability) Brown")
+    plot = CommunityGarden.register(pid, "Johnny Appleseed")
+    assert plot.plot_id == 1
+  end
 
-    plots = pid |> CommunityGarden.list_registrations()
-    unique_ids = plots |> Enum.map(& &1.plot_id) |> Enum.uniq()
-    assert length(plots) == length(unique_ids)
+  @tag task_id: 3
+  test "registered plots have incremental unique id" do
+    assert {:ok, pid} = CommunityGarden.start()
+    plot_1 = CommunityGarden.register(pid, "Johnny Appleseed")
+    plot_2 = CommunityGarden.register(pid, "Frederick Law Olmsted")
+    plot_3 = CommunityGarden.register(pid, "Lancelot (Capability) Brown")
+
+    assert plot_1.plot_id == 1
+    assert plot_2.plot_id == 2
+    assert plot_3.plot_id == 3
   end
 
   @tag task_id: 4
@@ -53,17 +60,17 @@ defmodule CommunityGardenTest do
     plot_1 = CommunityGarden.register(pid, "Keanu Reeves")
     plot_2 = CommunityGarden.register(pid, "Thomas A. Anderson")
 
-    ids = CommunityGarden.list_registrations(pid) |> Enum.map(& &1.plot_id)
+    assert plot_1.plot_id == 1
+    assert plot_2.plot_id == 2
 
     CommunityGarden.release(pid, plot_1.plot_id)
     CommunityGarden.release(pid, plot_2.plot_id)
 
-    CommunityGarden.register(pid, "John Doe")
-    CommunityGarden.register(pid, "Jane Doe")
+    plot_3 = CommunityGarden.register(pid, "John Doe")
+    plot_4 = CommunityGarden.register(pid, "Jane Doe")
 
-    new_ids = CommunityGarden.list_registrations(pid) |> Enum.map(& &1.plot_id)
-
-    refute Enum.sort(ids) == Enum.sort(new_ids)
+    assert plot_3.plot_id == 3
+    assert plot_4.plot_id == 4
   end
 
   @tag task_id: 5


### PR DESCRIPTION
This change is inspired by the Exhort students discussing how they were unsure how to handle the id generation. One student used random ids, another created a second Agent. I think the id generation isn't supposed to be a riddle in this exercise, so we might as well make our expected solution explicit - ids should be incremental, you're supposed to keep an id counter in the agent's state.