### PR TITLE
Fix for high_score_test.exs

### DIFF
--- a/exercises/concept/high-score/test/high_score_test.exs
+++ b/exercises/concept/high-score/test/high_score_test.exs
@@ -137,7 +137,7 @@ defmodule HighScoreTest do
         HighScore.new()
         |> HighScore.add_player("José Valim")
         |> HighScore.update_score("José Valim", 1)
-        |> HighScore.update_score("José Valim", 486_373)
+        |> HighScore.update_score("José Valim", 486_374)
 
       assert scores == %{"José Valim" => 486_374}
     end


### PR DESCRIPTION
There's a bug in the test at line 140.
|> HighScore.update_score("José Valim", 486_373)
It asserts against a different number 486_374