### PR TITLE
fix the disable comments for the markdown formatter

### DIFF
--- a/concepts/docs/about.md
+++ b/concepts/docs/about.md
@@ -74,7 +74,7 @@ If you have Elixir installed on your computer, you can use it in [the interactiv
 
 In `iex`, you can type [`h`][iex-h], followed by a space and a module name or a function name, to read its documentation.
 
-[]: # (elixir-formatter-disable-next-block)
+[//]: # (elixir-formatter-disable-next-block)
 
 ```elixir
 iex()> h String.upcase/1

--- a/concepts/keyword-lists/about.md
+++ b/concepts/keyword-lists/about.md
@@ -21,7 +21,7 @@ Keyword.keyword?([{"month", "April"}])
 
 If you want to use characters other than letters, numbers, and `_` in the key, you need to wrap it in quotes. However, that does not make it a string - it is still an atom.
 
-[]: # (elixir-formatter-disable-next-block)
+[//]: # (elixir-formatter-disable-next-block)
 
 ```elixir
 Keyword.keyword?(["day of week": "Monday"])
@@ -61,7 +61,7 @@ if age >= 16, do: "beer", else: "no beer"
 
 This may look like `if` accepts two arguments, but the `do:` and `else:` pair is actually a single argument - a keyword list. The same code could be written as:
 
-[]: # (elixir-formatter-disable-next-block)
+[//]: # (elixir-formatter-disable-next-block)
 
 ```elixir
 if age >= 16, [do: "beer", else: "no beer"]

--- a/concepts/list-comprehensions/about.md
+++ b/concepts/list-comprehensions/about.md
@@ -2,7 +2,7 @@
 
 [Comprehension][for] provide a facility for transforming _Enumerables_ easily and declaratively. They are _syntactic sugar_ for iterating through enumerables in Elixir.
 
-[]: # (elixir-formatter-disable-next-block)
+[//]: # (elixir-formatter-disable-next-block)
 
 ```elixir
 for s <- ["a", "b", "hello", "c"], # 1. generator

--- a/concepts/nil/about.md
+++ b/concepts/nil/about.md
@@ -9,7 +9,7 @@ favorite_color = nil
 
 `nil` is an atom, but it is usually written as `nil`, not `:nil`. The boolean values `true` and `false` are atoms too.
 
-[]: # (elixir-formatter-disable-next-block)
+[//]: # (elixir-formatter-disable-next-block)
 
 ```elixir
 nil === :nil

--- a/concepts/try-rescue/about.md
+++ b/concepts/try-rescue/about.md
@@ -4,19 +4,17 @@
 
 For example:
 
-[//]: # (elixir-formatter-disable-next-block)
-
 ```elixir
-try do                             #1
-  raise RuntimeError, "error"      #2
+try do
+  raise RuntimeError, "error"
 rescue
-  e in RuntimeError -> :error      #3
+  e in RuntimeError -> :error
 end
 ```
 
 - **Line 1**, the block is declared with `try`.
 - **Line 2**, the function call which may generate an error is placed here, in this case we are calling `raise/1`.
-- **Line 3**, in the `rescue` section, we pattern match on the _Module_ name of the error raised
+- **Line 4**, in the `rescue` section, we pattern match on the _Module_ name of the error raised
   - on the left side of `->`:
     - `e` is matched to the error struct.
     - `in` is a keyword.

--- a/concepts/try-rescue/about.md
+++ b/concepts/try-rescue/about.md
@@ -4,7 +4,7 @@
 
 For example:
 
-[]: # (elixir-formatter-disable-next-block)
+[//]: # (elixir-formatter-disable-next-block)
 
 ```elixir
 try do                             #1

--- a/concepts/try-rescue/introduction.md
+++ b/concepts/try-rescue/introduction.md
@@ -2,7 +2,7 @@
 
 Elixir provides a construct for rescuing from errors using `try .. rescue`
 
-[]: # (elixir-formatter-disable-next-block)
+[//]: # (elixir-formatter-disable-next-block)
 
 ```elixir
 try do                             #1

--- a/concepts/try-rescue/introduction.md
+++ b/concepts/try-rescue/introduction.md
@@ -2,13 +2,11 @@
 
 Elixir provides a construct for rescuing from errors using `try .. rescue`
 
-[//]: # (elixir-formatter-disable-next-block)
-
 ```elixir
-try do                             #1
-  raise RuntimeError, "error"      #2
+try do
+  raise RuntimeError, "error"
 rescue
-  e in RuntimeError -> :error      #3
+  e in RuntimeError -> :error
 end
 ```
 
@@ -16,7 +14,7 @@ Let's examine this construct:
 
 - **Line 1**, the block is declared with `try`.
 - **Line 2**, the function call which may error is placed here, in this case we are calling `raise/2`.
-- **Line 3**, in the `rescue` section, we pattern match on the _Module_ name of the error raised
+- **Line 4**, in the `rescue` section, we pattern match on the _Module_ name of the error raised
   - on the left side of `->`:
     - `e` is matched to the error struct.
     - `in` is a keyword.

--- a/docs/REPRESENTER_NORMALIZATIONS.md
+++ b/docs/REPRESENTER_NORMALIZATIONS.md
@@ -87,7 +87,7 @@ Types are written without.
 
 ### Before
 
-[]: # (elixir-formatter-disable-next-block)
+[//]: # (elixir-formatter-disable-next-block)
 
 ```elixir
 defmodule    Fake   do

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -71,7 +71,7 @@ Multiple tests may be executed by giving multiple line numbers separated by `:`.
 
 For example, given a file with the following content with line numbers:
 
-[]: # (elixir-formatter-disable-next-block)
+[//]: # (elixir-formatter-disable-next-block)
 
 ```elixir
 test "Test 1" do           # 1

--- a/exercises/concept/rpn-calculator/.docs/introduction.md
+++ b/exercises/concept/rpn-calculator/.docs/introduction.md
@@ -15,13 +15,11 @@ Map.fetch!(%{a: 1}, :b)
 
 Elixir provides a construct for rescuing from errors using `try .. rescue`
 
-[//]: # (elixir-formatter-disable-next-block)
-
 ```elixir
-try do                             #1
-  raise RuntimeError, "error"      #2
+try do
+  raise RuntimeError, "error"
 rescue
-  e in RuntimeError -> :error      #3
+  e in RuntimeError -> :error
 end
 ```
 
@@ -29,7 +27,7 @@ Let's examine this construct:
 
 - **Line 1**, the block is declared with `try`.
 - **Line 2**, the function call which may error is placed here, in this case we are calling `raise/2`.
-- **Line 3**, in the `rescue` section, we pattern match on the _Module_ name of the error raised
+- **Line 4**, in the `rescue` section, we pattern match on the _Module_ name of the error raised
   - on the left side of `->`:
     - `e` is matched to the error struct.
     - `in` is a keyword.

--- a/exercises/concept/rpn-calculator/.docs/introduction.md
+++ b/exercises/concept/rpn-calculator/.docs/introduction.md
@@ -15,7 +15,7 @@ Map.fetch!(%{a: 1}, :b)
 
 Elixir provides a construct for rescuing from errors using `try .. rescue`
 
-[]: # (elixir-formatter-disable-next-block)
+[//]: # (elixir-formatter-disable-next-block)
 
 ```elixir
 try do                             #1

--- a/exercises/practice/leap/.approaches/clauses/content.md
+++ b/exercises/practice/leap/.approaches/clauses/content.md
@@ -18,7 +18,7 @@ While in the [operators approach][operators-approach], it was possible to reorde
 
 In our case, the three guards in the function clauses are as follows:
 
-[]: # (elixir-formatter-disable-next-block)
+[//]: # (elixir-formatter-disable-next-block)
 
 ```elixir
 when rem(year, 400) == 0
@@ -28,7 +28,7 @@ when rem(year, 4) == 0
 
 But because of the order they are evaluated in, they are equivalent to:
 
-[]: # (elixir-formatter-disable-next-block)
+[//]: # (elixir-formatter-disable-next-block)
 
 ```elixir
 when rem(year, 400) == 0

--- a/exercises/practice/leap/.approaches/operators/content.md
+++ b/exercises/practice/leap/.approaches/operators/content.md
@@ -25,7 +25,7 @@ However, if `left` is *false*, `right` has to be evaluated to determine the outc
 
 ## Precedence of operators
 
-[]: # (elixir-formatter-disable-next-block)
+[//]: # (elixir-formatter-disable-next-block)
 
 Another thing to consider when using Boolean operators is their precedence.
 ```elixir


### PR DESCRIPTION
According to docs these comments should look like this. Hopefully this will prevent them from showing up on the exercism page e.g. <https://exercism.org/tracks/elixir/exercises/rpn-calculator> in the section "Try/Rescue"

![CleanShot 2024-06-11 at 23 59 25@2x](https://github.com/exercism/elixir/assets/3978662/e85d8c06-4b62-40f4-ad99-269445cfa21e)

See:
https://hexdocs.pm/markdown_code_block_formatter/readme.html#disabling-the-formatter-for-specific-code-blocks