### PR TITLE
Take-a-number needs a named function example

### DIFF
--- a/concepts/processes/introduction.md
+++ b/concepts/processes/introduction.md
@@ -5,11 +5,11 @@ In Elixir, all code runs inside processes.
 By default, a function will execute in the same process from which it was called. When you need to explicitly run a certain function in a new process, use `spawn/1`:
 
 ```elixir
-spawn(fn -> 2 + 2 end)
+spawn(&my_function/0)
 # => #PID<0.125.0>
 ```
 
-`spawn/1` creates a new process that executes the given function and returns a _process identifier_ (PID). The new process will stay alive as long as the function executes, and then silently exit.
+`spawn/1` creates a new process that executes the given 0-arity function and returns a _process identifier_ (PID). The new process will stay alive as long as the function executes, and then silently exit.
 
 Elixir's processes should not be confused with operating system processes. Elixir's processes use much less memory and CPU. It's perfectly fine to have Elixir applications that run hundreds of Elixir processes.
 

--- a/exercises/concept/take-a-number/.docs/hints.md
+++ b/exercises/concept/take-a-number/.docs/hints.md
@@ -8,7 +8,8 @@
 ## 1. Start the machine
 
 - The machine should run in a new process. There is [a built-in function that starts a new process][kernel-spawn-1].
-- You will need another function that the new process will execute.
+- You will need another function that the new process will execute. You can name it, for example, `loop`.
+- Use the [capture operator][special-forms-capture] to pass a named function as an argument.
 
 ## 2. Report the machine state
 
@@ -38,3 +39,4 @@
 [kernel-spawn-1]: https://hexdocs.pm/elixir/Kernel.html#spawn/1
 [kernel-receive]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#receive/1
 [kernel-send]: https://hexdocs.pm/elixir/Kernel.html#send/2
+[special-forms-capture]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#&/1

--- a/exercises/concept/take-a-number/.docs/introduction.md
+++ b/exercises/concept/take-a-number/.docs/introduction.md
@@ -7,11 +7,11 @@ In Elixir, all code runs inside processes.
 By default, a function will execute in the same process from which it was called. When you need to explicitly run a certain function in a new process, use `spawn/1`:
 
 ```elixir
-spawn(fn -> 2 + 2 end)
+spawn(&my_function/0)
 # => #PID<0.125.0>
 ```
 
-`spawn/1` creates a new process that executes the given function and returns a _process identifier_ (PID). The new process will stay alive as long as the function executes, and then silently exit.
+`spawn/1` creates a new process that executes the given 0-arity function and returns a _process identifier_ (PID). The new process will stay alive as long as the function executes, and then silently exit.
 
 Elixir's processes should not be confused with operating system processes. Elixir's processes use much less memory and CPU. It's perfectly fine to have Elixir applications that run hundreds of Elixir processes.
 


### PR DESCRIPTION
Partially addresses https://github.com/exercism/elixir/issues/1482

In take-a-number, it was difficult to figure out how to pass a named function to `spawn`. The example in the introduction used an anonymous function, and we actually don't teach anywhere how to use the capture operator to pass named functions as arguments. The only place this is mentioned, is the anonymous function's concept's "about" page, which most people will never see (rendered only if you browse the concept after learning it). None of the concept introductions mention how to use the capture operator for named functions.