### PR TITLE
Rename MixProject modules and application names to match their directory

### DIFF
--- a/exercises/concept/bread-and-potions/mix.exs
+++ b/exercises/concept/bread-and-potions/mix.exs
@@ -1,4 +1,4 @@
-defmodule RPG.MixProject do
+defmodule BreadAndPotions.MixProject do
   use Mix.Project
 
   def project do

--- a/exercises/concept/city-office/mix.exs
+++ b/exercises/concept/city-office/mix.exs
@@ -1,4 +1,4 @@
-defmodule Form.MixProject do
+defmodule CityOffice.MixProject do
   use Mix.Project
 
   def project do

--- a/exercises/concept/dna-encoding/mix.exs
+++ b/exercises/concept/dna-encoding/mix.exs
@@ -1,9 +1,9 @@
-defmodule DNA.MixProject do
+defmodule DNAEncoding.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :dna,
+      app: :dna_encoding,
       version: "0.1.0",
       # elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,

--- a/exercises/concept/german-sysadmin/mix.exs
+++ b/exercises/concept/german-sysadmin/mix.exs
@@ -1,4 +1,4 @@
-defmodule Username.MixProject do
+defmodule GermanSysadmin.MixProject do
   use Mix.Project
 
   def project do

--- a/exercises/concept/need-for-speed/mix.exs
+++ b/exercises/concept/need-for-speed/mix.exs
@@ -1,4 +1,4 @@
-defmodule RemoteControlCar.MixProject do
+defmodule NeedForSpeed.MixProject do
   use Mix.Project
 
   def project do

--- a/exercises/concept/pacman-rules/mix.exs
+++ b/exercises/concept/pacman-rules/mix.exs
@@ -1,4 +1,4 @@
-defmodule Rules.MixProject do
+defmodule PacmanRules.MixProject do
   use Mix.Project
 
   def project do

--- a/exercises/concept/rpg-character-sheet/mix.exs
+++ b/exercises/concept/rpg-character-sheet/mix.exs
@@ -1,4 +1,4 @@
-defmodule RPG.MixProject do
+defmodule RPGCharacterSheet.MixProject do
   use Mix.Project
 
   def project do

--- a/exercises/concept/rpn-calculator-inspection/mix.exs
+++ b/exercises/concept/rpn-calculator-inspection/mix.exs
@@ -1,4 +1,4 @@
-defmodule RPNCalculator.MixProject do
+defmodule RPNCalculatorInspection.MixProject do
   use Mix.Project
 
   def project do

--- a/exercises/concept/rpn-calculator-output/mix.exs
+++ b/exercises/concept/rpn-calculator-output/mix.exs
@@ -1,4 +1,4 @@
-defmodule RPNCalculator.MixProject do
+defmodule RPNCalculatorOutput.MixProject do
   use Mix.Project
 
   def project do

--- a/exercises/concept/stack-underflow/mix.exs
+++ b/exercises/concept/stack-underflow/mix.exs
@@ -1,4 +1,4 @@
-defmodule RPNCalculator.MixProject do
+defmodule StackUnderflow.MixProject do
   use Mix.Project
 
   def project do

--- a/exercises/concept/take-a-number-deluxe/mix.exs
+++ b/exercises/concept/take-a-number-deluxe/mix.exs
@@ -1,4 +1,4 @@
-defmodule TakeANumber.MixProject do
+defmodule TakeANumberDeluxe.MixProject do
   use Mix.Project
 
   def project do

--- a/exercises/practice/armstrong-numbers/mix.exs
+++ b/exercises/practice/armstrong-numbers/mix.exs
@@ -1,9 +1,9 @@
-defmodule ArmstrongNumber.MixProject do
+defmodule ArmstrongNumbers.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :armstrong_number,
+      app: :armstrong_numbers,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/atbash-cipher/mix.exs
+++ b/exercises/practice/atbash-cipher/mix.exs
@@ -1,9 +1,9 @@
-defmodule Atbash.MixProject do
+defmodule AtbashCipher.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :atbash,
+      app: :atbash_cipher,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/difference-of-squares/mix.exs
+++ b/exercises/practice/difference-of-squares/mix.exs
@@ -1,9 +1,9 @@
-defmodule Squares.MixProject do
+defmodule DifferenceOfSquares.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :squares,
+      app: :difference_of_squares,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/dot-dsl/mix.exs
+++ b/exercises/practice/dot-dsl/mix.exs
@@ -1,9 +1,9 @@
-defmodule Dot.MixProject do
+defmodule DotDsl.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :dot,
+      app: :dot_dsl,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/grade-school/mix.exs
+++ b/exercises/practice/grade-school/mix.exs
@@ -1,9 +1,9 @@
-defmodule School.MixProject do
+defmodule GradeSchool.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :school,
+      app: :grade_school,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/kindergarten-garden/mix.exs
+++ b/exercises/practice/kindergarten-garden/mix.exs
@@ -1,9 +1,9 @@
-defmodule Garden.MixProject do
+defmodule KindergartenGarden.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :garden,
+      app: :kindergarten_garden,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/largest-series-product/mix.exs
+++ b/exercises/practice/largest-series-product/mix.exs
@@ -1,9 +1,9 @@
-defmodule Series.MixProject do
+defmodule LargestSeriesProduct.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :series,
+      app: :largest_series_product,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/leap/mix.exs
+++ b/exercises/practice/leap/mix.exs
@@ -1,9 +1,9 @@
-defmodule Year.MixProject do
+defmodule Leap.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :year,
+      app: :leap,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/nth-prime/mix.exs
+++ b/exercises/practice/nth-prime/mix.exs
@@ -1,9 +1,9 @@
-defmodule Prime.MixProject do
+defmodule NthPrime.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :prime,
+      app: :nth_prime,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/palindrome-products/mix.exs
+++ b/exercises/practice/palindrome-products/mix.exs
@@ -1,9 +1,9 @@
-defmodule Palindromes.MixProject do
+defmodule PalindromeProducts.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :palindromes,
+      app: :palindrome_products,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/parallel-letter-frequency/mix.exs
+++ b/exercises/practice/parallel-letter-frequency/mix.exs
@@ -1,9 +1,9 @@
-defmodule Frequency.MixProject do
+defmodule ParallelLetterFrequency.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :frequency,
+      app: :parallel_letter_frequency,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/phone-number/mix.exs
+++ b/exercises/practice/phone-number/mix.exs
@@ -1,9 +1,9 @@
-defmodule Phone.MixProject do
+defmodule PhoneNumber.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :phone,
+      app: :phone_number,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/pythagorean-triplet/mix.exs
+++ b/exercises/practice/pythagorean-triplet/mix.exs
@@ -1,9 +1,9 @@
-defmodule Triplet.MixProject do
+defmodule PythagoreanTriplet.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :triplet,
+      app: :pythagorean_triplet,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/queen-attack/mix.exs
+++ b/exercises/practice/queen-attack/mix.exs
@@ -1,9 +1,9 @@
-defmodule Queens.MixProject do
+defmodule QueenAttack.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :queens,
+      app: :queen_attack,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/run-length-encoding/mix.exs
+++ b/exercises/practice/run-length-encoding/mix.exs
@@ -1,9 +1,9 @@
-defmodule RunLengthEncoder.MixProject do
+defmodule RunLengthEncoding.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :run_length_encoder,
+      app: :run_length_encoding,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/scrabble-score/mix.exs
+++ b/exercises/practice/scrabble-score/mix.exs
@@ -1,9 +1,9 @@
-defmodule Scrabble.MixProject do
+defmodule ScrabbleScore.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :scrabble,
+      app: :scrabble_score,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/simple-linked-list/mix.exs
+++ b/exercises/practice/simple-linked-list/mix.exs
@@ -1,9 +1,9 @@
-defmodule LinkedList.MixProject do
+defmodule SimpleLinkedList.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :linked_list,
+      app: :simple_linked_list,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,

--- a/exercises/practice/spiral-matrix/mix.exs
+++ b/exercises/practice/spiral-matrix/mix.exs
@@ -1,9 +1,9 @@
-defmodule Spiral.MixProject do
+defmodule SpiralMatrix.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :spiral,
+      app: :spiral_matrix,
       version: "0.1.0",
       # elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
In the same vein as #1260.

I stumbled on this while trying to run the tests of solved exercises in an umbrella project.