### PR TITLE
Add Elixir-specific note to Hamming instructions

### DIFF
--- a/exercises/practice/hamming/.docs/instructions.append.md
+++ b/exercises/practice/hamming/.docs/instructions.append.md
@@ -1,0 +1,5 @@
+# Instructions append
+
+## Elixir-specific changes
+
+This exercise is intended to reinforce the use of `Enum` functions, but it can also be solved with other methods.


### PR DESCRIPTION
## Summary
- Adds an `instructions.append.md` for the Hamming exercise clarifying that it's intended to reinforce `Enum` usage, while noting it can also be solved with other methods.

## Motivation
While solving this exercise, I started with an `Enum`-based approach and later rewrote it using recursion/pattern matching, realizing the exercise's intent (practicing `Enum`) wasn't explicit anywhere in the instructions.

## Test plan
- [ ] N/A (docs-only change)