### PR TITLE
add test for exercises/concept/german-sysadmin

### DIFF
--- a/exercises/concept/german-sysadmin/test/username_test.exs
+++ b/exercises/concept/german-sysadmin/test/username_test.exs
@@ -54,5 +54,10 @@ defmodule UsernameTest do
       assert Username.sanitize(~c"jäger") == ~c"jaeger"
       assert Username.sanitize(~c"groß") == ~c"gross"
     end
+
+    @tag task_id: 3
+    test "it substitutes German letters and removes disallowed characters" do
+      assert Username.sanitize(~c"köhler_jäger42") == ~c"koehler_jaeger"
+    end
   end
 end


### PR DESCRIPTION
fixes #1357

issue summary:
Tests for [german-sysadmin](https://github.com/exercism/elixir/tree/main/exercises/concept/german-sysadmin) does not check for multiple unwanted characters when testing for substitution of German letters. Say for example someone is called Köhler Jäger.