### PR TITLE
ELIXIR:community-garden add new test to Task4

### DIFF
--- a/exercises/concept/community-garden/test/community_garden_test.exs
+++ b/exercises/concept/community-garden/test/community_garden_test.exs
@@ -73,6 +73,21 @@ defmodule CommunityGardenTest do
     assert plot_4.plot_id == 4
   end
 
+  @tag task_id: 4
+  test "release only one plot at time" do
+    assert {:ok, pid} = CommunityGarden.start()
+
+    plot_1 = CommunityGarden.register(pid, "Keanu Reeves")
+    plot_2 = CommunityGarden.register(pid, "Thomas A. Anderson")
+
+    assert plot_1.plot_id == 1
+    assert plot_2.plot_id == 2
+
+    CommunityGarden.release(pid, plot_1.plot_id)
+
+    assert [plot_2] = CommunityGarden.list_registrations(pid)
+  end
+
   @tag task_id: 5
   test "can get registration of a registered plot" do
     assert {:ok, pid} = CommunityGarden.start()


### PR DESCRIPTION
there are no necessary test for https://exercism.org/tracks/elixir/exercises/community-garden/ which checking the using  `plot_id` param really used in `release` function

f.e. current code works well (no tests fails)
```
  def release(pid, _plot_id) do
    %{next_id: next_id} = Agent.get(pid, & &1)
    Agent.update(pid, fn %{next_id: next_id} -> %{plots: [], next_id: next_id} end)
  end
```

This PR adds new test to check this