### PR TITLE
Convert backtick (`) admonition fences to tildes (~)

### DIFF
--- a/exercises/practice/binary-search/.docs/instructions.md
+++ b/exercises/practice/binary-search/.docs/instructions.md
@@ -5,9 +5,9 @@ Your task is to implement a binary search algorithm.
 A binary search algorithm finds an item in a list by repeatedly splitting it in half, only keeping the half which contains the item we're looking for.
 It allows us to quickly narrow down the possible locations of our item until we find it, or until we've eliminated all possible locations.
 
-```exercism/caution
+~~~~exercism/caution
 Binary search only works when a list has been sorted.
-```
+~~~~
 
 The algorithm looks like this:
 

--- a/exercises/practice/etl/.docs/instructions.md
+++ b/exercises/practice/etl/.docs/instructions.md
@@ -22,6 +22,6 @@ This needs to be changed to store each individual letter with its score in a one
 
 As part of this change, the team has also decided to change the letters to be lower-case rather than upper-case.
 
-```exercism/note
+~~~~exercism/note
 If you want to look at how the data was previously structured and how it needs to change, take a look at the examples in the test suite.
-```
+~~~~

--- a/exercises/practice/gigasecond/.docs/introduction.md
+++ b/exercises/practice/gigasecond/.docs/introduction.md
@@ -13,7 +13,7 @@ Then we can use metric system prefixes for writing large numbers of seconds in m
 - Perhaps you and your family would travel to somewhere exotic for two megaseconds (that's two million seconds).
 - And if you and your spouse were married for _a thousand million_ seconds, you would celebrate your one gigasecond anniversary.
 
-```exercism/note
+~~~~exercism/note
 If we ever colonize Mars or some other planet, measuring time is going to get even messier.
 If someone says "year" do they mean a year on Earth or a year on Mars?
 
@@ -21,4 +21,4 @@ The idea for this exercise came from the science fiction novel ["A Deepness in t
 In it the author uses the metric system as the basis for time measurements.
 
 [vinge-novel]: https://www.tor.com/2017/08/03/science-fiction-with-something-for-everyone-a-deepness-in-the-sky-by-vernor-vinge/
-```
+~~~~

--- a/exercises/practice/pangram/.docs/introduction.md
+++ b/exercises/practice/pangram/.docs/introduction.md
@@ -7,10 +7,10 @@ To give a comprehensive sense of the font, the random sentences should use **all
 They're running a competition to get suggestions for sentences that they can use.
 You're in charge of checking the submissions to see if they are valid.
 
-```exercism/note
+~~~~exercism/note
 Pangram comes from Greek, παν γράμμα, pan gramma, which means "every letter".
 
 The best known English pangram is:
 
 > The quick brown fox jumps over the lazy dog.
-```
+~~~~

--- a/exercises/practice/rational-numbers/.docs/instructions.md
+++ b/exercises/practice/rational-numbers/.docs/instructions.md
@@ -2,11 +2,11 @@
 
 A rational number is defined as the quotient of two integers `a` and `b`, called the numerator and denominator, respectively, where `b != 0`.
 
-```exercism/note
+~~~~exercism/note
 Note that mathematically, the denominator can't be zero.
 However in many implementations of rational numbers, you will find that the denominator is allowed to be zero with behaviour similar to positive or negative infinity in floating point numbers.
 In those cases, the denominator and numerator generally still can't both be zero at once.
-```
+~~~~
 
 The absolute value `|r|` of the rational number `r = a/b` is equal to `|a|/|b|`.
 

--- a/exercises/practice/rna-transcription/.docs/instructions.md
+++ b/exercises/practice/rna-transcription/.docs/instructions.md
@@ -15,6 +15,6 @@ Given a DNA strand, its transcribed RNA strand is formed by replacing each nucle
 - `T` -> `A`
 - `A` -> `U`
 
-```exercism/note
+~~~~exercism/note
 If you want to look at how the inputs and outputs are structured, take a look at the examples in the test suite.
-```
+~~~~

--- a/exercises/practice/rna-transcription/.docs/introduction.md
+++ b/exercises/practice/rna-transcription/.docs/introduction.md
@@ -4,7 +4,7 @@ You work for a bioengineering company that specializes in developing therapeutic
 
 Your team has just been given a new project to develop a targeted therapy for a rare type of cancer.
 
-```exercism/note
+~~~~exercism/note
 It's all very complicated, but the basic idea is that sometimes people's bodies produce too much of a given protein.
 That can cause all sorts of havoc.
 
@@ -13,4 +13,4 @@ But if you can create a very specific molecule (called a micro-RNA), it can prev
 This technique is called [RNA Interference][rnai].
 
 [rnai]: https://admin.acceleratingscience.com/ask-a-scientist/what-is-rnai/
-```
+~~~~

--- a/exercises/practice/secret-handshake/.docs/instructions.md
+++ b/exercises/practice/secret-handshake/.docs/instructions.md
@@ -41,8 +41,8 @@ The secret handshake for 26 is therefore:
 jump, double blink
 ```
 
-```exercism/note
+~~~~exercism/note
 If you aren't sure what binary is or how it works, check out [this binary tutorial][intro-to-binary].
 
 [intro-to-binary]: https://medium.com/basecs/bits-bytes-building-with-binary-13cb4289aafa
-```
+~~~~

--- a/exercises/practice/sieve/.docs/instructions.md
+++ b/exercises/practice/sieve/.docs/instructions.md
@@ -18,11 +18,11 @@ Then you repeat the following steps:
 You keep repeating these steps until you've gone through every number in your list.
 At the end, all the unmarked numbers are prime.
 
-```exercism/note
+~~~~exercism/note
 [Wikipedia's Sieve of Eratosthenes article][eratosthenes] has a useful graphic that explains the algorithm.
 
 The tests don't check that you've implemented the algorithm, only that you've come up with the correct list of primes.
 A good first test is to check that you do not use division or remainder operations.
 
 [eratosthenes]: https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
-```
+~~~~

--- a/exercises/practice/simple-linked-list/.docs/instructions.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.md
@@ -7,7 +7,7 @@ Given a range of numbers (the song IDs), create a singly linked list.
 
 Given a singly linked list, you should be able to reverse the list to play the songs in the opposite order.
 
-```exercism/note
+~~~~exercism/note
 The linked list is a fundamental data structure in computer science, often used in the implementation of other data structures.
 
 The simplest kind of linked list is a **singly** linked list.
@@ -16,4 +16,4 @@ That means that each element (or "node") contains data, along with something tha
 If you want to dig deeper into linked lists, check out [this article][intro-linked-list] that explains it using nice drawings.
 
 [intro-linked-list]: https://medium.com/basecs/whats-a-linked-list-anyway-part-1-d8b7e6508b9d
-```
+~~~~


### PR DESCRIPTION
In line with Exercism's spec, we're ensuring that all admonition fences are demarcated with four tildes (`~~~~`) across all repositories. We will be following up with an org-wide script that can be used to keep this consistent. [Problem Specifications](https://github.com/exercism/problem-specifications) has already been updated.

We'll automatically merge this a week from now, but feel free to merge beforehand!

- Spec: https://exercism.org/docs/building/markdown/markdown#h-special-blocks-sometimes-called-admonitions
- Meta issue: https://github.com/exercism/exercism/issues/6705