### PR TITLE
Test updated for Freelancer Rates: Corrects a invalid test

### DIFF
--- a/exercises/concept/freelancer-rates/test/freelancer_rates_test.exs
+++ b/exercises/concept/freelancer-rates/test/freelancer_rates_test.exs
@@ -83,7 +83,7 @@ defmodule FreelancerRatesTest do
     @tag task_id: 4
     test "it applies the discount" do
       # 1.25
-      assert FreelancerRates.days_in_budget(480, 60, 20) == 1.2
+      assert FreelancerRates.days_in_budget(480, 60, 20) == 0.8
     end
   end
 end


### PR DESCRIPTION
This fixes one of freelancer rates test.

It was testing if a discount of 20% over a value of 1 was 1.2, the correct value should be 0.8.