### PR TITLE
Fixed Typos in Instructions of Pig Latin

### DIFF
--- a/exercises/practice/pig-latin/.docs/instructions.md
+++ b/exercises/practice/pig-latin/.docs/instructions.md
@@ -19,7 +19,7 @@ For example:
 
 ## Rule 2
 
-If a word begins with a one or more consonants, first move those consonants to the end of the word and then add an `"ay"` sound to the end of the word.
+If a word begins with one or more consonants, first move those consonants to the end of the word and then add an `"ay"` sound to the end of the word.
 
 For example:
 
@@ -33,7 +33,7 @@ If a word starts with zero or more consonants followed by `"qu"`, first move tho
 
 For example:
 
-- `"quick"` -> `"ickqu"` -> `"ay"` (starts with `"qu"`, no preceding consonants)
+- `"quick"` -> `"ickqu"` -> `"ickquay"` (starts with `"qu"`, no preceding consonants)
 - `"square"` -> `"aresqu"` -> `"aresquay"` (starts with one consonant followed by `"qu`")
 
 ## Rule 4


### PR DESCRIPTION
Fixed 2 typos in Pig-Latin.
I checked with [Problem Specifications](https://github.com/exercism/problem-specifications/blob/main/exercises/pig-latin/instructions.md) and although they differ generally by wording the typos are not in that one.

I don't know if they are supposed to be identical but they are not and I would atleast like to fix the typos.