### PR TITLE
Change refute to assert equals false 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
+          version-type: strict
 
       - name: Retrieve Mix Dependencies Cache
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
-          version-type: strict
 
       - name: Retrieve Mix Dependencies Cache
         uses: actions/cache@v3

--- a/exercises/concept/log-level/test/log_level_test.exs
+++ b/exercises/concept/log-level/test/log_level_test.exs
@@ -77,25 +77,25 @@ defmodule LogLevelTest do
 
     @tag task_id: 2
     test "trace code does not send alert" do
-       assert false == LogLevel.alert_recipient(0, false)
+      assert LogLevel.alert_recipient(0, false) == false
     end
 
     @tag task_id: 2
     test "debug code does not send alert" do
-      assert false == LogLevel.alert_recipient(1, false)
-      assert false == LogLevel.alert_recipient(1, true)
+      assert LogLevel.alert_recipient(1, false) == false
+      assert LogLevel.alert_recipient(1, true) == false
     end
 
     @tag task_id: 2
     test "info code does not send alert" do
-       assert false == LogLevel.alert_recipient(2, false)
-       assert false == LogLevel.alert_recipient(2, true)
+      assert LogLevel.alert_recipient(2, false) == false
+      assert LogLevel.alert_recipient(2, true) == false
     end
 
     @tag task_id: 2
     test "warning code does not send alert" do
-      assert false == LogLevel.alert_recipient(3, false)
-      assert false == LogLevel.alert_recipient(3, true)
+      assert LogLevel.alert_recipient(3, false) == false
+      assert LogLevel.alert_recipient(3, true) == false
     end
   end
 end

--- a/exercises/concept/log-level/test/log_level_test.exs
+++ b/exercises/concept/log-level/test/log_level_test.exs
@@ -77,25 +77,25 @@ defmodule LogLevelTest do
 
     @tag task_id: 2
     test "trace code does not send alert" do
-      refute LogLevel.alert_recipient(0, false)
+       assert false == LogLevel.alert_recipient(0, false)
     end
 
     @tag task_id: 2
     test "debug code does not send alert" do
-      refute LogLevel.alert_recipient(1, false)
-      refute LogLevel.alert_recipient(1, true)
+      assert false == LogLevel.alert_recipient(1, false)
+      assert false == LogLevel.alert_recipient(1, true)
     end
 
     @tag task_id: 2
     test "info code does not send alert" do
-      refute LogLevel.alert_recipient(2, false)
-      refute LogLevel.alert_recipient(2, true)
+       assert false == LogLevel.alert_recipient(2, false)
+       assert false == LogLevel.alert_recipient(2, true)
     end
 
     @tag task_id: 2
     test "warning code does not send alert" do
-      refute LogLevel.alert_recipient(3, false)
-      refute LogLevel.alert_recipient(3, true)
+      assert false == LogLevel.alert_recipient(3, false)
+      assert false == LogLevel.alert_recipient(3, true)
     end
   end
 end


### PR DESCRIPTION
When coding the exercise, the instructions are clear that alert_recipient/2 should return a `false` value in case none of the conditions match. Returnnig a nil would still make the tests pass.
This commit changes that to use an assertion for the `false` value instead.