### PR TITLE
Fix typo in hints.md

### DIFF
--- a/exercises/concept/dna-encoding/.docs/hints.md
+++ b/exercises/concept/dna-encoding/.docs/hints.md
@@ -21,7 +21,7 @@
 
 - Create a recursive function which takes a code point from the charlist and recursively builds the bitstring result.
 - Remember, a [charlist][charlist] is a list of [integer code points][codepoint].
-- You can get the first and remaining items from a list using a build in [`Kernel` module][kernel] function.
+- You can get the first and remaining items from a list using a built-in [`Kernel` module][kernel] function.
 - You can also pattern match on a list using the [`[head | tail]`][list] notation.
 - Use multiple clause functions to separate the base case from the recursive cases.
 - Do not forget to specify the types of bitstring segments using the `::` operator.


### PR DESCRIPTION
Should be `built-in` not `build in`