### PR TITLE
Update instructions.md to reflect actual map

### DIFF
--- a/exercises/concept/boutique-suggestions/.docs/instructions.md
+++ b/exercises/concept/boutique-suggestions/.docs/instructions.md
@@ -8,6 +8,7 @@ Clothing items are stored as a map:
 %{
   item_name: "Descriptive Name",
   price: 99.00,
+  color: "Ochre Red",
   base_color: "red"
 }
 ```


### PR DESCRIPTION
The documentation claims:

```
Clothing items are stored as a map:

%{
  item_name: "Descriptive Name",
  price: 99.00,
  base_color: "red"
}
```

While the actual structure is like this in the tests:

``` elixir
%{
  item_name: "Descriptive Name",
  price: 99.00,
  color: "Ochre Red",
  base_color: "red"
}
```