### PR TITLE
Use `assets.exercism.org` subdomain

### DIFF
--- a/exercises/concept/paint-by-number/.docs/instructions.md
+++ b/exercises/concept/paint-by-number/.docs/instructions.md
@@ -31,7 +31,7 @@ We can now use those color indices to represent the color of each pixel.
 
 | Smiley                                                                                                | Smiley with color indices                                                                                     |
 |-------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
-| ![](https://exercism-v3-icons.s3.eu-west-2.amazonaws.com/images/exercises/paint-by-number/smiley.png) | ![](https://exercism-v3-icons.s3.eu-west-2.amazonaws.com/images/exercises/paint-by-number/smiley-numbers.png) |
+| ![](https://assets.exercism.org/images/exercises/paint-by-number/smiley.png) | ![](https://assets.exercism.org/images/exercises/paint-by-number/smiley-numbers.png) |
 
 ## 1. Calculate palette bit size
 

--- a/exercises/practice/killer-sudoku-helper/.docs/instructions.md
+++ b/exercises/practice/killer-sudoku-helper/.docs/instructions.md
@@ -56,8 +56,8 @@ The screenshots above have been generated using [F-Puzzles.com](https://www.f-pu
 
 [sudoku-rules]: https://masteringsudoku.com/sudoku-rules-beginners/
 [killer-guide]: https://masteringsudoku.com/killer-sudoku/
-[one-solution-img]: https://exercism-v3-icons.s3.eu-west-2.amazonaws.com/images/exercises/killer-sudoku-helper/example1.png
-[four-solutions-img]: https://exercism-v3-icons.s3.eu-west-2.amazonaws.com/images/exercises/killer-sudoku-helper/example2.png
-[not-possible-img]: https://exercism-v3-icons.s3.eu-west-2.amazonaws.com/images/exercises/killer-sudoku-helper/example3.png
+[one-solution-img]: https://assets.exercism.org/images/exercises/killer-sudoku-helper/example1.png
+[four-solutions-img]: https://assets.exercism.org/images/exercises/killer-sudoku-helper/example2.png
+[not-possible-img]: https://assets.exercism.org/images/exercises/killer-sudoku-helper/example3.png
 [clover-puzzle]: https://app.crackingthecryptic.com/sudoku/HqTBn3Pr6R
 [goodliffe-video]: https://youtu.be/c_NjEbFEeW0?t=1180


### PR DESCRIPTION
Hi there. We're moving various parts of our image hosting behind a CDN, and so various links to images are changing. This PR updates the urls we automatically found in this repository. If you come across any more links pointing to `exercism-v3-icons.s3.eu-west-2.amazonaws.com` or `dg8krxphbh767.cloudfront.net`, please change those to `assets.exercism.org` too. Thanks!