### PR TITLE
Fix formatting in paint-by-numbers introduction

### DIFF
--- a/concepts/bitstrings/introduction.md
+++ b/concepts/bitstrings/introduction.md
@@ -64,8 +64,10 @@ value == 0b0110
 
 ## Inspecting bitstrings
 
-~~~~exericism/note
-Bitstrings might be printed (by the test runner or in iex) in a different format than the format that was used to create them. This often causes confusion when learning bistrings.
+~~~~exercism/note
+Bitstrings might be printed (by the test runner or in iex) in a
+different format than the format that was used to create them. This often
+causes confusion when learning bitstrings.
 ~~~~
 
 By default, bitstrings are displayed in fragments of 8 bits (a byte), even if you created them with fragments of a different size.

--- a/exercises/concept/paint-by-number/.docs/introduction.md
+++ b/exercises/concept/paint-by-number/.docs/introduction.md
@@ -67,9 +67,9 @@ value == 0b0110
 ### Inspecting bitstrings
 
 ~~~~exercism/note
-Bitstrings might be printed (by the test runner or in iex) in a different
-format than the format that was used to create them. This often causes
-confusion when learning bistrings.
+Bitstrings might be printed (by the test runner or in iex) in a
+different format than the format that was used to create them. This often
+causes confusion when learning bitstrings.
 ~~~~
 
 By default, bitstrings are displayed in fragments of 8 bits (a byte), even if you created them with fragments of a different size.

--- a/exercises/concept/paint-by-number/.docs/introduction.md
+++ b/exercises/concept/paint-by-number/.docs/introduction.md
@@ -66,8 +66,10 @@ value == 0b0110
 
 ### Inspecting bitstrings
 
-~~~~exericism/note
-Bitstrings might be printed (by the test runner or in iex) in a different format than the format that was used to create them. This often causes confusion when learning bistrings.
+~~~~exercism/note
+Bitstrings might be printed (by the test runner or in iex) in a different
+format than the format that was used to create them. This often causes
+confusion when learning bistrings.
 ~~~~
 
 By default, bitstrings are displayed in fragments of 8 bits (a byte), even if you created them with fragments of a different size.


### PR DESCRIPTION
* Fixes a typo 
* Splits lines each with <=80 chars