### PR TITLE
Sync connect

### DIFF
--- a/exercises/practice/connect/.meta/example.ex
+++ b/exercises/practice/connect/.meta/example.ex
@@ -1,52 +1,50 @@
 defmodule Connect do
   @doc """
   Calculates the winner (if any) of a board
-  using "O" as the white player
-  and "X" as the black player
   """
-  @spec result_for([String.t()]) :: :none | :black | :white
+  @spec result_for([String.t()]) :: :none | :X | :O
   def result_for(board) do
     cond do
-      black_wins?(board) -> :black
-      white_wins?(board) -> :white
+      x_wins?(board) -> :X
+      o_wins?(board) -> :O
       true -> :none
     end
   end
 
-  defp black_wins?(board) do
+  defp x_wins?(board) do
     board
     |> Enum.with_index()
     |> Enum.any?(fn {row, index} ->
-      String.first(row) == "X" && black_wins?(board, [{index, 0}])
+      String.first(row) == "X" && x_wins?(board, [{index, 0}])
     end)
   end
 
-  defp black_wins?(board, [{_, y} | _]) when y + 1 == byte_size(hd(board)), do: true
+  defp x_wins?(board, [{_, y} | _]) when y + 1 == byte_size(hd(board)), do: true
 
-  defp black_wins?(board, history = [last_loc | _]) do
+  defp x_wins?(board, history = [last_loc | _]) do
     last_loc
     |> locs_next_to(history)
     |> Enum.filter(&(get_loc(board, &1) == "X"))
-    |> Enum.any?(&black_wins?(board, [&1 | history]))
+    |> Enum.any?(&x_wins?(board, [&1 | history]))
   end
 
-  defp white_wins?(board) do
+  defp o_wins?(board) do
     board
     |> hd
     |> String.graphemes()
     |> Enum.with_index()
     |> Enum.any?(fn {spot, index} ->
-      spot == "O" && white_wins?(board, [{0, index}])
+      spot == "O" && o_wins?(board, [{0, index}])
     end)
   end
 
-  defp white_wins?(board, [{x, _} | _]) when x + 1 == length(board), do: true
+  defp o_wins?(board, [{x, _} | _]) when x + 1 == length(board), do: true
 
-  defp white_wins?(board, history = [last_loc | _]) do
+  defp o_wins?(board, history = [last_loc | _]) do
     last_loc
     |> locs_next_to(history)
     |> Enum.filter(&(get_loc(board, &1) == "O"))
-    |> Enum.any?(&white_wins?(board, [&1 | history]))
+    |> Enum.any?(&o_wins?(board, [&1 | history]))
   end
 
   defp locs_next_to({x, y}, history) do

--- a/exercises/practice/connect/.meta/tests.toml
+++ b/exercises/practice/connect/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [6eff0df4-3e92-478d-9b54-d3e8b354db56]
 description = "an empty board has no winner"
@@ -22,6 +29,12 @@ description = "nobody wins crossing adjacent angles"
 
 [cd61c143-92f6-4a8d-84d9-cb2b359e226b]
 description = "X wins crossing from left to right"
+
+[495e33ed-30a9-4012-b46e-d7c4d5fe13c3]
+description = "X wins with left-hand dead end fork"
+
+[ab167ab0-4a98-4d0f-a1c0-e1cddddc3d58]
+description = "X wins with right-hand dead end fork"
 
 [73d1eda6-16ab-4460-9904-b5f5dd401d0b]
 description = "O wins crossing from top to bottom"

--- a/exercises/practice/connect/lib/connect.ex
+++ b/exercises/practice/connect/lib/connect.ex
@@ -1,10 +1,8 @@
 defmodule Connect do
   @doc """
   Calculates the winner (if any) of a board
-  using "O" as the white player
-  and "X" as the black player
   """
-  @spec result_for([String.t()]) :: :none | :black | :white
+  @spec result_for([String.t()]) :: :none | :X | :O
   def result_for(board) do
   end
 end

--- a/exercises/practice/connect/test/connect_test.exs
+++ b/exercises/practice/connect/test/connect_test.exs
@@ -6,7 +6,7 @@ defmodule ConnectTest do
   end
 
   # @tag :pending
-  test "empty board has no winner" do
+  test "an empty board has no winner" do
     board =
       remove_spaces([
         ". . . . .",
@@ -20,15 +20,15 @@ defmodule ConnectTest do
   end
 
   @tag :pending
-  test "1x1 board with black stone" do
+  test "X can win on a 1x1 board" do
     board = ["X"]
-    assert Connect.result_for(board) == :black
+    assert Connect.result_for(board) == :X
   end
 
   @tag :pending
-  test "1x1 board with white stone" do
+  test "O can win on a 1x1 board" do
     board = ["O"]
-    assert Connect.result_for(board) == :white
+    assert Connect.result_for(board) == :O
   end
 
   @tag :pending
@@ -73,7 +73,7 @@ defmodule ConnectTest do
   end
 
   @tag :pending
-  test "black wins crossing from left to right" do
+  test "X wins crossing from left to right" do
     board =
       remove_spaces([
         ". O . .",
@@ -83,11 +83,11 @@ defmodule ConnectTest do
         "    . O X ."
       ])
 
-    assert Connect.result_for(board) == :black
+    assert Connect.result_for(board) == :X
   end
 
   @tag :pending
-  test "white wins crossing from top to bottom" do
+  test "O wins crossing from top to bottom" do
     board =
       remove_spaces([
         ". O . .",
@@ -97,11 +97,11 @@ defmodule ConnectTest do
         "    . O X ."
       ])
 
-    assert Connect.result_for(board) == :white
+    assert Connect.result_for(board) == :O
   end
 
   @tag :pending
-  test "black wins using a convoluted path" do
+  test "X wins using a convoluted path" do
     board =
       remove_spaces([
         ". X X . .",
@@ -111,11 +111,11 @@ defmodule ConnectTest do
         "    O O O O O"
       ])
 
-    assert Connect.result_for(board) == :black
+    assert Connect.result_for(board) == :X
   end
 
   @tag :pending
-  test "black wins using a spiral path" do
+  test "X wins using a spiral path" do
     board =
       remove_spaces([
         "O X X X X X X X X",
@@ -129,6 +129,6 @@ defmodule ConnectTest do
         "        X X X X X X X X O"
       ])
 
-    assert Connect.result_for(board) == :black
+    assert Connect.result_for(board) == :X
   end
 end

--- a/exercises/practice/connect/test/connect_test.exs
+++ b/exercises/practice/connect/test/connect_test.exs
@@ -87,6 +87,32 @@ defmodule ConnectTest do
   end
 
   @tag :pending
+  test "X wins with left-hand dead end fork" do
+    board =
+      remove_spaces([
+        ". . X .",
+        " X X . .",
+        "  . X X X",
+        "   O O O O"
+      ])
+
+    assert Connect.result_for(board) == :X
+  end
+
+  @tag :pending
+  test "X wins with right-hand dead end fork" do
+    board =
+      remove_spaces([
+        ". . X X",
+        " X X . .",
+        "  . X X .",
+        "   O O O O"
+      ])
+
+    assert Connect.result_for(board) == :X
+  end
+
+  @tag :pending
   test "O wins crossing from top to bottom" do
     board =
       remove_spaces([


### PR DESCRIPTION
I notices that we're using outdated symbols `:black` and `:white` for the player names that don't  show up in the exercise description, so I updated them to `:X` and `:O` to match the problem specs.

Adding two new tests.