### PR TITLE
Improvement in the explanation of the pipe operator (|>)

### DIFF
--- a/concepts/pipe-operator/introduction.md
+++ b/concepts/pipe-operator/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-The `|>` operator is called the pipe operator. It can be used to chain function calls together in such a way that the value returned by the previous function call is passed as the first argument to the next function call.
+The `|>` operator is called the pipe operator. It is used to chain function calls together in such a way that the value returned by the previous function call is passed as the first argument to the next function call.
 
 ```elixir
 "hello"

--- a/exercises/concept/high-school-sweetheart/.docs/introduction.md
+++ b/exercises/concept/high-school-sweetheart/.docs/introduction.md
@@ -44,6 +44,14 @@ Elixir provides many functions for working with strings in the `String` module.
 
 The `|>` operator is called the pipe operator. It is used to chain function calls together in such a way that the value returned by the previous function call is passed as the first argument to the next function call.
 
+It is important to use the pipe operator with prudence and adhere to best practices. Avoid using the pipe operator when performing a single function call, as it can lead to unnecessary complexity. In such cases, it is recommended to call the function directly with its arguments.
+
+For example:
+
+```elixir
+String.split("hello", "")
+```
+
 When using the pipeline, you can place the `|>` operator after the result of a function call to pass its return value as the first argument to the next function. However, there is no need to use the `|>` operator on the first function call, as you can simply call the function with its arguments.
 
 Here's an example:

--- a/exercises/concept/high-school-sweetheart/.docs/introduction.md
+++ b/exercises/concept/high-school-sweetheart/.docs/introduction.md
@@ -63,4 +63,4 @@ Here's an example:
 # => "HELLO?!"
 ```
 
-In this example, we first call `String.upcase/1` with the argument `"hello"`, and then we pass the result of that call `("HELLO")` as the first argument to `Kernel.<>/2` along with the argument `"?!"`.
+In this example, we "pipe" the string `"hello"` into the `String.upcase` function, and the resulting string is piped into `Kernel.<>` as the first argument.

--- a/exercises/concept/high-school-sweetheart/.docs/introduction.md
+++ b/exercises/concept/high-school-sweetheart/.docs/introduction.md
@@ -42,7 +42,11 @@ Elixir provides many functions for working with strings in the `String` module.
 
 ## Pipe Operator
 
-The `|>` operator is called the pipe operator. It can be used to chain function calls together in such a way that the value returned by the previous function call is passed as the first argument to the next function call.
+The `|>` operator is called the pipe operator. It is used to chain function calls together in such a way that the value returned by the previous function call is passed as the first argument to the next function call.
+
+When using the pipeline, you can place the `|>` operator after the result of a function call to pass its return value as the first argument to the next function. However, there is no need to use the `|>` operator on the first function call, as you can simply call the function with its arguments.
+
+Here's an example:
 
 ```elixir
 "hello"
@@ -50,3 +54,5 @@ The `|>` operator is called the pipe operator. It can be used to chain function 
 |> Kernel.<>("?!")
 # => "HELLO?!"
 ```
+
+In this example, we first call `String.upcase/1` with the argument `"hello"`, and then we pass the result of that call `("HELLO")` as the first argument to `Kernel.<>/2` along with the argument `"?!"`.


### PR DESCRIPTION
In this pull request, I propose an improvement in the explanation of the pipe operator (`|>`) in the exercise's `README` file. Currently, the explanation may give the impression that the `|>` operator should be used in every function call, which can be confusing for new Elixir users and those not familiar with functional programming concepts.

I have rewritten the explanation to clarify that the `|>` operator is used to chain functions starting from the second call, and that it is not necessary to use the operator in the first function call. I hope this improvement helps new Elixir users better understand how the pipe operator works and how to use it effectively in their programs.

I appreciate your feedback and suggestions to continue improving the learning material!

Thank you very much for reviewing this pull request!!! 🌷 