### PR TITLE
Yacht: Reorder 3+2 full house test case in order to lower the chance of passing it coincidentally

### DIFF
--- a/exercises/practice/yacht/test/yacht_test.exs
+++ b/exercises/practice/yacht/test/yacht_test.exs
@@ -63,7 +63,7 @@ defmodule YachtTest do
 
   @tag :pending
   test "Full house three small, two big" do
-    assert Yacht.score(:full_house, [5, 3, 3, 5, 3]) == 19
+    assert Yacht.score(:full_house, [3, 5, 3, 5, 3]) == 19
   end
 
   @tag :pending


### PR DESCRIPTION
The existing versions of "Full house two small, three big" and "Full house three small, two big" test cases share a similarity which may help pass them by chance. Namely, in both cases the group of two is comprised of the element which is a head of the list. This causes the following "solution" to be accepted:

```elixir
def score(:full_house, dice) do
    case Enum.split_with(dice, fn x -> x == hd(dice) end) do
      {[a, a], [b, b, b]} -> 2*a + 3*b
      _ -> 0
    end
end
 ```

The present PR makes a tiny change in the 3+2 test case that will require to also consider an alternative grouping:

```elixir
def score(:full_house, dice) do
    case Enum.split_with(dice, fn x -> x == hd(dice) end) do
      {[a, a], [b, b, b]} -> 2*a + 3*b
      {[a, a, a], [b, b]} -> 3*a + 2*b # <-- This one.
      _ -> 0
    end
 end
 ```
 
 Seems like there's nothing more to it:
  
 ```sh
 ./bin/configlet sync --update --exercise yacht
Updating cached 'problem-specifications' data...
Checking exercises...
The `yacht` exercise has up-to-date docs, filepaths, metadata, and tests!
```
