### PR TITLE
Added assertion to bread-and-potions test

### DIFF
--- a/exercises/concept/bread-and-potions/test/rpg_test.exs
+++ b/exercises/concept/bread-and-potions/test/rpg_test.exs
@@ -62,6 +62,8 @@ defmodule RPGTest do
       character = %Character{mana: 10}
       {_byproduct, %Character{} = character} = Edible.eat(%ManaPotion{strength: 6}, character)
       assert character.mana == 16
+      {_byproduct, %Character{} = character} = Edible.eat(%ManaPotion{strength: 9}, character)
+      assert character.mana == 25
     end
 
     @tag task_id: 3


### PR DESCRIPTION
* ensure that the bread-and-potion ManaPotion strength attribute is used, and not just a value of 6.
I ran into this by just staticky using "6" as a value for all mana potions, and both tests happened to pass. (Any other value would fail). This small addition should fix being able to use a static value for mana.