### PR TITLE
Add missing spaces in `input` of `rectangles`

### DIFF
--- a/exercises/practice/rectangles/test/rectangles_test.exs
+++ b/exercises/practice/rectangles/test/rectangles_test.exs
@@ -154,7 +154,7 @@ defmodule RectanglesTest do
     +-+ +-+
     | | | |
     +-+-+-+
-      | |
+      | | \s
     +-+-+-+
     | | | |
     +-+ +-+


### PR DESCRIPTION
The test `rectangles must have four sides` from [problem-specifications](https://github.com/exercism/problem-specifications/blob/main/exercises/rectangles/canonical-data.json) has 2 trailing spaces on the 4th line.

Spaces have been added like in the test `two rectangles without shared parts` to avoid the formatter to remove them.