### PR TITLE
rpg-character-sheet: IO inspect label problems

### DIFF
--- a/exercises/concept/rpg-character-sheet/.docs/hints.md
+++ b/exercises/concept/rpg-character-sheet/.docs/hints.md
@@ -30,6 +30,7 @@
 
 - Reuse functions implemented in previous steps.
 - There is a [built-in function][io-inspect], useful for debugging, that can write to the standard output more than just strings. That functions accepts options, for example a string that will be written before the passed value.
+- The function and its option mentioned above will append a colon and a space to that string for you.
 
 [module-io]: https://hexdocs.pm/elixir/IO.html
 [getting-started-io]: https://elixir-lang.org/getting-started/io-and-the-file-system.html#the-io-module

--- a/exercises/concept/rpg-character-sheet/test/rpg/character_sheet_test.exs
+++ b/exercises/concept/rpg-character-sheet/test/rpg/character_sheet_test.exs
@@ -99,6 +99,22 @@ defmodule RPG.CharacterSheetTest do
     end
 
     @tag task_id: 5
+    test "it only has a single colon and single space after the 'Your character' label" do
+      io =
+        capture_io("Anne\nhealer\n4\n", fn ->
+          RPG.CharacterSheet.run()
+        end)
+
+      case Regex.run(~r/.*(Your character.*)%{/, io) do
+        [_, label] ->
+          assert label == "Your character: "
+
+        _ ->
+          nil
+      end
+    end
+
+    @tag task_id: 5
     test "it inspects the character map" do
       io =
         capture_io("Anne\nhealer\n4\n", fn ->


### PR DESCRIPTION
As reported here https://forum.exercism.org/t/rpg-character-sheet-label-hint-suggestion/4279 and here http://forum.exercism.org/t/bug-report-tracking/1334/10, people are struggling to notice that IO.inspect adds a color and a space for them. The output of the one test that fails if you misuse the label is not easy to parse as it's a regex match and prints out the whole string, with the double color hidden somewhere in the middle, hard to notice (see screenshot, you can test your own eyes 🙂 ).

To help out with this, I'm adding a new test that will fail explicitly on misuse of the label option, and a new hint.

<img width="997" alt="Screenshot 2023-03-04 at 08 43 35" src="https://user-images.githubusercontent.com/7852553/222883579-face04d6-90e5-4b53-974b-0d7525670b82.png">
