### PR TITLE
Remove Unicode test from `series` exercise

### DIFF
--- a/exercises/practice/series/test/string_series_test.exs
+++ b/exercises/practice/series/test/string_series_test.exs
@@ -66,12 +66,6 @@ defmodule StringSeriesTest do
   end
 
   @tag :pending
-  test "Unicode characters count as a single character" do
-    assert StringSeries.slices("José", 1) == ["J", "o", "s", "é"]
-    assert StringSeries.slices("José", 2) == ["Jo", "os", "sé"]
-  end
-
-  @tag :pending
   test "slices with size longer than string return empty list" do
     assert StringSeries.slices("01234", 6) == []
   end


### PR DESCRIPTION
To be consistent with its instructions.md ("Given a string of digits...") and design.md ("This is one of the simpler `Enum` exercises in the track and we want to keep it simple.")