### PR TITLE
Regenerate concept exercise introductions

### DIFF
--- a/exercises/concept/dancing-dots/.docs/introduction.md
+++ b/exercises/concept/dancing-dots/.docs/introduction.md
@@ -66,7 +66,7 @@ To mark which function comes from which behaviour, we should use the module attr
 defmodule BookCollection do
   @behaviour Countable
 
-  defstruct :list, :owner
+  defstruct [:list, :owner]
 
   @impl Countable
   def count(collection) do

--- a/exercises/concept/language-list/.docs/introduction.md
+++ b/exercises/concept/language-list/.docs/introduction.md
@@ -11,7 +11,7 @@ two_item_list = [1, 2]
 multiple_type_list = [1, :pi, 3.14, "four"]
 ```
 
-Elixir implements lists as a linked list, where each node stores the reference to the next list. The first item in the list is referred to as the _head_ and the remaining list of items is called the _tail_. We can use this notation in code:
+Elixir implements lists as a linked list, where each node stores two values: the first item and another list with all the remaining items. The first item in the list is referred to as the _head_ and the remaining list of items is called the _tail_. We can use this notation in code:
 
 ```elixir
 # [1] represented in [head | tail] notation

--- a/exercises/concept/stack-underflow/.docs/introduction.md
+++ b/exercises/concept/stack-underflow/.docs/introduction.md
@@ -7,7 +7,7 @@ All errors in Elixir implement the _Exception Behaviour_. Just like the _Access 
 - The module's name defines the error's name.
 - The module defines an error-struct.
 - The struct will have a `:message` field.
-- The module can be be used with `raise/1` and `raise/2` to raise the intended error
+- The module can be used with `raise/1` and `raise/2` to raise the intended error
 
 The _Exception Behaviour_ also specifies two callbacks: `message/1` and `exception/1`. If unimplemented, default implementations will be used. `message/1` transforms the error-struct to a readable message when called with `raise`. `exception/1` allows additional context to be added to the message when it is called with `raise/2`
 

--- a/exercises/concept/take-a-number-deluxe/.docs/introduction.md
+++ b/exercises/concept/take-a-number-deluxe/.docs/introduction.md
@@ -69,7 +69,7 @@ Those two functions:
 
 - Accept a module implementing the `GenServer` behaviour as the first argument.
 - Accept anything as the second argument called `init_arg`. As the name suggest, this argument gets passed to the `init/1` callback.
-- Accept an optional third argument with advanced options for running the process that we wont' cover now.
+- Accept an optional third argument with advanced options for running the process that we won't cover now.
 
 Starting a server by calling `GenServer.start/3` or `GenServer.start_link/3` will invoke the `init/1` callback in a blocking way. The return value of `init/1` dictates if the server can be started successfully.
 


### PR DESCRIPTION
A few fixes to concept introductions didn't make it to concept exercise introductions. This PR commits changes after running `configlet regenerate` and nothing else.