### PR TITLE
Fix isbn_verifier test differs from problem-specifications

### DIFF
--- a/exercises/practice/isbn-verifier/test/isbn_verifier_test.exs
+++ b/exercises/practice/isbn-verifier/test/isbn_verifier_test.exs
@@ -33,7 +33,7 @@ defmodule IsbnVerifierTest do
 
   @tag :pending
   test "X is only valid as a check digit" do
-    refute IsbnVerifier.isbn?("3-598-2X507-0")
+    refute IsbnVerifier.isbn?("3-598-2X507-9")
   end
 
   @tag :pending


### PR DESCRIPTION
Test "X is only valid as a check digit" is different than the test specified in [exercism/problem-specifications](https://github.com/exercism/problem-specifications). See [isbn-verifier/canonical-data.json](https://github.com/exercism/problem-specifications/blob/main/exercises/isbn-verifier/canonical-data.json#L67)

The issue is that `"3-598-2X507-0"` checksum is 299 - not divisible by 11
but the original `"3-598-2X507-9"` checksum is 308 - divisible by 11
It makes this test less useful and redundant unless fixed.