### PR TITLE
Add test for race condition in community gardens

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Please keep the following in mind:
 - Each problem should have a test suite, an example solution, and a template
   file for the real implementation. Read about [the anatomy of practice exercises](https://github.com/exercism/docs/blob/main/building/tracks/practice-exercises.md) or [the anatomy of concept exercises](https://github.com/exercism/docs/blob/main/building/tracks/concept-exercises.md), depending on to which type of exercise you want to contribute.
 
-- For practice exercises, `instructions.md` come from the [problem specifications](https://github.com/exercism/problem-specifications) repository. They cannot be changed without updating them in that repository first. If Elixir-specific changes are necessary, that can be appended to the instructions by creating a `instructions.append.md` file.
+- For practice exercises, `instructions.md` come from the [problem specifications](https://github.com/exercism/problem-specifications) repository. They cannot be changed without updating them in that repository first. If Elixir-specific changes are necessary, they can be appended to the instructions by creating a `instructions.append.md` file.
 
 - For practice exercises, use typespecs in the example and template files as described [here](https://elixir-lang.org/getting-started/typespecs-and-behaviours.html).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Please keep the following in mind:
 - Each problem should have a test suite, an example solution, and a template
   file for the real implementation. Read about [the anatomy of practice exercises](https://github.com/exercism/docs/blob/main/building/tracks/practice-exercises.md) or [the anatomy of concept exercises](https://github.com/exercism/docs/blob/main/building/tracks/concept-exercises.md), depending on to which type of exercise you want to contribute.
 
-- For practice exercises, `instructions.md` come from the [problem specifications](https://github.com/exercism/problem-specifications) repository. They cannot be changed without updating them in that repository first. If Elixir-specific changes are necessary, than can be appended to the instructions by creating a `instructions.append.md` file.
+- For practice exercises, `instructions.md` come from the [problem specifications](https://github.com/exercism/problem-specifications) repository. They cannot be changed without updating them in that repository first. If Elixir-specific changes are necessary, that can be appended to the instructions by creating a `instructions.append.md` file.
 
 - For practice exercises, use typespecs in the example and template files as described [here](https://elixir-lang.org/getting-started/typespecs-and-behaviours.html).
 

--- a/exercises/concept/community-garden/test/community_garden_test.exs
+++ b/exercises/concept/community-garden/test/community_garden_test.exs
@@ -102,4 +102,24 @@ defmodule CommunityGardenTest do
     assert {:ok, pid} = CommunityGarden.start()
     assert {:not_found, "plot is unregistered"} = CommunityGarden.get_registration(pid, 1)
   end
+
+  @tag task_id: 6
+  test "register multiple plots concurrently" do
+    {:ok, pid} = CommunityGarden.start()
+
+    # Spawn 25 processes that register a plot concurrently
+    for _ <- 1..25 do
+      Task.async(fn -> CommunityGarden.register(pid, "user") end)
+    end
+    |> Enum.map(&Task.await/1)
+    |> Enum.map(& &1.plot_id)
+
+    # Get the list of registered plot IDs
+    plot_ids =
+      CommunityGarden.list_registrations(pid)
+      |> Enum.map(& &1.plot_id)
+
+    # Assert that each plot ID is unique
+    assert Enum.uniq(plot_ids) == plot_ids
+  end
 end


### PR DESCRIPTION
If the `register` function uses `get` and `update` instead of `get_and_update` concurrent operations results in non-unique ids.