### PR TITLE
Mention function/variable naming possibilities and conventions in the learning module

### DIFF
--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -48,7 +48,7 @@
 
 Module names should use `PascalCase`. A module name must start with an uppercase letter `A-Z` and can contain letters `a-zA-Z`, numbers `0-9`, and underscores `_`.
 
-Variable and function names should use `snake_case`. A variable or function name must start with a lowercase letter `a-z` or an underscore `_`, can contain letters `a-zA-Z`, numbers `0-9`, and underscores `_`, and might end with a question mark `?` or exclamation mark `!`.
+Variable and function names should use `snake_case`. A variable or function name must start with a lowercase letter `a-z` or an underscore `_`, can contain letters `a-zA-Z`, numbers `0-9`, and underscores `_`, and might end with a question mark `?` or an exclamation mark `!`.
 
 ## Integers
 

--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -44,6 +44,12 @@
   def add(x, y, z), do: x + y + z
   ```
 
+## Naming conventions
+
+Module names should use `PascalCase`. A module name must start with an uppercase letter `A-Z` and can contain letters `a-zA-Z`, numbers `0-9`, and underscores `_`.
+
+Variable and function names should use `snake_case`. A variable or function name must start with a lowercase letter `a-z` or an underscore `_`, can contain letters `a-zA-Z`, numbers `0-9`, and underscores `_`, and might end with a question mark `?` or exclamation mark `!`.
+
 ## Integers
 
 Integer values are whole numbers written with one or more digits. You can perform [basic mathematical operations][operators] on them.

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -78,6 +78,12 @@ def add(x, y, z) do
 end
 ```
 
+## Naming conventions
+
+Module names should use `PascalCase`. A module name must start with an uppercase letter `A-Z` and can contain letters `a-zA-Z`, numbers `0-9`, and underscores `_`.
+
+Variable and function names should use `snake_case`. A variable or function name must start with a lowercase letter `a-z` or an underscore `_`, can contain letters `a-zA-Z`, numbers `0-9`, and underscores `_`, and might end with a question mark `?` or exclamation mark `!`.
+
 ## Standard library
 
 Elixir has a very rich and well-documented standard library. The documentation is available online at [hexdocs.pm/elixir][docs]. Save this link somewhere - you will use it a lot!

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -82,7 +82,7 @@ end
 
 Module names should use `PascalCase`. A module name must start with an uppercase letter `A-Z` and can contain letters `a-zA-Z`, numbers `0-9`, and underscores `_`.
 
-Variable and function names should use `snake_case`. A variable or function name must start with a lowercase letter `a-z` or an underscore `_`, can contain letters `a-zA-Z`, numbers `0-9`, and underscores `_`, and might end with a question mark `?` or exclamation mark `!`.
+Variable and function names should use `snake_case`. A variable or function name must start with a lowercase letter `a-z` or an underscore `_`, can contain letters `a-zA-Z`, numbers `0-9`, and underscores `_`, and might end with a question mark `?` or an exclamation mark `!`.
 
 ## Standard library
 

--- a/concepts/booleans/about.md
+++ b/concepts/booleans/about.md
@@ -24,11 +24,11 @@ not true and false # => false
 not (true and false) # => true
 ```
 
-When writing a function that returns a boolean value, it is [idiomatic to end the function name][naming] with a `?`.
+When writing a function that returns a boolean value, it is [idiomatic to end the function name][naming] with a `?`. The same convention can be used for variables that store boolean values.
 
 ```elixir
-def either_true?(a, b) do
-  a or b
+def either_true?(a?, b?) do
+  a? or b?
 end
 ```
 

--- a/concepts/booleans/introduction.md
+++ b/concepts/booleans/introduction.md
@@ -20,10 +20,10 @@ true_variable = not false
 false_variable = not true
 ```
 
-When writing a function that returns a boolean value, it is idiomatic to end the function name with a `?`.
+When writing a function that returns a boolean value, it is idiomatic to end the function name with a `?`. The same convention can be used for variables that store boolean values.
 
 ```elixir
-def either_true?(a, b) do
-  a or b
+def either_true?(a?, b?) do
+  a? or b?
 end
 ```

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -80,6 +80,12 @@ def add(x, y, z) do
 end
 ```
 
+### Naming conventions
+
+Module names should use `PascalCase`. A module name must start with an uppercase letter `A-Z` and can contain letters `a-zA-Z`, numbers `0-9`, and underscores `_`.
+
+Variable and function names should use `snake_case`. A variable or function name must start with a lowercase letter `a-z` or an underscore `_`, can contain letters `a-zA-Z`, numbers `0-9`, and underscores `_`, and might end with a question mark `?` or exclamation mark `!`.
+
 ### Standard library
 
 Elixir has a very rich and well-documented standard library. The documentation is available online at [hexdocs.pm/elixir][docs]. Save this link somewhere - you will use it a lot!

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -84,7 +84,7 @@ end
 
 Module names should use `PascalCase`. A module name must start with an uppercase letter `A-Z` and can contain letters `a-zA-Z`, numbers `0-9`, and underscores `_`.
 
-Variable and function names should use `snake_case`. A variable or function name must start with a lowercase letter `a-z` or an underscore `_`, can contain letters `a-zA-Z`, numbers `0-9`, and underscores `_`, and might end with a question mark `?` or exclamation mark `!`.
+Variable and function names should use `snake_case`. A variable or function name must start with a lowercase letter `a-z` or an underscore `_`, can contain letters `a-zA-Z`, numbers `0-9`, and underscores `_`, and might end with a question mark `?` or an exclamation mark `!`.
 
 ### Standard library
 

--- a/exercises/concept/pacman-rules/.docs/introduction.md
+++ b/exercises/concept/pacman-rules/.docs/introduction.md
@@ -22,10 +22,10 @@ true_variable = not false
 false_variable = not true
 ```
 
-When writing a function that returns a boolean value, it is idiomatic to end the function name with a `?`.
+When writing a function that returns a boolean value, it is idiomatic to end the function name with a `?`. The same convention can be used for variables that store boolean values.
 
 ```elixir
-def either_true?(a, b) do
-  a or b
+def either_true?(a?, b?) do
+  a? or b?
 end
 ```


### PR DESCRIPTION
Resolves https://github.com/exercism/elixir/issues/1283

This text contains a white lie about which letters are allowed in which names. I'm simplifying and saying that ASCII letters are allowed everywhere, but in reality function and variable names (not module names) support more letters, e.g. `spät? = true`.

The convention that `!` functions raise errors has already been mentioned in the introduction of the errors concept.