### PR TITLE
Sync ledger

### DIFF
--- a/exercises/practice/ledger/.meta/tests.toml
+++ b/exercises/practice/ledger/.meta/tests.toml
@@ -20,6 +20,7 @@ description = "credit and debit"
 
 [502c4106-0371-4e7c-a7d8-9ce33f16ccb1]
 description = "multiple entries on same date ordered by description"
+include = false
 
 [29dd3659-6c2d-4380-94a8-6d96086e28e1]
 description = "final order tie breaker is change"
@@ -41,3 +42,7 @@ description = "Dutch negative number with 3 digits before decimal point"
 
 [29670d1c-56be-492a-9c5e-427e4b766309]
 description = "American negative number with 3 digits before decimal point"
+
+[9c70709f-cbbd-4b3b-b367-81d7c6101de4]
+description = "multiple entries on same date ordered by description"
+reimplements = "502c4106-0371-4e7c-a7d8-9ce33f16ccb1"

--- a/exercises/practice/ledger/test/ledger_test.exs
+++ b/exercises/practice/ledger/test/ledger_test.exs
@@ -40,7 +40,7 @@ defmodule LedgerTest do
   @tag :pending
   test "multiple entries on same date ordered by description" do
     entries = [
-      %{amount_in_cents: 1000, date: ~D[2015-01-02], description: "Get present"},
+      %{amount_in_cents: 1000, date: ~D[2015-01-01], description: "Get present"},
       %{amount_in_cents: -1000, date: ~D[2015-01-01], description: "Buy present"}
     ]
 
@@ -48,7 +48,7 @@ defmodule LedgerTest do
              """
              Date       | Description               | Change\s\s\s\s\s\s\s
              01/01/2015 | Buy present               |      ($10.00)
-             01/02/2015 | Get present               |       $10.00\s
+             01/01/2015 | Get present               |       $10.00\s
              """
   end
 


### PR DESCRIPTION
There was a factual error in the test that got fixed in problem specs. The test description claimed to use the same date for two entries, but different dates were used.