### PR TITLE
Prefer more concise and cross-language ** operator over Integer.pow/2

### DIFF
--- a/exercises/concept/paint-by-number/.docs/hints.md
+++ b/exercises/concept/paint-by-number/.docs/hints.md
@@ -13,7 +13,7 @@
 - Find the smallest positive number `n` such that 2 raised to the power of `n` is greater than or equal than the number of colors we need to represent.
 - Create a recursive function for this.
 - Choose a starting bit size of 1. If 2 raised to the power of the bit size is greater than or equal to the color count, we've found our bit size. If not, add 1 to the bit size and check again (recursion).
-- Use the [`power operator `**`][power-operator] to raise 2 to a given power.
+- Use the [power operator `**`][power-operator] to raise 2 to a given power.
 
 ## 2. Create an empty picture
 

--- a/exercises/concept/paint-by-number/.docs/hints.md
+++ b/exercises/concept/paint-by-number/.docs/hints.md
@@ -13,7 +13,7 @@
 - Find the smallest positive number `n` such that 2 raised to the power of `n` is greater than or equal than the number of colors we need to represent.
 - Create a recursive function for this.
 - Choose a starting bit size of 1. If 2 raised to the power of the bit size is greater than or equal to the color count, we've found our bit size. If not, add 1 to the bit size and check again (recursion).
-- Use [`Integer.pow/2`][integer-pow] to raise 2 to a given power.
+- Use the [`power operator `**`][power-operator] to raise 2 to a given power.
 
 ## 2. Create an empty picture
 
@@ -54,4 +54,4 @@
 [bitstring-form]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#%3C%3C%3E%3E/1
 [bitstring-matching]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#%3C%3C%3E%3E/1-binary-bitstring-matching
 [type-operator]: https://hexdocs.pm/elixir/Kernel.SpecialForms.html#::/2
-[integer-pow]: https://hexdocs.pm/elixir/Integer.html#pow/2
+[power-operator]: https://hexdocs.pm/elixir/Kernel.html#**/2

--- a/exercises/concept/paint-by-number/.docs/instructions.md
+++ b/exercises/concept/paint-by-number/.docs/instructions.md
@@ -44,7 +44,7 @@ PaintByNumber.palette_bit_size(13)
 # => 4
 ```
 
-Note: there is no `log2` function in the Elixir standard library. You will later learn how to use [Erlang libraries][erlang-libraries] from Elixir where you can find this function. Now, solve this task with recursion and the [power operator][power-operator] instead.
+Note: there is no `log2` function in the Elixir standard library. You will later learn how to use [Erlang libraries][erlang-libraries] from Elixir where you can find this function. Now, solve this task with recursion and the [power operator `**`][power-operator] instead.
 
 ## 2. Create an empty picture
 

--- a/exercises/concept/paint-by-number/.docs/instructions.md
+++ b/exercises/concept/paint-by-number/.docs/instructions.md
@@ -44,7 +44,7 @@ PaintByNumber.palette_bit_size(13)
 # => 4
 ```
 
-Note: there is no `log2` function in the Elixir standard library. You will later learn how to use [Erlang libraries][erlang-libraries] from Elixir where you can find this function. Now, solve this task with recursion and the [`Integer.pow/2`][integer-pow] function instead.
+Note: there is no `log2` function in the Elixir standard library. You will later learn how to use [Erlang libraries][erlang-libraries] from Elixir where you can find this function. Now, solve this task with recursion and the [power operator][power-operator] instead.
 
 ## 2. Create an empty picture
 
@@ -113,4 +113,4 @@ PaintByNumber.concat_pictures(picture1, picture2)
 [paint-by-number]: https://en.wikipedia.org/wiki/Paint_by_number
 [binary-file]: https://en.wikipedia.org/wiki/Binary_file
 [erlang-libraries]: https://exercism.org/tracks/elixir/concepts/erlang-libraries
-[integer-pow]: https://hexdocs.pm/elixir/Integer.html#pow/2
+[power-operator]: https://hexdocs.pm/elixir/Kernel.html#**/2

--- a/exercises/concept/paint-by-number/.meta/exemplar.ex
+++ b/exercises/concept/paint-by-number/.meta/exemplar.ex
@@ -4,7 +4,7 @@ defmodule PaintByNumber do
   end
 
   defp do_palette_bit_size(color_count, bits \\ 1) do
-    if Integer.pow(2, bits) >= color_count do
+    if 2 ** bits >= color_count do
       bits
     else
       do_palette_bit_size(color_count, bits + 1)


### PR DESCRIPTION
`**` has been available since 1.13, and will be already familiar to those coming from other languages.