### PR TITLE
Add link to Kernel documentation

### DIFF
--- a/concepts/binaries/links.json
+++ b/concepts/binaries/links.json
@@ -2,5 +2,9 @@
   {
     "url": "https://elixir-lang.org/getting-started/binaries-strings-and-char-lists.html#binaries",
     "description": "Getting Started guide - Binaries"
+  },
+  {
+    "url": "https://hexdocs.pm/elixir/Kernel.SpecialForms.html#%3C%3C%3E%3E/1",
+    "description": "Elixir Kernel documentation - Binaries"
   }
 ]

--- a/concepts/binaries/links.json
+++ b/concepts/binaries/links.json
@@ -5,6 +5,6 @@
   },
   {
     "url": "https://hexdocs.pm/elixir/Kernel.SpecialForms.html#%3C%3C%3E%3E/1",
-    "description": "Elixir Kernel documentation - Binaries"
+    "description": "Documentation - bitstring special form"
   }
 ]


### PR DESCRIPTION
I found it helpful to look at these more details doc as I was learning about binaries.

New link: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#%3C%3C%3E%3E/1