### PR TITLE
Sync flatten-array

### DIFF
--- a/exercises/practice/flatten-array/.docs/instructions.append.md
+++ b/exercises/practice/flatten-array/.docs/instructions.append.md
@@ -1,0 +1,5 @@
+# Instructions append
+
+## Elixir-specific changes
+
+The above description of this exercise is shared between all Exercism tracks. It speaks of "arrays", but there is no such data type in Elixir. This exercise is about **lists**.

--- a/exercises/practice/flatten-array/.docs/instructions.md
+++ b/exercises/practice/flatten-array/.docs/instructions.md
@@ -1,11 +1,16 @@
 # Instructions
 
-Take a nested list and return a single flattened list with all values except nil/null.
+Take a nested array of any depth and return a fully flattened array.
 
-The challenge is to take an arbitrarily-deep nested list-like structure and produce a flattened structure without any nil/null values.
+Note that some language tracks may include null-like values in the input array, and the way these values are represented varies by track.
+Such values should be excluded from the flattened array.
 
-For example:
+Additionally, the input may be of a different data type and contain different types, depending on the track.
 
-input: [1,[2,3,null,4],[null],5]
+Check the test suite for details.
 
-output: [1,2,3,4,5]
+## Example
+
+input: `[1, [2, 6, null], [[null, [4]], 5]]`
+
+output: `[1, 2, 6, 4, 5]`

--- a/exercises/practice/flatten-array/.docs/introduction.md
+++ b/exercises/practice/flatten-array/.docs/introduction.md
@@ -1,0 +1,7 @@
+# Introduction
+
+A shipment of emergency supplies has arrived, but there's a problem.
+To protect from damage, the items — flashlights, first-aid kits, blankets — are packed inside boxes, and some of those boxes are nested several layers deep inside other boxes!
+
+To be prepared for an emergency, everything must be easily accessible in one box.
+Can you unpack all the supplies and place them into a single box, so they're ready when needed most?

--- a/exercises/practice/flatten-array/.meta/tests.toml
+++ b/exercises/practice/flatten-array/.meta/tests.toml
@@ -33,11 +33,31 @@ description = "null values are omitted from the final result"
 [c6cf26de-8ccd-4410-84bd-b9efd88fd2bc]
 description = "consecutive null values at the front of the list are omitted from the final result"
 
+[bc72da10-5f55-4ada-baf3-50e4da02ec8e]
+description = "consecutive null values at the front of the array are omitted from the final result"
+reimplements = "c6cf26de-8ccd-4410-84bd-b9efd88fd2bc"
+include = false
+
 [382c5242-587e-4577-b8ce-a5fb51e385a1]
 description = "consecutive null values in the middle of the list are omitted from the final result"
+
+[6991836d-0d9b-4703-80a0-3f1f23eb5981]
+description = "consecutive null values in the middle of the array are omitted from the final result"
+reimplements = "382c5242-587e-4577-b8ce-a5fb51e385a1"
+include = false
 
 [ef1d4790-1b1e-4939-a179-51ace0829dbd]
 description = "6 level nest list with null values"
 
+[dc90a09c-5376-449c-a7b3-c2d20d540069]
+description = "6 level nested array with null values"
+reimplements = "ef1d4790-1b1e-4939-a179-51ace0829dbd"
+include = false
+
 [85721643-705a-4150-93ab-7ae398e2942d]
 description = "all values in nested list are null"
+
+[51f5d9af-8f7f-4fb5-a156-69e8282cb275]
+description = "all values in nested array are null"
+reimplements = "85721643-705a-4150-93ab-7ae398e2942d"
+include = false

--- a/exercises/practice/flatten-array/test/flatten_array_test.exs
+++ b/exercises/practice/flatten-array/test/flatten_array_test.exs
@@ -14,13 +14,13 @@ defmodule FlattenArrayTest do
   end
 
   @tag :pending
-  test "flattens a nested array" do
+  test "flattens a nested list" do
     assert FlattenArray.flatten([[[]]]) ==
              []
   end
 
   @tag :pending
-  test "flattens array with just integers present" do
+  test "flattens list with just integers present" do
     assert FlattenArray.flatten([1, [2, 3, 4, 5, 6, 7], 8]) ==
              [1, 2, 3, 4, 5, 6, 7, 8]
   end


### PR DESCRIPTION
The updated test cases only differ by one detail - the test description uses the word "array" instead of "list". I think is is an undesirable change for the Elixir track. I am ignoring those changes, and I have added an appends file to clarify that there are no arrays in Elixir.