### PR TITLE
Extend test for log-parser

### DIFF
--- a/exercises/concept/log-parser/test/log_parser_test.exs
+++ b/exercises/concept/log-parser/test/log_parser_test.exs
@@ -35,6 +35,8 @@ defmodule LogParserTest do
     @tag task_id: 1
     test "level must be wrapped in square brackets" do
       assert LogParser.valid_line?("ERROR something really bad happened") == false
+      assert LogParser.valid_line?("[INFO the latest information") == false
+      assert LogParser.valid_line?("DEBUG] response time 3ms") == false
     end
 
     @tag task_id: 1


### PR DESCRIPTION
I have seen several "Community Solutions" for this exercise which were not correct:

  def valid_line?(line) do
    line =~ ~r/^\[DEBUG|INFO|WARNING|ERROR\]/
  end

This would yield wrong result for some lines, which are now covered by the test.