### PR TITLE
Pacman rules: Added missing testcase

### DIFF
--- a/exercises/concept/pacman-rules/test/rules_test.exs
+++ b/exercises/concept/pacman-rules/test/rules_test.exs
@@ -16,6 +16,11 @@ defmodule RulesTest do
     test "ghost does not get eaten because not touching ghost" do
       refute Rules.eat_ghost?(true, false)
     end
+
+    @tag task_id: 1
+    test "ghost does not get eaten because no power pellet is active, even if not touching ghost" do
+      refute Rules.eat_ghost?(false, false)
+    end
   end
 
   describe "score?/2" do


### PR DESCRIPTION
The first function of the Pacman exercise is intended to be solved by using the `and` operator. However, with the test for double `false` missing, an implementation that used `==` instead passed the tests and was uncaught by automated feedback.

I realized this during a mentoring session; perhaps there is a preferred course of action, but I thought I could contribute the missing test case, just in case.