### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/complex-numbers/.docs/instructions.append.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Implementation
+## Track specific instructions
 
 In this exercise, complex numbers are represented as a tuple-pair containing the real and imaginary parts.
 

--- a/exercises/practice/complex-numbers/.docs/instructions.append.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Track specific instructions
+## Elixir-specific changes
 
 In this exercise, complex numbers are represented as a tuple-pair containing the real and imaginary parts.
 

--- a/exercises/practice/complex-numbers/.docs/instructions.append.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 In this exercise, complex numbers are represented as a tuple-pair containing the real and imaginary parts.
 
 For example, the real number `1` is `{1, 0}`, the imaginary number `i` is `{0, 1}` and the complex number `4+3i` is `{4, 3}`.

--- a/exercises/practice/custom-set/.docs/instructions.append.md
+++ b/exercises/practice/custom-set/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Track specific instructions
+## Elixir-specific changes
 
 For this exercise please refrain from using the `MapSet` API.

--- a/exercises/practice/custom-set/.docs/instructions.append.md
+++ b/exercises/practice/custom-set/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 For this exercise please refrain from using the `MapSet` API.

--- a/exercises/practice/custom-set/.docs/instructions.append.md
+++ b/exercises/practice/custom-set/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Implementation
+## Track specific instructions
 
 For this exercise please refrain from using the `MapSet` API.

--- a/exercises/practice/resistor-color/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 For this exercise, returning the list of colors is not required.

--- a/exercises/practice/resistor-color/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Track specific instructions
+## Elixir-specific changes
 
 For this exercise, returning the list of colors is not required.

--- a/exercises/practice/resistor-color/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Implementation
+## Track specific instructions
 
 For this exercise, returning the list of colors is not required.

--- a/exercises/practice/square-root/.docs/instructions.append.md
+++ b/exercises/practice/square-root/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Track specific instructions
+## Elixir-specific changes
 
 Make sure you implement an algorithm that doesn't rely on built-in functions such as `:math.sqrt/1` or `Float.pow/2`.

--- a/exercises/practice/square-root/.docs/instructions.append.md
+++ b/exercises/practice/square-root/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 Make sure you implement an algorithm that doesn't rely on built-in functions such as `:math.sqrt/1` or `Float.pow/2`.

--- a/exercises/practice/square-root/.docs/instructions.append.md
+++ b/exercises/practice/square-root/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Implementation
+## Track specific instructions
 
 Make sure you implement an algorithm that doesn't rely on built-in functions such as `:math.sqrt/1` or `Float.pow/2`.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.