### PR TITLE
Fix typo in the "dig deeper" section of the Leap Year exercise

### DIFF
--- a/exercises/practice/leap/.approaches/introduction.md
+++ b/exercises/practice/leap/.approaches/introduction.md
@@ -29,7 +29,7 @@ A year is a leap year if
 We can use [boolean operators][boolean-operators] to combine the checks, for example, like so:
 
 ```elixir
-(rem(year, 5) == 0 and not rem(year, 100) == 0) or rem(year, 400) == 0
+(rem(year, 4) == 0 and not rem(year, 100) == 0) or rem(year, 400) == 0
 ```
 In the [boolean operators approach][operators-approach] we discuss the details of the solution.
 It includes variations of the operators and their precedence.


### PR DESCRIPTION
The rule about leap year uses modulo 4, not 5.