### PR TITLE
Adding another test for Top Secret exercise.

### DIFF
--- a/exercises/concept/top-secret/test/top_secret_test.exs
+++ b/exercises/concept/top-secret/test/top_secret_test.exs
@@ -86,7 +86,7 @@ defmodule TopSecretTest do
       assert actual_ast == ast
       assert actual_acc == acc
     end
-    
+
     @tag task_id: 2
     test "works for AST made only of basic types" do
       acc = ["abc"]
@@ -94,15 +94,15 @@ defmodule TopSecretTest do
       {actual_ast, actual_acc} = TopSecret.decode_secret_message_part(12, acc)
       assert actual_ast == 12
       assert actual_acc == acc
-      
+
       {actual_ast, actual_acc} = TopSecret.decode_secret_message_part(true, acc)
       assert actual_ast == true
       assert actual_acc == acc
-      
+
       {actual_ast, actual_acc} = TopSecret.decode_secret_message_part(:ok, acc)
       assert actual_ast == :ok
       assert actual_acc == acc
-      
+
       {actual_ast, actual_acc} = TopSecret.decode_secret_message_part("meh", acc)
       assert actual_ast == "meh"
       assert actual_acc == acc

--- a/exercises/concept/top-secret/test/top_secret_test.exs
+++ b/exercises/concept/top-secret/test/top_secret_test.exs
@@ -86,6 +86,27 @@ defmodule TopSecretTest do
       assert actual_ast == ast
       assert actual_acc == acc
     end
+    
+    @tag task_id: 2
+    test "works for AST made only of basic types" do
+      acc = ["abc"]
+
+      {actual_ast, actual_acc} = TopSecret.decode_secret_message_part(12, acc)
+      assert actual_ast == 12
+      assert actual_acc == acc
+      
+      {actual_ast, actual_acc} = TopSecret.decode_secret_message_part(true, acc)
+      assert actual_ast == true
+      assert actual_acc == acc
+      
+      {actual_ast, actual_acc} = TopSecret.decode_secret_message_part(:ok, acc)
+      assert actual_ast == :ok
+      assert actual_acc == acc
+      
+      {actual_ast, actual_acc} = TopSecret.decode_secret_message_part("meh", acc)
+      assert actual_ast == "meh"
+      assert actual_acc == acc
+    end
 
     @tag task_id: 2
     test "appends a public function name to the accumulator" do

--- a/exercises/concept/top-secret/test/top_secret_test.exs
+++ b/exercises/concept/top-secret/test/top_secret_test.exs
@@ -77,7 +77,7 @@ defmodule TopSecretTest do
 
   describe "decode_secret_message_part/2" do
     @tag task_id: 2
-    test "returns the AST and accumulator unchanged" do
+    test "returns the AST and accumulator unchanged (function call)" do
       string = "2 + 3"
       ast = TopSecret.to_ast(string)
       acc = ["le", "mo"]
@@ -88,7 +88,7 @@ defmodule TopSecretTest do
     end
 
     @tag task_id: 2
-    test "works for AST made only of basic types" do
+    test "returns the AST and accumulator unchanged (literal values)" do
       acc = ["abc"]
 
       {actual_ast, actual_acc} = TopSecret.decode_secret_message_part(12, acc)


### PR DESCRIPTION
Added another test for the exercise Top Secret that checks if the `decode_secret_message_part/2` function works for ASTs made of code consisting only of basic types.
- Fixes #1315.