### PR TITLE
Sync protein-translation

### DIFF
--- a/exercises/practice/protein-translation/.meta/tests.toml
+++ b/exercises/practice/protein-translation/.meta/tests.toml
@@ -87,11 +87,15 @@ description = "Translation stops if STOP codon in middle of three-codon sequence
 [2c2a2a60-401f-4a80-b977-e0715b23b93d]
 description = "Translation stops if STOP codon in middle of six-codon sequence"
 
+[f6f92714-769f-4187-9524-e353e8a41a80]
+description = "Sequence of two non-STOP codons does not translate to a STOP codon"
+
 [1e75ea2a-f907-4994-ae5c-118632a1cb0f]
 description = "Non-existing codon can't translate"
 
 [9eac93f3-627a-4c90-8653-6d0a0595bc6f]
 description = "Unknown amino acids, not part of a codon, can't translate"
+reimplements = "1e75ea2a-f907-4994-ae5c-118632a1cb0f"
 
 [9d73899f-e68e-4291-b1e2-7bf87c00f024]
 description = "Incomplete RNA sequence can't translate"

--- a/exercises/practice/protein-translation/test/protein_translation_test.exs
+++ b/exercises/practice/protein-translation/test/protein_translation_test.exs
@@ -140,12 +140,6 @@ defmodule ProteinTranslationTest do
     end
 
     @tag :pending
-    test "known amino acids, but invalid codon, invalid RNA" do
-      strand = "AAA"
-      assert ProteinTranslation.of_rna(strand) == {:error, "invalid RNA"}
-    end
-
-    @tag :pending
     test "unknown amino acids, not part of a codon, invalid RNA" do
       strand = "XYZ"
       assert ProteinTranslation.of_rna(strand) == {:error, "invalid RNA"}

--- a/exercises/practice/protein-translation/test/protein_translation_test.exs
+++ b/exercises/practice/protein-translation/test/protein_translation_test.exs
@@ -128,6 +128,12 @@ defmodule ProteinTranslationTest do
     end
 
     @tag :pending
+    test "sequence of two non-STOP codons does not translate to a STOP codon" do
+      strand = "AUGAUG"
+      assert ProteinTranslation.of_rna(strand) == {:ok, ~w(Methionine Methionine)}
+    end
+
+    @tag :pending
     test "incomplete codon, invalid RNA" do
       strand = "UG"
       assert ProteinTranslation.of_rna(strand) == {:error, "invalid RNA"}


### PR DESCRIPTION
- One new test added
- One test, for "AAA", removed, because "AAA" is a known amino acid and shouldn't cause errors. The test for "XYZ" is taking over as the main test for "invalid codon" (see: https://forum.exercism.org/t/incorrect-test-in-protein-translation/10616/13)