### PR TITLE
Improvement of type spec for balance method of bank account exercidse

### DIFF
--- a/exercises/practice/bank-account/lib/bank_account.ex
+++ b/exercises/practice/bank-account/lib/bank_account.ex
@@ -25,7 +25,7 @@ defmodule BankAccount do
   @doc """
   Get the account's balance.
   """
-  @spec balance(account) :: integer
+  @spec balance(account) :: integer | {:error, :account_closed}
   def balance(account) do
   end
 


### PR DESCRIPTION
I added {:ok, account_closed} to balance type spec, as this is expected output for this exercise according to test