### PR TITLE
fix nth-prime typespec

### DIFF
--- a/exercises/practice/nth-prime/.meta/example.ex
+++ b/exercises/practice/nth-prime/.meta/example.ex
@@ -2,7 +2,7 @@ defmodule Prime do
   @doc """
   Generates the nth prime.
   """
-  @spec nth(non_neg_integer) :: non_neg_integer
+  @spec nth(pos_integer()) :: pos_integer()
   def nth(count) when is_integer(count) and count > 0, do: do_nth(count, 2, [])
 
   defp do_nth(0, value, _), do: value

--- a/exercises/practice/nth-prime/lib/prime.ex
+++ b/exercises/practice/nth-prime/lib/prime.ex
@@ -2,7 +2,7 @@ defmodule Prime do
   @doc """
   Generates the nth prime.
   """
-  @spec nth(non_neg_integer) :: non_neg_integer
+  @spec nth(pos_integer()) :: pos_integer()
   def nth(count) do
   end
 end


### PR DESCRIPTION
I noticed that it uses non_neg_integer() but pos_integer() would be more appropriate (for both the count param and the returned prime number).