### PR TITLE
Expect `non_neg_integer` instead of `pos_integer`

### DIFF
--- a/exercises/concept/city-office/test/form_test.exs
+++ b/exercises/concept/city-office/test/form_test.exs
@@ -209,7 +209,7 @@ defmodule FormTest do
       assert_spec(
         {:check_length, 2},
         ["word :: String.t(), length :: non_neg_integer()", "String.t(), non_neg_integer()"],
-        ":ok | {:error, pos_integer()}"
+        ":ok | {:error, non_neg_integer()}"
       )
     end
   end


### PR DESCRIPTION
As [String — Elixir v1.18.3](https://hexdocs.pm/elixir/String.html#length/1) states, `String.length/1` returns a `non_neg_integer()`, not a `pos_integer()`.