### PR TITLE
Update captains_log_test.exs

### DIFF
--- a/exercises/concept/captains-log/test/captains_log_test.exs
+++ b/exercises/concept/captains-log/test/captains_log_test.exs
@@ -59,15 +59,9 @@ defmodule CaptainsLogTest do
     end
 
     @tag task_id: 3
-    test "is equal to or greater than 41_000.0" do
+    test "is greater than or equal to 41_000.0 and less than 42_000.0" do
       Enum.each(0..100, fn _ ->
         assert CaptainsLog.random_stardate() >= 41_000.0
-      end)
-    end
-
-    @tag task_id: 3
-    test "is less than 42_000.0" do
-      Enum.each(0..100, fn _ ->
         assert CaptainsLog.random_stardate() < 42_000.0
       end)
     end


### PR DESCRIPTION
Combine stardate range checks into one test with two asserts. Currently, as two separate tests, the first test passes (>= 41_000.0) with a nil implementation. This new combined test follows the pattern already demonstrated in this test file as "ends with a random integer between 1000 and 9999"