### PR TITLE
Do not use ignored arguments in solution boilerplate

### DIFF
--- a/exercises/practice/bottle-song/lib/bottle_song.ex
+++ b/exercises/practice/bottle-song/lib/bottle_song.ex
@@ -4,6 +4,6 @@ defmodule BottleSong do
   """
 
   @spec recite(pos_integer, pos_integer) :: String.t()
-  def recite(_start_bottle, _take_down) do
+  def recite(start_bottle, take_down) do
   end
 end

--- a/exercises/practice/series/lib/string_series.ex
+++ b/exercises/practice/series/lib/string_series.ex
@@ -5,6 +5,6 @@ defmodule StringSeries do
   return an empty list.
   """
   @spec slices(s :: String.t(), size :: integer) :: list(String.t())
-  def slices(_s, _size) do
+  def slices(s, size) do
   end
 end


### PR DESCRIPTION
Resolves https://github.com/exercism/elixir/issues/1517

We don't use ignored arguments in solutions boilerplate for most exercises, so we shouldn't use it in any of them. I was grepping for `\(_`, and `, _` to find underscored arguments in practice exercises and only found those two.