### PR TITLE
Fix decimal to binary youtube link

### DIFF
--- a/exercises/concept/paint-by-number/.docs/hints.md
+++ b/exercises/concept/paint-by-number/.docs/hints.md
@@ -48,7 +48,7 @@
 - The [bitstring special form][bitstring-form] can be used to concatenate two bitstrings.
 - Use the special `::bitstring` type to specify that each of the bitstring fragments is of unknown size.
 
-[decimal-to-binary-youtube]: https://www.youtube.com/watch?v=gGiEu7QTi68
+[decimal-to-binary-youtube]: https://www.youtube.com/watch?v=H4BstqvgBow
 [integer-literal]: https://hexdocs.pm/elixir/syntax-reference.html#integers-in-other-bases-and-unicode-code-points
 [bitstring]: https://hexdocs.pm/elixir/binaries-strings-and-charlists.html#bitstrings
 [bitstring-form]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#%3C%3C%3E%3E/1


### PR DESCRIPTION
Some youtube video got removed.

According to the way back machine, the removed video is "How to Convert Decimal to Binary" by tecmath and it was 3 minutes long. I found something similar.