### PR TITLE
RPN Calculator: two additional test cases so that a naïve implementation cannot pass the test suite

### DIFF
--- a/exercises/concept/rpn-calculator/test/rpn_calculator_test.exs
+++ b/exercises/concept/rpn-calculator/test/rpn_calculator_test.exs
@@ -2,8 +2,13 @@ defmodule RPNCalculatorTest do
   use ExUnit.Case
 
   @tag task_id: 1
-  test "calculate! returns an :ok atom" do
+  test "calculate! returns what the operation does: :ok atom" do
     assert RPNCalculator.calculate!([], fn _ -> :ok end) == :ok
+  end
+
+  @tag task_id: 1
+  test "calculate! returns what the operation does: an ok string" do
+    assert RPNCalculator.calculate!([], fn _ -> "ok" end) == "ok"
   end
 
   @tag task_id: 1
@@ -14,9 +19,15 @@ defmodule RPNCalculatorTest do
   end
 
   @tag task_id: 2
-  test "calculate returns a tuple" do
+  test "calculate returns the result of the operation (a string) wrapped in an :ok tuple" do
     assert RPNCalculator.calculate([], fn _ -> "operation completed" end) ==
              {:ok, "operation completed"}
+  end
+
+  @tag task_id: 2
+  test "calculate returns the result of the operation (an atom) wrapped in an :ok tuple" do
+    assert RPNCalculator.calculate([], fn _ -> :success end) ==
+             {:ok, :success}
   end
 
   @tag task_id: 2
@@ -25,9 +36,15 @@ defmodule RPNCalculatorTest do
   end
 
   @tag task_id: 3
-  test "calculate_verbose returns a tuple" do
+  test "calculate_verbose returns the result of the operation (a string) wrapped in an :ok tuple" do
     assert RPNCalculator.calculate_verbose([], fn _ -> "operation completed" end) ==
              {:ok, "operation completed"}
+  end
+
+  @tag task_id: 3
+  test "calculate_verbose returns the result of the operation (an atom) wrapped in an :ok tuple" do
+    assert RPNCalculator.calculate_verbose([], fn _ -> :success end) ==
+             {:ok, :success}
   end
 
   @tag task_id: 3


### PR DESCRIPTION
Got a student which implementation was passing all tests, but whose implementation was not actually using the result of `operation.(stack)` at any time. Instead, it was manually returning `:ok` and `{:ok, "operation completed"}`.

This was passing the test suite because only one `operation` was being used as test case for either `calculate!/2`, `calculate/2` and `calculate_verbose/2`. Simply adding another test case that uses a different `operation` function should prevent such naïve implementation from passing all the tests. 