### PR TITLE
Elixir - Language List - Fixed a shallow test

### DIFF
--- a/exercises/concept/language-list/test/language_list_test.exs
+++ b/exercises/concept/language-list/test/language_list_test.exs
@@ -105,7 +105,7 @@ defmodule LanguageListTest do
   describe "functional_list?/1" do
     @tag task_id: 6
     test "a functional language list" do
-      assert LanguageList.functional_list?(["Clojure", "Haskell", "Erlang", "F#", "Elixir"])
+      assert LanguageList.functional_list?(["Clojure", "Haskell", "Erlang", "Elixir", "F#"])
     end
 
     @tag task_id: 6


### PR DESCRIPTION
The tests as of now let the following solution pass:

```ex
defmodule LanguageList do
  def new(), do: []
  def add(list, language), do: [language | list]
  def remove([_ | others]), do: others
  def first([head | _]), do: head
  def count([]), do: 0
  def count([_ | others]), do: count(others) + 1
  def functional_list?([]), do: false
  def functional_list?(["Elixir" | []]), do: true
  def functional_list?([_ | others]), do: functional_list?(others)
end
```

But it shouldn't, as the above pattern
```ex
def functional_list?(["Elixir" | []]), do: true
```

only works if `"Elixir"` is the last one in the list.

The error lies in the empty list `[]` being matched, instead of a generic `_` wildcard).