### PR TITLE
Include all IO in the last test

### DIFF
--- a/exercises/concept/rpg-character-sheet/test/rpg/character_sheet_test.exs
+++ b/exercises/concept/rpg-character-sheet/test/rpg/character_sheet_test.exs
@@ -122,7 +122,13 @@ defmodule RPG.CharacterSheetTest do
         end)
 
       assert io =~
-               "\nYour character: " <>
+               """
+               Welcome! Let's fill out your character sheet together.
+               What is your character's name?
+               What is your character's class?
+               What is your character's level?
+               """ <>
+                 "Your character: " <>
                  inspect(%{
                    name: "Anne",
                    class: "healer",


### PR DESCRIPTION
This fix adds all the IO that are displayed when the CharacterSheet.run() function is called