### PR TITLE
Edit note on how to use `Bitwise` module on v1.14.0

### DIFF
--- a/concepts/bit-manipulation/introduction.md
+++ b/concepts/bit-manipulation/introduction.md
@@ -18,4 +18,4 @@ Bitwise.bsl(1, 3)
 
 All bitwise functions only work on integers.
 
-If you are running Elixir version 1.9 or lower, you will need to call `require Bitwise` at the beginning of the module definition to be able to use the _Bitwise_ module.
+**Note:** You will need to call `require Bitwise` at the beginning of the module definition to be able to use the _Bitwise_ module functions like in the example above: `Bitwise.bsl(1, 3)` . Also you can call `import Bitwise` and use imported functions directly: `bsl(1, 3)`.


### PR DESCRIPTION
Maybe we should remove all Elixir version references and just go with the way it should be used on current stable Elixir version (v1.14.0). This is a text for people learning the language, they should not be learning it with older versions.