### PR TITLE
Make community-garden Livebook compatible

### DIFF
--- a/exercises/concept/community-garden/.docs/instructions.md
+++ b/exercises/concept/community-garden/.docs/instructions.md
@@ -51,6 +51,9 @@ CommunityGarden.list_registrations(pid)
 Implement the `CommunityGarden.get_registration/2` function. It should receive the `pid` and `id` of the plot to be checked. It should return the plot if it is registered, and `:not_found` if it is unregistered.
 
 ```elixir
+{:ok, pid} = CommunityGarden.start()
+CommunityGarden.register(pid, "Emma Balan")
+
 CommunityGarden.get_registration(pid, 1)
 # => %Plot{plot_id: 1, registered_to: "Emma Balan"}
 CommunityGarden.get_registration(pid, 7)


### PR DESCRIPTION
For the community-garden exercise Task 5 should include the plot with id 1 after it was released in the task prior.