### PR TITLE
Remove printable charlists from bird-count (lists)

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -5,3 +5,4 @@ github.com/pulls
 twitter.com
 regexr.com
 papyr.com
+reddit.com

--- a/exercises/concept/bird-count/test/bird_count_test.exs
+++ b/exercises/concept/bird-count/test/bird_count_test.exs
@@ -9,7 +9,7 @@ defmodule BirdCountTest do
 
     @tag task_id: 1
     test "returns today's bird count" do
-      assert BirdCount.today([7]) == 7
+      assert BirdCount.today([5]) == 5
       assert BirdCount.today([2, 4, 11, 10, 6, 8]) == 2
     end
   end
@@ -22,7 +22,7 @@ defmodule BirdCountTest do
 
     @tag task_id: 2
     test "adds 1 to today's bird count" do
-      assert BirdCount.increment_day_count([7]) == [8]
+      assert BirdCount.increment_day_count([5]) == [6]
       assert BirdCount.increment_day_count([4, 2, 1, 0, 10]) == [5, 2, 1, 0, 10]
     end
   end


### PR DESCRIPTION
Bird count is one of the first learning exercises, and it's about lists. Sooner or later Elixir learners will hit the confusing behavior of lists of integers being charlists, and thus printable list of integers being always printed as charlists. However, I think we can postpone that happening to a later exercise, ideally the one about charlists 🙂 

This issue was brought to my attention by this forum post: https://forum.exercism.org/t/bird-count-test-case-appears-to-use-sigils/8922