### PR TITLE
Exchange dead link for 'with'

### DIFF
--- a/concepts/with/links.json
+++ b/concepts/with/links.json
@@ -4,8 +4,8 @@
     "description": "Getting Started guide - With"
   },
   {
-    "url": "http://learningelixir.joekain.com/learning-elixir-with/",
-    "description": "Learning Elixir - Learning Elixir's with"
+    "url": "https://elixirschool.com/en/lessons/basics/control_structures#with-3",
+    "description": "Elixir School - With"
   },
   {
     "url": "https://hexdocs.pm/elixir/Kernel.SpecialForms.html#with/1",

--- a/concepts/with/links.json
+++ b/concepts/with/links.json
@@ -10,5 +10,9 @@
   {
     "url": "https://hexdocs.pm/elixir/Kernel.SpecialForms.html#with/1",
     "description": "Kernel.SpecialForms.with/1"
+  },
+  {
+    "url": "https://hexdocs.pm/elixir/main/code-anti-patterns.html#complex-else-clauses-in-with",
+    "description": "Anti-pattern: complex else clauses in with"
   }
 ]


### PR DESCRIPTION
This was the original: https://web.archive.org/web/20150511141513/http://twitter.com/@Joseph_Kain

It's from 2015 and talks about version 1.2 being upcoming 😁 maybe not the best message for beginners. So I decided against linking to its wayback machine copy, and just find a new link.