### PR TITLE
Remove reference to Gitter

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -3,5 +3,3 @@
 ## Installation
 
 Detailed installation instructions can be found at [elixir-lang.org/install](http://elixir-lang.org/install.html).
-
-Help can be found on [Exercism's BEAM Gitter channel](https://gitter.im/exercism/xerlang)

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -16,5 +16,4 @@ The official [Elixir Getting Started Guide](http://elixir-lang.org/getting-start
 * [Elixir School](https://elixirschool.com)
 * [Joy of Elixir](https://joyofelixir.com/toc.html)
 * [Elixir Examples](https://elixir-examples.github.io/)
-* [Exercism's BEAM Gitter channel](https://gitter.im/exercism/xerlang)
 * [Elixir Forum](https://elixirforum.com/)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -8,7 +8,6 @@
 
 ## Communication channels
 
-* [Exercism's BEAM Gitter Channel](https://gitter.im/exercism/xerlang)
 * [Elixir Forum](https://elixirforum.com/)
 * [Slack](https://elixir-slackin.herokuapp.com/)
 * [Discord](https://discord.gg/elixir)

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -1,4 +1,3 @@
 # Help
 
 If you're stuck on something, it may help to look at some of the [available resources](https://exercism.org/docs/tracks/elixir/resources) out there where answers might be found.
-If you can't find what you're looking for in the documentation, feel free to ask help in the Exercism's BEAM [gitter channel](https://gitter.im/exercism/xerlang).


### PR DESCRIPTION
The Exerism Forum (https://forum.exercism.org/) has now made Gitter redundant.
We're directing everyone there.
