### PR TITLE
Fix dead links to hexdocs.pm

### DIFF
--- a/concepts/bitstrings/about.md
+++ b/concepts/bitstrings/about.md
@@ -39,7 +39,7 @@
 - Elixir provides syntactic sugar for working with [integer literals][integer-literal] in different forms:
   - `0b1000001 = ?A = 65`
 
-[integer-literal]: https://hexdocs.pm/elixir/master/syntax-reference.html#integers-in-other-bases-and-unicode-code-points
+[integer-literal]: https://hexdocs.pm/elixir/syntax-reference.html#integers-in-other-bases-and-unicode-code-points
 [bitstring]: https://elixir-lang.org/getting-started/binaries-strings-and-char-lists.html#bitstrings
 [bitstring-form]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#%3C%3C%3E%3E/1
 [bitstring-matching]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#%3C%3C%3E%3E/1-binary-bitstring-matching

--- a/concepts/default-arguments/introduction.md
+++ b/concepts/default-arguments/introduction.md
@@ -18,4 +18,4 @@ def number(n) when n < 10, do: "Dream bigger!"
 def number(n) when n > 100, do: "Not that big..."
 ```
 
-[kernel-guards]: https://hexdocs.pm/elixir/master/Kernel.html#guards
+[kernel-guards]: https://hexdocs.pm/elixir/Kernel.html#guards

--- a/concepts/guards/about.md
+++ b/concepts/guards/about.md
@@ -32,22 +32,22 @@ end
     end
     ```
 
-[guards]: https://hexdocs.pm/elixir/master/patterns-and-guards.html#guards
-[kernel-guards]: https://hexdocs.pm/elixir/master/Kernel.html#guards
+[guards]: https://hexdocs.pm/elixir/patterns-and-guards.html#guards
+[kernel-guards]: https://hexdocs.pm/elixir/Kernel.html#guards
 [pure-function]: https://gist.github.com/tomekowal/16cb4192b73fe9222de9fd09e653c03e
-[guard-is-integer]: https://hexdocs.pm/elixir/master/Kernel.html#is_integer/1
-[guard-is-list]: https://hexdocs.pm/elixir/master/Kernel.html#is_list/1
-[guard-is-nil]: https://hexdocs.pm/elixir/master/Kernel.html#is_nil/1
-[guard-plus]: https://hexdocs.pm/elixir/master/Kernel.html#+/2
-[guard-minus]: https://hexdocs.pm/elixir/master/Kernel.html#-/2
-[guard-equals]: https://hexdocs.pm/elixir/master/Kernel.html#==/2
-[guard-greater]: https://hexdocs.pm/elixir/master/Kernel.html#%3E/2
-[guard-less]: https://hexdocs.pm/elixir/master/Kernel.html#%3C/2
-[guard-and]: https://hexdocs.pm/elixir/master/Kernel.html#and/2
-[guard-or]: https://hexdocs.pm/elixir/master/Kernel.html#or/2
-[guard-not]: https://hexdocs.pm/elixir/master/Kernel.html#not/1
-[guard-in]: https://hexdocs.pm/elixir/master/Kernel.html#in/2
+[guard-is-integer]: https://hexdocs.pm/elixir/Kernel.html#is_integer/1
+[guard-is-list]: https://hexdocs.pm/elixir/Kernel.html#is_list/1
+[guard-is-nil]: https://hexdocs.pm/elixir/Kernel.html#is_nil/1
+[guard-plus]: https://hexdocs.pm/elixir/Kernel.html#+/2
+[guard-minus]: https://hexdocs.pm/elixir/Kernel.html#-/2
+[guard-equals]: https://hexdocs.pm/elixir/Kernel.html#==/2
+[guard-greater]: https://hexdocs.pm/elixir/Kernel.html#%3E/2
+[guard-less]: https://hexdocs.pm/elixir/Kernel.html#%3C/2
+[guard-and]: https://hexdocs.pm/elixir/Kernel.html#and/2
+[guard-or]: https://hexdocs.pm/elixir/Kernel.html#or/2
+[guard-not]: https://hexdocs.pm/elixir/Kernel.html#not/1
+[guard-in]: https://hexdocs.pm/elixir/Kernel.html#in/2
 [defguard]: https://hexdocs.pm/elixir/Kernel.html#defguard/1
 [naming]: https://hexdocs.pm/elixir/naming-conventions.html#is_-prefix-is_foo
-[where-guards-can-be-used]: https://hexdocs.pm/elixir/master/patterns-and-guards.html#where-patterns-and-guards-can-be-used
+[where-guards-can-be-used]: https://hexdocs.pm/elixir/patterns-and-guards.html#where-patterns-and-guards-can-be-used
 [exercism-pattern-matching]: https://exercism.org/tracks/elixir/concepts/pattern-matching

--- a/concepts/guards/introduction.md
+++ b/concepts/guards/introduction.md
@@ -7,4 +7,4 @@ Guards are used to prevent Elixir from invoking functions based on evaluation of
 
 A list of common guards can be found in the [Elixir documentation][kernel-guards]. It includes type checks, basic arithmetic, comparisons, and strictly boolean operators.
 
-[kernel-guards]: https://hexdocs.pm/elixir/master/Kernel.html#guards
+[kernel-guards]: https://hexdocs.pm/elixir/Kernel.html#guards

--- a/concepts/guards/links.json
+++ b/concepts/guards/links.json
@@ -1,10 +1,10 @@
 [
   {
-    "url": "https://hexdocs.pm/elixir/master/patterns-and-guards.html#guards",
+    "url": "https://hexdocs.pm/elixir/patterns-and-guards.html#guards",
     "description": "Guards"
   },
   {
-    "url": "https://hexdocs.pm/elixir/master/Kernel.html#guards",
+    "url": "https://hexdocs.pm/elixir/Kernel.html#guards",
     "description": "List of guards"
   }
 ]

--- a/concepts/integers/about.md
+++ b/concepts/integers/about.md
@@ -54,4 +54,4 @@ Integers and floats can be considered equal ([`==`][kernel-equal]) if they have 
 [kernel-equal]: https://hexdocs.pm/elixir/Kernel.html#==/2
 [kernel-strictly-equal]: https://hexdocs.pm/elixir/Kernel.html#===/2
 [integer]: https://hexdocs.pm/elixir/Integer.html
-[integers-in-other-bases]: https://hexdocs.pm/elixir/master/syntax-reference.html#integers-in-other-bases-and-unicode-code-points
+[integers-in-other-bases]: https://hexdocs.pm/elixir/syntax-reference.html#integers-in-other-bases-and-unicode-code-points

--- a/concepts/integers/links.json
+++ b/concepts/integers/links.json
@@ -4,7 +4,7 @@
     "description": "The Integer module"
   },
   {
-    "url": "https://hexdocs.pm/elixir/master/syntax-reference.html#integers-in-other-bases-and-unicode-code-points",
+    "url": "https://hexdocs.pm/elixir/syntax-reference.html#integers-in-other-bases-and-unicode-code-points",
     "description": "Integers in other bases"
   }
 ]

--- a/concepts/regular-expressions/about.md
+++ b/concepts/regular-expressions/about.md
@@ -103,5 +103,5 @@ if String.ends_with?("YELLING!", "!"), do: "Whoa, chill out!"
 [regex-character-classes]: https://hexdocs.pm/elixir/Regex.html#module-character-classes
 [regex-run]: https://hexdocs.pm/elixir/Regex.html#run/3
 [regex-named-captures]: https://hexdocs.pm/elixir/Regex.html#named_captures/3
-[regex-match-operator]: https://hexdocs.pm/elixir/master/Kernel.html#=~/2
-[regex-compile]: https://hexdocs.pm/elixir/master/Regex.html#compile!/2
+[regex-match-operator]: https://hexdocs.pm/elixir/Kernel.html#=~/2
+[regex-compile]: https://hexdocs.pm/elixir/Regex.html#compile!/2

--- a/exercises/concept/dna-encoding/.docs/hints.md
+++ b/exercises/concept/dna-encoding/.docs/hints.md
@@ -37,7 +37,7 @@
 - Do not forget to specify the types of bitstring segments using the `::` operator.
 - You will need to reverse the accumulator at the end. Write a private tail-recursive `reverse` function to do that and use it in the base-case of the `decode` function.
 
-[integer-literal]: https://hexdocs.pm/elixir/master/syntax-reference.html#integers-in-other-bases-and-unicode-code-points
+[integer-literal]: https://hexdocs.pm/elixir/syntax-reference.html#integers-in-other-bases-and-unicode-code-points
 [codepoint]: https://elixir-lang.org/getting-started/binaries-strings-and-char-lists.html#unicode-and-code-points
 [charlist]: https://elixir-lang.org/getting-started/binaries-strings-and-char-lists.html#charlists
 [bitstring]: https://elixir-lang.org/getting-started/binaries-strings-and-char-lists.html#bitstrings

--- a/exercises/concept/guessing-game/.docs/hints.md
+++ b/exercises/concept/guessing-game/.docs/hints.md
@@ -28,6 +28,6 @@
 - Use a function header before all the other function clauses to define the default argument.
 
 [default-arg]: https://elixir-lang.org/getting-started/modules-and-functions.html#default-arguments
-[guard]: https://hexdocs.pm/elixir/master/Kernel.html#guards
+[guard]: https://hexdocs.pm/elixir/Kernel.html#guards
 [guide]: https://elixir-lang.org/getting-started/modules-and-functions.html#named-functions
 [multiple-fn-clauses]: https://elixir-lang.org/getting-started/modules-and-functions.html#named-functions

--- a/exercises/concept/guessing-game/.docs/introduction.md
+++ b/exercises/concept/guessing-game/.docs/introduction.md
@@ -48,4 +48,4 @@ def number(n) when n < 10, do: "Dream bigger!"
 def number(n) when n > 100, do: "Not that big..."
 ```
 
-[kernel-guards]: https://hexdocs.pm/elixir/master/Kernel.html#guards
+[kernel-guards]: https://hexdocs.pm/elixir/Kernel.html#guards

--- a/exercises/concept/guessing-game/.meta/design.md
+++ b/exercises/concept/guessing-game/.meta/design.md
@@ -35,7 +35,7 @@ This exercise is a fork from [F#'s Number Guessing Game](https://github.com/exer
 
 ## Resources to refer to
 
-- <https://hexdocs.pm/elixir/master/Kernel.html#guards>
+- <https://hexdocs.pm/elixir/Kernel.html#guards>
 - <https://elixir-lang.org/getting-started/modules-and-functions.html#default-arguments>
 - [multiple clauses in anon functions](https://til.hashrocket.com/posts/36c6d2684e-defining-multiple-clauses-in-an-anonymous-function)
 - <https://elixirschool.com/en/lessons/basics/functions/#guards>

--- a/exercises/concept/lucas-numbers/.docs/hints.md
+++ b/exercises/concept/lucas-numbers/.docs/hints.md
@@ -21,7 +21,7 @@
 - Use a [guard][guards] to catch the cases when an integer isn't passed as an argument to `generate/1`.
 
 [enum]: https://hexdocs.pm/elixir/Enum.html#content
-[guards]: https://hexdocs.pm/elixir/master/patterns-and-guards.html#guards
+[guards]: https://hexdocs.pm/elixir/patterns-and-guards.html#guards
 [list]: https://elixir-lang.org/getting-started/basic-types.html#linked-lists
 [multiple-fn-clauses]: https://elixir-lang.org/getting-started/modules-and-functions.html#named-functions
 [pattern-matching]: https://elixir-lang.org/getting-started/pattern-matching.html#pattern-matching-1

--- a/exercises/concept/paint-by-number/.docs/hints.md
+++ b/exercises/concept/paint-by-number/.docs/hints.md
@@ -49,9 +49,9 @@
 - Use the special `::bitstring` type to specify that each of the bitstring fragments is of unknown size.
 
 [decimal-to-binary-youtube]: https://www.youtube.com/watch?v=gGiEu7QTi68
-[integer-literal]: https://hexdocs.pm/elixir/master/syntax-reference.html#integers-in-other-bases-and-unicode-code-points
+[integer-literal]: https://hexdocs.pm/elixir/syntax-reference.html#integers-in-other-bases-and-unicode-code-points
 [bitstring]: https://elixir-lang.org/getting-started/binaries-strings-and-char-lists.html#bitstrings
 [bitstring-form]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#%3C%3C%3E%3E/1
 [bitstring-matching]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#%3C%3C%3E%3E/1-binary-bitstring-matching
 [type-operator]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#::/2
-[integer-pow]: https://hexdocs.pm/elixir/master/Integer.html#pow/2
+[integer-pow]: https://hexdocs.pm/elixir/Integer.html#pow/2


### PR DESCRIPTION
Many links pointing to documentation in hexdocs.pm, like the ones in the [Guards](https://exercism.org/tracks/elixir/concepts/guards) concept introduction page, are incorrect (outdated?) as they include an extraneous path segment, "master".

Fixed every link with such an error in the Elixir track.