### PR TITLE
Try to remove ambiguity from log-label task 2

### DIFF
--- a/exercises/concept/log-level/.docs/hints.md
+++ b/exercises/concept/log-level/.docs/hints.md
@@ -4,7 +4,7 @@
 
 - The [atom type is described here][atom].
 
-## 1. Return the logging code label
+## 1. Determine the log label
 
 - You can use the [`cond/1` special form][cond] to elegantly handle the various log codes.
 - You can use [equality operators][equality] to compare integers for strict type equality.

--- a/exercises/concept/log-level/.docs/instructions.md
+++ b/exercises/concept/log-level/.docs/instructions.md
@@ -2,19 +2,21 @@
 
 You are running a system that consists of a few applications producing many logs. You want to write a small program that will aggregate those logs and give them labels according to their severity level. All applications in your system use the same log codes, but some of the legacy applications don't support all the codes.
 
-| Log code | Log label | Supported in legacy apps? |
-| -------- | --------- | ------------------------- |
-| 0        | trace     | no                        |
-| 1        | debug     | yes                       |
-| 2        | info      | yes                       |
-| 3        | warning   | yes                       |
-| 4        | error     | yes                       |
-| 5        | fatal     | no                        |
-| ?        | unknown   | -                         |
+| Log code              | Log label | Supported in legacy apps? |
+|-----------------------| --------- | ------------------------- |
+| 0                     | trace     | no                        |
+| 1                     | debug     | yes                       |
+| 2                     | info      | yes                       |
+| 3                     | warning   | yes                       |
+| 4                     | error     | yes                       |
+| 5                     | fatal     | no                        |
+| other / not supported | unknown   | -                         |
 
-## 1. Return the logging code label
+## 1. Determine the log label
 
-Implement the `LogLevel.to_label/2` function. It should take an integer code and a boolean flag telling you if the log comes from a legacy app, and return the label of a log line as an atom. Unknown log codes and codes unsupported in a legacy app should return an _unknown_ label.
+Implement the `LogLevel.to_label/2` function. It should take an integer code and a boolean flag telling you if the log comes from a legacy app, and return the label of a log line as an atom.
+
+Log codes not specified in the table should return an _unknown_ label. Log codes specified in the table as not supported in legacy apps should also return an _unknown_ label if the log came from a legacy app.
 
 ```elixir
 LogLevel.to_label(0, false)
@@ -30,7 +32,7 @@ Somebody has to be notified when unexpected things happen.
 
 Implement the `LogLevel.alert_recipient/2` function to determine to whom the alert needs to be sent. The function should take an integer code and a boolean flag telling you if the log comes from a legacy app, and return the name of the recipient as an atom.
 
-If the log label is _error_ or _fatal_, send the alert to the _ops_ team. If you receive a log with an _unknown_ label from a legacy system, send the alert to the _dev1_ team, other unknown labels should be sent to the _dev2_ team. All other log labels can be safely ignored.
+Use the `LogLevel.to_label/2` function from the previous task. If the log label is _error_ or _fatal_, send the alert to the _ops_ team. If you receive a log with an _unknown_ label from a legacy system, send the alert to the _dev1_ team, other unknown labels should be sent to the _dev2_ team. All other log labels can be safely ignored.
 
 ```elixir
 LogLevel.alert_recipient(-1, true)


### PR DESCRIPTION
Hopefully resolves https://github.com/exercism/elixir/issues/1314

A few tiny wording changes to:
- avoid using the phrase "unknown code" to limit the chance of equating "unknown code" to "unknown label"
- spell out in task 1 that codes included in the table produce an "unknown label" sometimes
- spell out in task 2 that the function from task 1 needs to be used to determine the log's label