### PR TITLE
Use 22.04 instead of deprecated 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   precheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         elixir: [1.18.1]
@@ -71,7 +71,7 @@ jobs:
         run: bin/ci-check.sh
 
   ci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:


### PR DESCRIPTION
Cf. https://github.com/actions/runner-images/issues/11101 — currently failing normal PR checks.