### PR TITLE
Fixed typos and formatting of md files

### DIFF
--- a/concepts/bitstrings/introduction.md
+++ b/concepts/bitstrings/introduction.md
@@ -1,21 +1,31 @@
 # Introduction
 
-Working with binary data is an important concept in any language, and Elixir provides an elegant syntax to write, match, and construct binary data.
+Working with binary data is an important concept in any language, and Elixir 
+provides an elegant syntax to write, match, and construct binary data.
 
-In Elixir, binary data is referred to as the bitstring type. The binary data _type_ (not to be confused with binary data in general) is a specific form of a bitstring, which we will discuss in a later exercise.
+In Elixir, binary data is referred to as the bitstring type. The binary data
+_type_ (not to be confused with binary data in general) is a specific form of
+a bitstring, which we will discuss in a later exercise.
 
-Bitstring literals are defined using the bitstring special form `<<>>`. When defining a bitstring literal, it is defined in segments. Each segment has a value and type, separated by the `::` operator. The type specifies how many bits will be used to encode the value. The type can be omitted completely, which will default to a 8-bit integer value.
+Bitstring literals are defined using the bitstring special form `<<>>`. When 
+defining a bitstring literal, it is defined in segments. Each segment has a 
+value and type, separated by the `::` operator. The type specifies how many 
+bits will be used to encode the value. The type can be omitted completely, 
+which will default to a 8-bit integer value.
 
 ```elixir
 # This defines a bitstring with three segments of a single bit each
 <<0::1, 1::1, 0::1>>
 ```
 
-Specifying the type as `::1` is a shorthand for writing `::size(1)`. You need to use the longer syntax if the bit size comes from a variable.
+Specifying the type as `::1` is a shorthand for writing `::size(1)`. 
+You need to use the longer syntax if the bit size comes from a variable.
 
 ## Binary
 
-When writing binary integer literals, we can write them directly in base-2 notation by prefixing the literal with `0b`. Note that they will be anyway displayed as decimal numbers when printed in tests results or when using iex.
+When writing binary integer literals, we can write them directly in base-2 
+notation by prefixing the literal with `0b`. Note that they will be anyway 
+displayed as decimal numbers when printed in tests results or when using iex.
 
 ```elixir
 <<0b1011::4>> == <<11::4>>
@@ -24,7 +34,8 @@ When writing binary integer literals, we can write them directly in base-2 notat
 
 ## Truncating
 
-If the value of the segment overflows the capacity of the segment's type, it will be truncated from the left.
+If the value of the segment overflows the capacity of the segment's type,
+it will be truncated from the left.
 
 ```elixir
 <<0b1011::3>> == <<0b0011::3>>
@@ -33,7 +44,9 @@ If the value of the segment overflows the capacity of the segment's type, it wil
 
 ## Prepending and appending
 
-You can both prepend and append to an existing bitstring using the special form. The `::bistring` type must be used on the existing bitstring if it's of unknown size.
+You can both prepend and append to an existing bitstring using
+the special form. The `::bitstring` type must be used on the existing
+bitstring if it's of unknown size.
 
 ```elixir
 value = <<0b110::3, 0b001::3>>
@@ -43,7 +56,9 @@ new_value = <<0b011::3, value::bitstring, 0b000::3>>
 
 ## Concatenating
 
-We can concatenate bitstrings stored in variables using the special form. The `::bistring` type must be used when concatenating two bitstrings of unknown sizes.
+We can concatenate bitstrings stored in variables using the special form. 
+The `::bitstring` type must be used when concatenating two bitstrings of 
+unknown sizes.
 
 ```elixir
 first = <<0b110::3>>
@@ -54,7 +69,10 @@ concatenated = <<first::bitstring, second::bitstring>>
 
 ## Pattern matching
 
-Pattern matching can also be done to obtain values from the special form. You have to know the number of bits for each fragment you want to capture, with one exception: the `::bitstring` type can be used to pattern match on a bitstring of an unknown size, but this can only be used for the last fragment.
+Pattern matching can also be done to obtain values from the special form.
+You have to know the number of bits for each fragment you want to capture, 
+with one exception: the `::bitstring` type can be used to pattern match on a 
+bitstring of an unknown size, but this can only be used for the last fragment.
 
 ```elixir
 <<value::4, rest::bitstring>> = <<0b01101001::8>>
@@ -65,17 +83,21 @@ value == 0b0110
 ## Inspecting bitstrings
 
 ~~~~exericism/note
-Bitstrings might be printed (by the test runner or in iex) in a different format than the format that was used to create them. This often causes confusion when learning bistrings.
+Bitstrings might be printed (by the test runner or in iex) in a different 
+format than the format that was used to create them. 
+This often causes confusion when learning bitstrings.
 ~~~~
 
-By default, bitstrings are displayed in fragments of 8 bits (a byte), even if you created them with fragments of a different size.
+By default, bitstrings are displayed in fragments of 8 bits (a byte),
+even if you created them with fragments of a different size.
 
 ```elixir
 <<2011::11>>
 # => <<251, 3::size(3)>>
 ```
 
-If you create a bitstring that represents a printable UTF-8 encoded string, it gets displayed as a string.
+If you create a bitstring that represents a printable UTF-8 encoded string,
+it gets displayed as a string.
 
 ```elixir
 <<>>

--- a/exercises/concept/paint-by-number/.docs/hints.md
+++ b/exercises/concept/paint-by-number/.docs/hints.md
@@ -10,9 +10,12 @@
 ## 1. Calculate palette bit size
 
 - This task doesn't use the bitstring data type.
-- Find the smallest positive number `n` such that 2 raised to the power of `n` is greater than or equal than the number of colors we need to represent.
+- Find the smallest positive number `n` such that 2 raised to the power of `n`
+  is greater than or equal than the number of colors we need to represent.
 - Create a recursive function for this.
-- Choose a starting bit size of 1. If 2 raised to the power of the bit size is greater than or equal to the color count, we've found our bit size. If not, add 1 to the bit size and check again (recursion).
+- Choose a starting bit size of 1. If 2 raised to the power of the bit size
+  is greater than or equal to the color count, we've found our bit size.
+  If not, add 1 to the bit size and check again (recursion).
 - Use [`Integer.pow/2`][integer-pow] to raise 2 to a given power.
 
 ## 2. Create an empty picture
@@ -26,27 +29,38 @@
 
 ## 4. Prepend a pixel to a picture
 
-- The [bitstring special form][bitstring-form] can be used to append a new fragment to an existing bitstring.
-- Use the [type operator][type-operator] to specify the bit size of the new fragment as well as the existing bitstring.
-- Use the previously implemented `PaintByNumber.palette_bit_size/1` function to get the bit size of the new fragment.
+- The [bitstring special form][bitstring-form] can be used to append a new 
+  fragment to an existing bitstring.
+- Use the [type operator][type-operator] to specify the bit size of the new 
+  fragment as well as the existing bitstring.
+- Use the previously implemented `PaintByNumber.palette_bit_size/1` 
+  function to get the bit size of the new fragment.
 - Use the special `::bitstring` type to specify that the old fragment is of unknown size.
 
 ## 5. Get the first pixel from a picture
 
-- The [bitstring special form][bitstring-form] can be used to [pattern match bitstrings][bitstring-matching].
-- Use the previously implemented `PaintByNumber.palette_bit_size/1` function to get the bit size of one pixel.
-- Use the special `::bitstring` type to specify that the rest of the bitstring is of unknown size.
+- The [bitstring special form][bitstring-form] can be used to 
+  [pattern match bitstrings][bitstring-matching].
+- Use the previously implemented `PaintByNumber.palette_bit_size/1` 
+  function to get the bit size of one pixel.
+- Use the special `::bitstring` type to specify that the rest of the 
+  bitstring is of unknown size.
 
 ## 6. Drop the first pixel from a picture
 
-- The [bitstring special form][bitstring-form] can be used to [pattern match bitstrings][bitstring-matching].
-- Use the previously implemented `PaintByNumber.palette_bit_size/1` function to get the bit size of one pixel.
-- Use the special `::bitstring` type to specify that the rest of the bitstring is of unknown size.
+- The [bitstring special form][bitstring-form] can be used to 
+  [pattern match bitstrings][bitstring-matching].
+- Use the previously implemented `PaintByNumber.palette_bit_size/1`
+  function to get the bit size of one pixel.
+- Use the special `::bitstring` type to specify that the rest of the 
+  bitstring is of unknown size.
 
 ## 7. Concatenate two pictures
 
-- The [bitstring special form][bitstring-form] can be used to concatenate two bitstrings.
-- Use the special `::bitstring` type to specify that each of the bitstring fragments is of unknown size.
+- The [bitstring special form][bitstring-form] can be used to 
+  concatenate two bitstrings.
+- Use the special `::bitstring` type to specify that each of the bitstring 
+  fragments is of unknown size.
 
 [decimal-to-binary-youtube]: https://www.youtube.com/watch?v=gGiEu7QTi68
 [integer-literal]: https://hexdocs.pm/elixir/master/syntax-reference.html#integers-in-other-bases-and-unicode-code-points

--- a/exercises/concept/paint-by-number/.docs/instructions.md
+++ b/exercises/concept/paint-by-number/.docs/instructions.md
@@ -13,13 +13,15 @@ You want your app to be able to import and export pictures in a custom data form
 You have decided to use [binary files][binary-file] to store your picture data.
 
 ~~~~exercism/note
-This exercise assumes that you're familiar with [binary numbers](https://en.wikipedia.org/wiki/Binary_number)
+This exercise assumes that you're familiar with 
+[binary numbers](https://en.wikipedia.org/wiki/Binary_number)
 and understand the principles behind changing binary numbers to decimal numbers
 and decimal numbers to binary numbers.
 ~~~~
 
 Let's imagine you have a picture of a smiley, like the one shown below.
-The picture has a white background. The smiley has a black border and a yellow fill color.
+The picture has a white background. 
+The smiley has a black border and a yellow fill color.
 
 This picture uses 3 colors.
 Let's say we assign indices to those colors:
@@ -35,32 +37,53 @@ We can now use those color indices to represent the color of each pixel.
 
 ## 1. Calculate palette bit size
 
-Implement the `PaintByNumber.palette_bit_size/1` function. It should take the count of colors in the palette and return how many bits are necessary to represent that many color indices as binary numbers. Color indices always start at 0 and are continuous ascending integers.
+Implement the `PaintByNumber.palette_bit_size/1` function. 
+It should take the count of colors in the palette and return how many 
+bits are necessary to represent that many color indices as binary numbers.
+Color indices always start at 0 and are continuous ascending integers.
 
-For example, representing 13 different colors require 4 bits. 4 bits can store up to 16 color indices (2^4). 3 bits would not be enough because 3 bits can only store up to 8 color indices (2^3).
+For example, representing 13 different colors require 4 bits. 
+4 bits can store up to 16 color indices (2^4).
+3 bits would not be enough because 3 bits can only store up to 8 color indices (2^3).
 
 ```elixir
 PaintByNumber.palette_bit_size(13)
 # => 4
 ```
 
-Note: there is no `log2` function in the Elixir standard library. You will later learn how to use [Erlang libraries][erlang-libraries] from Elixir where you can find this function. Now, solve this task with recursion and the [`Integer.pow/2`][integer-pow] function instead. If you're solving this exercise on your own computer using an older Elixir version (1.11 or lower) that doesn't have `Integer.pow/2` function, use the `Math.pow/2` function we provided in the `lib/math.ex` file for this exercise.
+Note: there is no `log2` function in the Elixir standard library.
+You will later learn how to use [Erlang libraries][erlang-libraries]
+from Elixir where you can find this function.
+Now, solve this task with recursion and the [`Integer.pow/2`][integer-pow]
+function instead. If you're solving this exercise on your own computer 
+using an older Elixir version (1.11 or lower) that doesn't have `Integer.pow/2`
+function, use the `Math.pow/2` function we provided in the `lib/math.ex`
+file for this exercise.
 
 ## 2. Create an empty picture
 
-Implement the `PaintByNumber.empty_picture/0` function. It should return an empty bitstring.
+Implement the `PaintByNumber.empty_picture/0` function.
+It should return an empty bitstring.
 
 ## 3. Create a test picture
 
-A predefined test picture will be used for manual testing of basic features of your app.
+A predefined test picture will be used for manual testing of basic features 
+of your app.
 The test picture consists of 4 pixels with 4 different colors.
 
-Implement the `PaintByNumber.test_picture/0` function. It should return a bitstring that consists of 4 segments.
-Each segment should have a bit size of 2. The segments should have values 0, 1, 2, and 3.
+Implement the `PaintByNumber.test_picture/0` function. 
+It should return a bitstring that consists of 4 segments.
+
+Each segment should have a bit size of 2.
+The segments should have values 0, 1, 2, and 3.
 
 ## 4. Prepend a pixel to a picture
 
-Implement the `PaintByNumber.prepend_pixel/3` function. It should take three arguments: a bitstring with the picture to which we're prepending, the count of colors in the palette, and the index of the color for the new pixel. It should return a bitstring with a picture with the new pixel added to the beginning.
+Implement the `PaintByNumber.prepend_pixel/3` function. 
+It should take three arguments: a bitstring with the picture to which we're
+prepending, the count of colors in the palette, and the index of the
+color for the new pixel. It should return a bitstring with a picture with 
+the new pixel added to the beginning.
 
 ```elixir
 picture = <<2::4, 0::4>>
@@ -74,7 +97,11 @@ PaintByNumber.prepend_pixel(picture, color_count, pixel_color_index)
 
 ## 5. Get the first pixel from a picture
 
-Implement the `PaintByNumber.get_first_pixel/2` function. It should take two arguments: a bitstring with the picture from which we're reading, and the count of colors in the palette. It should return the color index of the first pixel in the given picture. When given an empty picture, it should return `nil`.
+Implement the `PaintByNumber.get_first_pixel/2` function.
+It should take two arguments: a bitstring with the picture from which we're
+reading, and the count of colors in the palette. It should return the color
+index of the first pixel in the given picture.
+When given an empty picture, it should return `nil`.
 
 ```elixir
 picture = <<19::5, 2::5, 18::5>>
@@ -86,7 +113,11 @@ PaintByNumber.get_first_pixel(picture, color_count)
 
 ## 6. Drop the first pixel from a picture
 
-Implement the `PaintByNumber.drop_first_pixel/2` function. It should take two arguments: a bitstring with the picture from which we're removing a pixel, and the count of colors in the palette. It should return the picture without the first pixel. When given an empty picture, it should return an empty picture.
+Implement the `PaintByNumber.drop_first_pixel/2` function. 
+It should take two arguments: a bitstring with the picture from which we're
+removing a pixel, and the count of colors in the palette. 
+It should return the picture without the first pixel.
+When given an empty picture, it should return an empty picture.
 
 ```elixir
 picture = <<2::3, 5::3, 5::3, 0::3>>
@@ -99,7 +130,10 @@ PaintByNumber.drop_first_pixel(picture, color_count)
 
 ## 7. Concatenate two pictures
 
-Implement the `PaintByNumber.concat_pictures/2` function. It should take two arguments, two bitstrings. It should return a bitstrings that is the result of prepending the first argument to the second argument.
+Implement the `PaintByNumber.concat_pictures/2` function. 
+It should take two arguments: two bitstrings. 
+It should return a bitstrings that is the result of prepending the first
+argument to the second argument.
 
 ```elixir
 picture1 = <<52::6, 51::6>>

--- a/exercises/concept/paint-by-number/.docs/introduction.md
+++ b/exercises/concept/paint-by-number/.docs/introduction.md
@@ -2,22 +2,32 @@
 
 ## Bitstrings
 
-Working with binary data is an important concept in any language, and Elixir provides an elegant syntax to write, match, and construct binary data.
+Working with binary data is an important concept in any language, and Elixir 
+provides an elegant syntax to write, match, and construct binary data.
 
-In Elixir, binary data is referred to as the bitstring type. The binary data _type_ (not to be confused with binary data in general) is a specific form of a bitstring, which we will discuss in a later exercise.
+In Elixir, binary data is referred to as the bitstring type. The binary data
+_type_ (not to be confused with binary data in general) is a specific form of
+a bitstring, which we will discuss in a later exercise.
 
-Bitstring literals are defined using the bitstring special form `<<>>`. When defining a bitstring literal, it is defined in segments. Each segment has a value and type, separated by the `::` operator. The type specifies how many bits will be used to encode the value. The type can be omitted completely, which will default to a 8-bit integer value.
+Bitstring literals are defined using the bitstring special form `<<>>`. When 
+defining a bitstring literal, it is defined in segments. Each segment has a 
+value and type, separated by the `::` operator. The type specifies how many 
+bits will be used to encode the value. The type can be omitted completely, 
+which will default to a 8-bit integer value.
 
 ```elixir
 # This defines a bitstring with three segments of a single bit each
 <<0::1, 1::1, 0::1>>
 ```
 
-Specifying the type as `::1` is a shorthand for writing `::size(1)`. You need to use the longer syntax if the bit size comes from a variable.
+Specifying the type as `::1` is a shorthand for writing `::size(1)`. 
+You need to use the longer syntax if the bit size comes from a variable.
 
 ### Binary
 
-When writing binary integer literals, we can write them directly in base-2 notation by prefixing the literal with `0b`. Note that they will be anyway displayed as decimal numbers when printed in tests results or when using iex.
+When writing binary integer literals, we can write them directly in base-2 
+notation by prefixing the literal with `0b`. Note that they will be anyway 
+displayed as decimal numbers when printed in tests results or when using iex.
 
 ```elixir
 <<0b1011::4>> == <<11::4>>
@@ -26,7 +36,8 @@ When writing binary integer literals, we can write them directly in base-2 notat
 
 ### Truncating
 
-If the value of the segment overflows the capacity of the segment's type, it will be truncated from the left.
+If the value of the segment overflows the capacity of the segment's type,
+it will be truncated from the left.
 
 ```elixir
 <<0b1011::3>> == <<0b0011::3>>
@@ -35,7 +46,9 @@ If the value of the segment overflows the capacity of the segment's type, it wil
 
 ### Prepending and appending
 
-You can both prepend and append to an existing bitstring using the special form. The `::bistring` type must be used on the existing bitstring if it's of unknown size.
+You can both prepend and append to an existing bitstring using
+the special form. The `::bitstring` type must be used on the existing
+bitstring if it's of unknown size.
 
 ```elixir
 value = <<0b110::3, 0b001::3>>
@@ -45,7 +58,9 @@ new_value = <<0b011::3, value::bitstring, 0b000::3>>
 
 ### Concatenating
 
-We can concatenate bitstrings stored in variables using the special form. The `::bistring` type must be used when concatenating two bitstrings of unknown sizes.
+We can concatenate bitstrings stored in variables using the special form. 
+The `::bitstring` type must be used when concatenating two bitstrings of 
+unknown sizes.
 
 ```elixir
 first = <<0b110::3>>
@@ -56,7 +71,10 @@ concatenated = <<first::bitstring, second::bitstring>>
 
 ### Pattern matching
 
-Pattern matching can also be done to obtain values from the special form. You have to know the number of bits for each fragment you want to capture, with one exception: the `::bitstring` type can be used to pattern match on a bitstring of an unknown size, but this can only be used for the last fragment.
+Pattern matching can also be done to obtain values from the special form.
+You have to know the number of bits for each fragment you want to capture, 
+with one exception: the `::bitstring` type can be used to pattern match on a 
+bitstring of an unknown size, but this can only be used for the last fragment.
 
 ```elixir
 <<value::4, rest::bitstring>> = <<0b01101001::8>>
@@ -67,17 +85,21 @@ value == 0b0110
 ### Inspecting bitstrings
 
 ~~~~exericism/note
-Bitstrings might be printed (by the test runner or in iex) in a different format than the format that was used to create them. This often causes confusion when learning bistrings.
+Bitstrings might be printed (by the test runner or in iex) in a different 
+format than the format that was used to create them. 
+This often causes confusion when learning bitstrings.
 ~~~~
 
-By default, bitstrings are displayed in fragments of 8 bits (a byte), even if you created them with fragments of a different size.
+By default, bitstrings are displayed in fragments of 8 bits (a byte),
+even if you created them with fragments of a different size.
 
 ```elixir
 <<2011::11>>
 # => <<251, 3::size(3)>>
 ```
 
-If you create a bitstring that represents a printable UTF-8 encoded string, it gets displayed as a string.
+If you create a bitstring that represents a printable UTF-8 encoded string,
+it gets displayed as a string.
 
 ```elixir
 <<>>


### PR DESCRIPTION
Fixed the ::bistring typos and changed the formatting, the original was difficult to read due to the constant need to scroll.