### PR TITLE
Lower case resistor colors in instructions

### DIFF
--- a/exercises/practice/resistor-color-duo/.docs/instructions.md
+++ b/exercises/practice/resistor-color-duo/.docs/instructions.md
@@ -17,16 +17,16 @@ The program will take color names as input and output a two digit number, even i
 
 The band colors are encoded as follows:
 
-- Black: 0
-- Brown: 1
-- Red: 2
-- Orange: 3
-- Yellow: 4
-- Green: 5
-- Blue: 6
-- Violet: 7
-- Grey: 8
-- White: 9
+- black: 0
+- brown: 1
+- red: 2
+- orange: 3
+- yellow: 4
+- green: 5
+- blue: 6
+- violet: 7
+- grey: 8
+- white: 9
 
 From the example above:
 brown-green should return 15


### PR DESCRIPTION
The actual atoms are lowercase. For me "The band colors are encoded as follows:" implies the atoms might be uppercase. I tried copy pasting "Black", "Brown"... into a map and then on execution saw the atoms are actually lowercase like "black", "brown". Its a small change, but might reduce one more error!