### PR TITLE
Sync knapsack

### DIFF
--- a/exercises/practice/knapsack/.meta/tests.toml
+++ b/exercises/practice/knapsack/.meta/tests.toml
@@ -8,8 +8,14 @@
 #
 # As user-added comments (using the # character) will be removed when this file
 # is regenerated, comments can be added via a `comment` key.
+
 [a4d7d2f0-ad8a-460c-86f3-88ba709d41a7]
 description = "no items"
+include = false
+
+[3993a824-c20e-493d-b3c9-ee8a7753ee59]
+description = "no items"
+reimplements = "a4d7d2f0-ad8a-460c-86f3-88ba709d41a7"
 
 [1d39e98c-6249-4a8b-912f-87cb12e506b0]
 description = "one item, too heavy"


### PR DESCRIPTION
No changes - problem specs changed the type of the input from an empty object to an empty array. We've been using an empty list all along.