### PR TITLE
Updates secrets for order of operations clarity

### DIFF
--- a/exercises/concept/secrets/.docs/instructions.md
+++ b/exercises/concept/secrets/.docs/instructions.md
@@ -73,10 +73,10 @@ xorer.(3)
 Implement `Secrets.secret_combine/2`. It should return a function which takes one argument and applies to it the two functions passed in to `secret_combine` in order.
 
 ```elixir
-multiply = Secrets.secret_multiply(7)
-divide = Secrets.secret_divide(3)
-combined = Secrets.secret_combine(multiply, divide)
+add_one = Secrets.secret_add(1) 
+multiply_by_2 = Secrets.secret_multiply(2)
+combined = Secrets.secret_combine(add_one, multiply_by_2)
 
-combined.(6)
-# => 14
+combined.(3)
+# => 8
 ```

--- a/exercises/concept/secrets/.docs/instructions.md
+++ b/exercises/concept/secrets/.docs/instructions.md
@@ -73,7 +73,7 @@ xorer.(3)
 Implement `Secrets.secret_combine/2`. It should return a function which takes one argument and applies to it the two functions passed in to `secret_combine` in order.
 
 ```elixir
-add_one = Secrets.secret_add(1) 
+add_one = Secrets.secret_add(1)
 multiply_by_2 = Secrets.secret_multiply(2)
 combined = Secrets.secret_combine(add_one, multiply_by_2)
 


### PR DESCRIPTION
The original example is slightly confusing because division and multiplication can be swapped in some cases and does not clearly show the order of operations:

* The expected output (14) could be achieved through either (6 * 7) / 3 or (6 / 3) * 7. 
* As a result you could write both `secret_function2.(secret_function1.(x))` or `secret_function1.(secret_function2.(x))`, but only 1 will pass test cases when the anonymous functions have varying order of operations. 
* In the revised version, the order matters and is clear (3+1=4, then 4\*2=8 is different from 3\*2=6, then 6+1=7)
