### PR TITLE
[#1528 ] Remove mentions and uses of `unless`

### DIFF
--- a/concepts/if/about.md
+++ b/concepts/if/about.md
@@ -1,8 +1,8 @@
 # About
 
-Besides `cond`, Elixir also provides the macros [`if/2` and `unless/2`][getting-started-if-unless] which are useful when you need to check for only one condition.
+Besides `cond`, Elixir also provides the macro [`if/2`][getting-started-if] which is useful when you need to check for only one condition.
 
-[`if/2`][kernel-if] accepts a condition and two options. It returns the first option if the condition is _truthy_, and the second option if the condition is _falsy_. [`unless/2`][kernel-unless] does the opposite.
+[`if/2`][kernel-if] accepts a condition and two options. It returns the first option if the condition is _truthy_, and the second option if the condition is _falsy_.
 
 ```elixir
 age = 15
@@ -36,16 +36,6 @@ if age >= 16, do: "beer", else: "no beer"
 
 This syntax is helpful for very short expressions, but should be avoided if the expression won't fit on a single line.
 
-`unless` with an `else` option should be avoided.
-
-```elixir
-# preferred
-if age >= 16, do: "beer", else: "no beer"
-
-# not preferred
-unless age < 16, do: "no beer", else: "beer"
-```
-
 ## _Truthy_ and _falsy_
 
 In Elixir, all datatypes evaluate to a _truthy_ or _falsy_ value when they are encountered in a boolean context (like an `if` expression). All data is considered _truthy_ **except** for `false` and `nil`. In particular, empty strings, the integer `0`, and empty lists are all considered _truthy_ in Elixir. In this way, [Elixir is similar to Ruby but different than JavaScript, Python, or PHP][falsy-various-langs].
@@ -76,9 +66,8 @@ truthy?.(nil)
 # => true
 ```
 
-[getting-started-if-unless]: https://hexdocs.pm/elixir/case-cond-and-if.html#if-unless
+[getting-started-if]: https://hexdocs.pm/elixir/case-cond-and-if.html#if-unless
 [kernel-if]: https://hexdocs.pm/elixir/Kernel.html#if/2
-[kernel-unless]: https://hexdocs.pm/elixir/Kernel.html#unless/2
 [kernel-boolean-and]: https://hexdocs.pm/elixir/Kernel.html#and/2
 [kernel-boolean-or]: https://hexdocs.pm/elixir/Kernel.html#or/2
 [kernel-boolean-not]: https://hexdocs.pm/elixir/Kernel.html#not/1

--- a/concepts/if/introduction.md
+++ b/concepts/if/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Besides `cond`, Elixir also provides the macro [`if/2`][getting-started-if-unless] which is useful when you need to check for only one condition.
+Besides `cond`, Elixir also provides the macro [`if/2`][getting-started-if] which is useful when you need to check for only one condition.
 
 [`if/2`][kernel-if] accepts a condition and two options. It returns the first option if the condition is _truthy_, and the second option if the condition is _falsy_.
 
@@ -28,5 +28,5 @@ This syntax is helpful for very short expressions, but should be avoided if the 
 
 In Elixir, all datatypes evaluate to a _truthy_ or _falsy_ value when they are encountered in a boolean context (like an `if` expression). All data is considered _truthy_ **except** for `false` and `nil`. In particular, empty strings, the integer `0`, and empty lists are all considered _truthy_ in Elixir.
 
-[getting-started-if-unless]: https://hexdocs.pm/elixir/case-cond-and-if.html#if-unless
+[getting-started-if]: https://hexdocs.pm/elixir/case-cond-and-if.html#if-unless
 [kernel-if]: https://hexdocs.pm/elixir/Kernel.html#if/2

--- a/concepts/if/links.json
+++ b/concepts/if/links.json
@@ -1,7 +1,7 @@
 [
   {
     "url": "https://hexdocs.pm/elixir/case-cond-and-if.html#if-unless",
-    "description": "Getting Started: `if` and `unless`"
+    "description": "Getting Started: `if`"
   },
   {
     "url": "https://hexdocs.pm/elixir/basic-types.html#booleans-and-nil",
@@ -10,9 +10,5 @@
   {
     "url": "https://hexdocs.pm/elixir/Kernel.html#if/2",
     "description": "Documentation: `if/2`"
-  },
-  {
-    "url": "https://hexdocs.pm/elixir/Kernel.html#unless/2",
-    "description": "Documentation: `unless/2`"
   }
 ]

--- a/exercises/concept/name-badge/.docs/hints.md
+++ b/exercises/concept/name-badge/.docs/hints.md
@@ -2,7 +2,7 @@
 
 ## General
 
-- Read about `if` in the official [Getting Started guide][getting-started-if-unless] or on [elixirschool.com][elixirschool-if-unless].
+- Read about `if` in the official [Getting Started guide][getting-started-if] or on [elixirschool.com][elixirschool-if].
 
 ## 1. Print a badge for an employee
 
@@ -21,5 +21,5 @@
 
 [kernel-if]: https://hexdocs.pm/elixir/Kernel.html#if/2
 [getting-started-basic-strings]: https://hexdocs.pm/elixir/basic-types.html#strings
-[getting-started-if-unless]: https://hexdocs.pm/elixir/case-cond-and-if.html#if-unless
-[elixir-school-if-unless]: https://elixirschool.com/en/lessons/basics/control-structures/#if-and-unless
+[getting-started-if]: https://hexdocs.pm/elixir/case-cond-and-if.html#if-unless
+[elixirschool-if]: https://elixirschool.com/en/lessons/basics/control-structures/#if-and-unless

--- a/exercises/concept/name-badge/.docs/introduction.md
+++ b/exercises/concept/name-badge/.docs/introduction.md
@@ -13,7 +13,7 @@ In other programming languages, `null` or `none` values might play a similar rol
 
 ## If
 
-Besides `cond`, Elixir also provides the macro [`if/2`][getting-started-if-unless] which is useful when you need to check for only one condition.
+Besides `cond`, Elixir also provides the macro [`if/2`][getting-started-if] which is useful when you need to check for only one condition.
 
 [`if/2`][kernel-if] accepts a condition and two options. It returns the first option if the condition is _truthy_, and the second option if the condition is _falsy_.
 
@@ -42,5 +42,5 @@ This syntax is helpful for very short expressions, but should be avoided if the 
 In Elixir, all datatypes evaluate to a _truthy_ or _falsy_ value when they are encountered in a boolean context (like an `if` expression). All data is considered _truthy_ **except** for `false` and `nil`. In particular, empty strings, the integer `0`, and empty lists are all considered _truthy_ in Elixir.
 
 [nil-dictionary]: https://www.merriam-webster.com/dictionary/nil
-[getting-started-if-unless]: https://hexdocs.pm/elixir/case-cond-and-if.html#if-unless
+[getting-started-if]: https://hexdocs.pm/elixir/case-cond-and-if.html#if-unless
 [kernel-if]: https://hexdocs.pm/elixir/Kernel.html#if/2

--- a/exercises/concept/name-badge/.meta/design.md
+++ b/exercises/concept/name-badge/.meta/design.md
@@ -5,7 +5,7 @@
 - Know what `nil` represents
 - Know that `nil` is a special atom
 - Know how to pattern match on `nil`
-- Know how to use the `if`/`unless` macros
+- Know how to use the `if` macro
 - Know about truthiness
 
 ## Out of scope

--- a/exercises/practice/alphametics/.meta/example.ex
+++ b/exercises/practice/alphametics/.meta/example.ex
@@ -35,7 +35,7 @@ defmodule Alphametics do
     Enum.find_value(numbers, fn number ->
       leading_zero? = number == 0 && letter in problem.first_letters
 
-      unless leading_zero? do
+      if !leading_zero? do
         numbers = List.delete(numbers, number)
         solution = put_in(solution[letter], number)
         solve(letters, numbers, solution, problem)

--- a/exercises/practice/largest-series-product/.meta/example.ex
+++ b/exercises/practice/largest-series-product/.meta/example.ex
@@ -25,7 +25,7 @@ defmodule Series do
   end
 
   def largest_product(number_string, size) do
-    unless Enum.member?(Range.new(0, String.length(number_string)), size) do
+    if not Enum.member?(Range.new(0, String.length(number_string)), size) do
       raise ArgumentError
     end
 

--- a/exercises/practice/leap/.approaches/flow/content.md
+++ b/exercises/practice/leap/.approaches/flow/content.md
@@ -15,9 +15,9 @@ end
 
 ## If
 
-Elixir provides four [control flow structures][hexdocs-structures]: `case`, `cond`, `if`, and `unless`.
+Elixir provides three [control flow structures][hexdocs-structures]: `case`, `cond`, `if`.
 
-The `if` and `unless` allow to evaluate only one condition.
+The `if` allows to evaluate only one condition.
 Unlike in many other languages, there is no `else if` option in Elixir.
 
 However, in this case, it is not necessary. We can use `if` once to check if the year is divisible by 100.


### PR DESCRIPTION
Closes #1528 

It's a bit unfortunate that some links (like `https://hexdocs.pm/elixir/case-cond-and-if.html#if-unless`) mention unless in the hash, but it'll be a quick fix. We could also wait for 1.18 before merging this.