### PR TITLE
City office > add new solutions to type address_map test

### DIFF
--- a/exercises/concept/city-office/test/form_test.exs
+++ b/exercises/concept/city-office/test/form_test.exs
@@ -223,7 +223,14 @@ defmodule FormTest do
         "%{postal_code: String.t(), street: String.t(), city: String.t()}",
         "%{postal_code: String.t(), city: String.t(), street: String.t()}",
         "%{city: String.t(), street: String.t(), postal_code: String.t()}",
-        "%{city: String.t(), postal_code: String.t(), street: String.t()}"
+        "%{city: String.t(), postal_code: String.t(), street: String.t()}",
+
+        "%{(:street | :postal_code | :city) => String.t()}",
+        "%{(:street | :city | :postal_code) => String.t()}",
+        "%{(:postal_code | :street | :city) => String.t()}",
+        "%{(:postal_code | :city | :street) => String.t()}",
+        "%{(:city | :street | :postal_code) => String.t()}",
+        "%{(:city | :postal_code | :street) => String.t()}"
       ]
 
       assert_type({Form, :address_map}, expected_type_definitions)


### PR DESCRIPTION
The [City Office exercise](https://exercism.org/tracks/elixir/exercises/city-office) teaches about typespec.

Due to the constraints around testing type definitions, the tests are testing them as strings against hard-coded possibilities.

I wish to allow at least `%{(:street | :postal_code | :city) => String.t()}` as an alternative solution to `%{street: String.t(), postal_code: String.t(), city: String.t()}`