### PR TITLE
Fix erlef/setup-beam not finding Erlang versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   precheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         elixir: [1.14]
@@ -70,7 +70,7 @@ jobs:
         run: bin/ci-check.sh
 
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:

--- a/.github/workflows/pr.ci.yml
+++ b/.github/workflows/pr.ci.yml
@@ -10,7 +10,7 @@ on: pull_request
 
 jobs:
   precheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         elixir: [1.14]
@@ -67,7 +67,7 @@ jobs:
         run: bin/pr-check.sh
 
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:


### PR DESCRIPTION
I noticed that the CI was failing on a PR that doesn't touch any Elixir code: https://github.com/exercism/elixir/pull/1241

It was suspicious because it started failing without any changes. I assume github changed what "ubuntu-latest" means.

I chose a lower Ubuntu version according to this table: https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp 