### PR TITLE
Rename MixProject module for library-fees exercise

### DIFF
--- a/exercises/concept/library-fees/mix.exs
+++ b/exercises/concept/library-fees/mix.exs
@@ -1,4 +1,4 @@
-defmodule CaptainsLog.MixProject do
+defmodule LibraryFees.MixProject do
   use Mix.Project
 
   def project do


### PR DESCRIPTION
I guess CaptainsLog came from the captains-log exercise, but they aren't related at all.