### PR TITLE
Fix return value of Map.fetch example

### DIFF
--- a/exercises/concept/remote-control-car/.docs/introduction.md
+++ b/exercises/concept/remote-control-car/.docs/introduction.md
@@ -24,7 +24,7 @@ Since structs are built on maps, we can use most map functions to get and manipu
   plane.engine
   # => nil
   Map.fetch(plane, :wings)
-  # => 2
+  # => {:ok, 2}
   ```
 
 - update field values


### PR DESCRIPTION
Instead of just the value `2`, `Map.fetch` returns `{:ok, 2}`.