### PR TITLE
.github(CODEOWNERS): reflect renaming of `fetch-configlet`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 .github/CODEOWNERS      @exercism/maintainers-admin
 
 # Changes to `fetch-configlet` should be made in the `exercism/configlet` repo
-bin/fetch_configlet.sh  @exercism/maintainers-admin
+bin/fetch-configlet     @exercism/maintainers-admin


### PR DESCRIPTION
Follow up for commit 213ef5b3860b. Needs maintainers-admin approval.

This makes the `CODEOWNERS` file the same as one on a track that lacks the PowerShell script.

---

Previously: https://github.com/exercism/elixir/pull/1218#issuecomment-1285867624