### PR TITLE
Fix types in complex numbers

### DIFF
--- a/exercises/practice/complex-numbers/.meta/example.ex
+++ b/exercises/practice/complex-numbers/.meta/example.ex
@@ -5,45 +5,45 @@ defmodule ComplexNumbers do
   For example, the real number `1` is `{1, 0}`, the imaginary number `i` is `{0, 1}` and
   the complex number `4+3i` is `{4, 3}'.
   """
-  @type complex :: {float, float}
+  @type complex :: {number, number}
 
   @doc """
   Return the real part of a complex number
   """
-  @spec real(a :: complex) :: float
+  @spec real(a :: complex) :: number
   def real({real, _im}), do: real
 
   @doc """
   Return the imaginary part of a complex number
   """
-  @spec imaginary(a :: complex) :: float
+  @spec imaginary(a :: complex) :: number
   def imaginary({_real, im}), do: im
 
   @doc """
   Multiply two complex numbers, or a real and a complex number
   """
-  @spec mul(a :: complex | float, b :: complex | float) :: complex
+  @spec mul(a :: complex | number, b :: complex | number) :: complex
   def mul({a, b}, {c, d}), do: {a * c - b * d, b * c + a * d}
   def mul(a, b), do: mul(to_complex(a), to_complex(b))
 
   @doc """
   Add two complex numbers, or a real and a complex number
   """
-  @spec add(a :: complex | float, b :: complex | float) :: complex
+  @spec add(a :: complex | number, b :: complex | number) :: complex
   def add({a, b}, {c, d}), do: {a + c, b + d}
   def add(a, b), do: add(to_complex(a), to_complex(b))
 
   @doc """
   Subtract two complex numbers, or a real and a complex number
   """
-  @spec sub(a :: complex | float, b :: complex | float) :: complex
+  @spec sub(a :: complex | number, b :: complex | number) :: complex
   def sub({a, b}, {c, d}), do: {a - c, b - d}
   def sub(a, b), do: sub(to_complex(a), to_complex(b))
 
   @doc """
   Divide two complex numbers, or a real and a complex number
   """
-  @spec div(a :: complex | float, b :: complex | float) :: complex
+  @spec div(a :: complex | number, b :: complex | number) :: complex
   def div({a, b}, {c, d}) do
     {(a * c + b * d) / (c * c + d * d), (b * c - a * d) / (c * c + d * d)}
   end

--- a/exercises/practice/complex-numbers/.meta/example.ex
+++ b/exercises/practice/complex-numbers/.meta/example.ex
@@ -53,7 +53,7 @@ defmodule ComplexNumbers do
   @doc """
   Absolute value of a complex number
   """
-  @spec abs(a :: complex) :: float
+  @spec abs(a :: complex) :: number
   def abs({a, b}), do: :math.sqrt(a * a + b * b)
 
   @doc """

--- a/exercises/practice/complex-numbers/lib/complex_numbers.ex
+++ b/exercises/practice/complex-numbers/lib/complex_numbers.ex
@@ -5,47 +5,47 @@ defmodule ComplexNumbers do
   For example, the real number `1` is `{1, 0}`, the imaginary number `i` is `{0, 1}` and
   the complex number `4+3i` is `{4, 3}'.
   """
-  @type complex :: {float, float}
+  @type complex :: {number, number}
 
   @doc """
   Return the real part of a complex number
   """
-  @spec real(a :: complex) :: float
+  @spec real(a :: complex) :: number
   def real(a) do
   end
 
   @doc """
   Return the imaginary part of a complex number
   """
-  @spec imaginary(a :: complex) :: float
+  @spec imaginary(a :: complex) :: number
   def imaginary(a) do
   end
 
   @doc """
   Multiply two complex numbers, or a real and a complex number
   """
-  @spec mul(a :: complex | float, b :: complex | float) :: complex
+  @spec mul(a :: complex | number, b :: complex | number) :: complex
   def mul(a, b) do
   end
 
   @doc """
   Add two complex numbers, or a real and a complex number
   """
-  @spec add(a :: complex | float, b :: complex | float) :: complex
+  @spec add(a :: complex | number, b :: complex | number) :: complex
   def add(a, b) do
   end
 
   @doc """
   Subtract two complex numbers, or a real and a complex number
   """
-  @spec sub(a :: complex | float, b :: complex | float) :: complex
+  @spec sub(a :: complex | number, b :: complex | number) :: complex
   def sub(a, b) do
   end
 
   @doc """
   Divide two complex numbers, or a real and a complex number
   """
-  @spec div(a :: complex | float, b :: complex | float) :: complex
+  @spec div(a :: complex | number, b :: complex | number) :: complex
   def div(a, b) do
   end
 

--- a/exercises/practice/complex-numbers/lib/complex_numbers.ex
+++ b/exercises/practice/complex-numbers/lib/complex_numbers.ex
@@ -52,7 +52,7 @@ defmodule ComplexNumbers do
   @doc """
   Absolute value of a complex number
   """
-  @spec abs(a :: complex) :: float
+  @spec abs(a :: complex) :: number
   def abs(a) do
   end
 


### PR DESCRIPTION
Reported on the forum: http://forum.exercism.org/t/mismatch-between-spec-and-test-on-complex-numbers/10850

I left `abs` as returning float because `:math.sqrt` always returns a float. But maybe that doesn't matter... it wouldn't break the test to return an integer from that function if the decimal part is equal to zero. `assert_delta_in`, used for all assertions, allows mixing up integers and floats.