### PR TITLE
Stack underflow: specify 2 numbers are expected

### DIFF
--- a/exercises/concept/stack-underflow/.docs/instructions.md
+++ b/exercises/concept/stack-underflow/.docs/instructions.md
@@ -27,7 +27,7 @@ raise StackUnderflowError, "when dividing"
 
 ## 3. Write a dividing function
 
-Implement the `divide/1` function which takes a stack _(list of numbers)_ and:
+Implement the `divide/1` function which takes a stack _(a list of two numbers)_ and:
 
 - raises _stack underflow_ when the stack does not contain enough numbers
 - raises _division by zero_ when the divisor is 0 (note the stack of numbers is stored in the reverse order)

--- a/exercises/concept/stack-underflow/.meta/exemplar.ex
+++ b/exercises/concept/stack-underflow/.meta/exemplar.ex
@@ -18,6 +18,6 @@ defmodule RPNCalculator.Exception do
   end
 
   def divide(stack) when length(stack) < 2, do: raise(StackUnderflowError, "when dividing")
-  def divide([divisor, _number | _]) when divisor == 0, do: raise(DivisionByZeroError)
-  def divide([divisor, number | _]), do: number / divisor
+  def divide([divisor, _number]) when divisor == 0, do: raise(DivisionByZeroError)
+  def divide([divisor, number]), do: number / divisor
 end


### PR DESCRIPTION
In response to feedback from Discord:

> It's kind of implied, but it's not totally obvious that the divide function should be written with the expectation that it will receive a list of exactly two numbers: a divisor and its denominator. Most of the community solutions i looked at were written according to this assumption, and would fail if given a list of, say, [2, 2, 8], and the test only covers cases with at most two numbers in the list. When i read the exercise I kind of assumed I needed to accept lists of arbitrary length and wrote my implementation with that in mind. Maybe the exercise should make it explicit that only a list of two numbers is considered valid?