### PR TITLE
fix(german-sysadmin): refer to diacritics as non-ACSII letters

### DIFF
--- a/exercises/concept/german-sysadmin/.docs/hints.md
+++ b/exercises/concept/german-sysadmin/.docs/hints.md
@@ -21,7 +21,7 @@
 
 ## 3. Substitute German characters
 
-- There is a [special syntax][syntax-reference-code-points] for getting a character's code point. It can be used in guards and it works for non-Latin letters too.
+- There is a [special syntax][syntax-reference-code-points] for getting a character's code point. It can be used in guards and it works for non-ASCII letters too.
 - There is [a built-in function][kernel-concat-list] that allows you to concatenate two lists.
 
 [syntax-reference-code-points]: https://hexdocs.pm/elixir/syntax-reference.html#integers-in-other-bases-and-unicode-code-points

--- a/exercises/concept/german-sysadmin/.docs/instructions.md
+++ b/exercises/concept/german-sysadmin/.docs/instructions.md
@@ -2,7 +2,7 @@
 
 You are working as a system administrator for a big company in Munich, Germany. One of your responsibilities is managing email accounts.
 
-You have been hearing complaints from people saying they are unable to write emails to Mr. Müller. You quickly realize that most of the company uses an old email client that doesn't recognize `müller@firma.de` as a valid email address because of the non-Latin character.
+You have been hearing complaints from people saying they are unable to write emails to Mr. Müller. You quickly realize that most of the company uses an old email client that doesn't recognize `müller@firma.de` as a valid email address because of the non-ASCII character.
 
 Telling people to give up their favorite old email client is a lost battle, so you decide to create sanitized aliases for all email accounts.
 
@@ -26,9 +26,9 @@ Username.sanitize(~c"mark_fischer$$$")
 
 ## 3. Substitute German characters
 
-There are 4 non-Latin characters in the German alphabet, and all of them have commonly-recognized Latin substitutes.
+There are 4 non-ASCII characters in the German alphabet, and all of them have commonly-recognized ASCII substitutes.
 
-| German character | Latin substitute |
+| German character | ASCII substitute |
 | ---------------- | ---------------- |
 | ä                | ae               |
 | ö                | oe               |


### PR DESCRIPTION
See commit message(s).

---

I updated the test hints/instructions as they seemed to be explicitly wrong. Stating that diacritics or `ß` is non-Latin can be misleading.

However, I didn't update the tests as they don't outright say `ß` isn't Latin. It just asks for _"Latin letters"_ or the _"whole lowercase Latin alphabet"_ which I believe most people understand this refers to _"the 26"_ letters of the Latin alphabet.

It feels a bit contradictory, but I think this is the best route for UX/learners without getting overly pedantic about it.

> This modern form is the basis of the [Latin script](https://en.wikipedia.org/wiki/Latin_script), which is the most widely used writing system in the world, _often with [diacritics](https://en.wikipedia.org/wiki/Diacritic) or additional letters beyond the basic 26._
> 
> \- [Latin alphabet](https://en.wikipedia.org/wiki/Latin_alphabet) (emphasis mine)

## Related

* Closes https://github.com/exercism/elixir/issues/1644