### PR TITLE
Fix misleading type_from_binary instructions in file-sniffer

### DIFF
--- a/exercises/concept/file-sniffer/.docs/instructions.md
+++ b/exercises/concept/file-sniffer/.docs/instructions.md
@@ -26,7 +26,7 @@ FileSniffer.type_from_extension("txt")
 
 ## 2. Given a binary file, return the expected media type
 
-Implement the `type_from_binary/1` function. It should take a file (binary) and return the media type (string) or nil if the extension does not match with the expected ones.
+Implement the `type_from_binary/1` function. It should take a file (binary) and return the media type (string) or nil if the file signature does not match with the expected ones.
 
 ```elixir
 file = File.read!("application.exe")


### PR DESCRIPTION
This PR fixes a misleading sentence in the File Sniffer concept exercise.

The `type_from_binary/1` function receives a binary file and determines the media type from the file signature. The previous wording mentioned the extension not matching, but extensions are handled by `type_from_extension/1` and `verify/2`.

This change clarifies that `type_from_binary/1` returns `nil` when the file signature does not match the expected ones.